### PR TITLE
bugfix: håndter routing i prod og test

### DIFF
--- a/server.js
+++ b/server.js
@@ -20,7 +20,7 @@ app.use(express.static(path.join(__dirname, 'build'), { index: false }));
 // Nais functions
 app.get(`/internal/isAlive|isReady`, (req, res) => res.sendStatus(200));
 
-app.get('/', (req, res) =>
+app.get('*', (req, res) =>
     getDecorator()
         .then(fragments => {
             res.render('index.html', fragments);

--- a/src/Miljø.ts
+++ b/src/Miljø.ts
@@ -3,11 +3,11 @@ interface MiljøProps {
 }
 
 const Miljø = (): MiljøProps => {
-    if (window.location.hostname.indexOf('www-q0') > -1) {
+    if (window.location.hostname.indexOf('familie-ba-soknad.dev') > -1) {
         return {
             loginService: 'https://loginservice-q.nav.no/login?',
         };
-    } else if (window.location.hostname.indexOf('www') > -1) {
+    } else if (window.location.hostname.indexOf('familie-ba-soknad.adeo') > -1) {
         return {
             loginService: 'https://loginservice.nav.no/login?',
         };


### PR DESCRIPTION
Håndterer routingproblem som oppstod under redirect.
I tillegg fikser det feilen ved å bruke "../noe" på localhost:9000 etter `yarn build_and_serve`