### PR TITLE
bugfix: flytt interceptor-kall til App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,9 +6,12 @@ import NavFrontendSpinner from 'nav-frontend-spinner';
 import Helse from './components/Helse/Helse';
 import { verifiserAtBrukerErAutentisert } from './utils/autentisering';
 import Forside from './components/Forside/Forside';
+import { autentiseringsInterceptor } from './utils/autentisering';
 
 function App() {
     const [autentisert, settAutentisering] = useState<boolean>(false);
+
+    autentiseringsInterceptor();
 
     useEffect(() => {
         verifiserAtBrukerErAutentisert(settAutentisering);

--- a/src/context/AppContext.ts
+++ b/src/context/AppContext.ts
@@ -17,8 +17,6 @@ const [AppProvider, useApp] = createUseContext(() => {
     const [helseMottak, settHelseMottak] = useState(byggTomRessurs<string>());
     const [helsePdl, settHelsePdl] = useState(byggTomRessurs<string>());
 
-    autentiseringsInterceptor();
-
     useEffect(() => {
         settHelseApi(byggHenterRessurs());
         settHelseMottak(byggHenterRessurs());


### PR DESCRIPTION
Interceptoren ble aldri kalt da den lå i `AppContext.tsx`, og ble derfor flyttet til `App.tsx` slik at den håndterer 401-feil.