### PR TITLE
(fix) Få intellij til å kjøre frontend-tester med jest

### DIFF
--- a/.idea/runConfigurations/_template__of_JavaScriptTestRunnerJest.xml
+++ b/.idea/runConfigurations/_template__of_JavaScriptTestRunnerJest.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="true" type="JavaScriptTestRunnerJest">
+    <node-interpreter value="project" />
+    <node-options value="" />
+    <jest-package value="$PROJECT_DIR$/node_modules/jest" />
+    <working-dir value="" />
+    <envs />
+    <scope-kind value="ALL" />
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fikse å kjøre tester fra intellij-shortcuts. Bruker `react-scripts test` by default, trenger å endre til å bruke jest


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
Det er ikke mulig å teste ide-config

### 🤷‍♀ ️Hvor er det lurt å starte?
Checkout branch og sjekk at jest-templaten i run configurations har endret seg

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
![Screenshot 2021-02-01 at 11 23 35](https://user-images.githubusercontent.com/77009351/106446022-0b1d6780-6480-11eb-84fd-2f1fc5a62cbd.png)
