### PR TITLE
Fix/nullstill felter

### DIFF
--- a/src/frontend/components/Felleskomponenter/LandDropdown/LandDropdown.tsx
+++ b/src/frontend/components/Felleskomponenter/LandDropdown/LandDropdown.tsx
@@ -12,7 +12,7 @@ import { device } from '../../../Theme';
 import { SkjemaFeltTyper } from '../../../typer/skjema';
 
 interface LandDropdownProps {
-    felt: Felt<Alpha3Code | undefined>;
+    felt: Felt<Alpha3Code | ''>;
     skjema: ISkjema<SkjemaFeltTyper, string>;
     label?: ReactNode;
 }
@@ -45,7 +45,6 @@ export const LandDropdown: React.FC<LandDropdownProps> = ({ felt, skjema, label 
         <Container id={felt.id}>
             <StyledSelect
                 label={label}
-                defaultValue={''}
                 {...felt.hentNavInputProps(skjema.visFeilmeldinger)}
                 id={undefined}
             >

--- a/src/frontend/components/SøknadsSteg/OmDeg/useDatovelgerFeltMedJaNeiAvhengighet.ts
+++ b/src/frontend/components/SøknadsSteg/OmDeg/useDatovelgerFeltMedJaNeiAvhengighet.ts
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { ESvar, ISODateString } from '@navikt/familie-form-elements';
 import { Felt, useFelt } from '@navikt/familie-skjema';
 
@@ -10,20 +12,28 @@ const useDatovelgerFeltMedJaNeiAvhengighet = (
     avhengighet: Felt<ESvar | undefined>,
     avgrensDatoFremITid = false
 ) => {
-    return useFelt<ISODateString>({
+    const skalFeltetVises = jaNeiSpmVerdi => jaNeiSpmVerdi === avhengigSvarCondition;
+
+    const dato = useFelt<ISODateString>({
         feltId: søknadsfelt.id,
         verdi: søknadsfelt.svar,
         valideringsfunksjon: felt => {
             return validerDato(felt, avgrensDatoFremITid);
         },
         skalFeltetVises: avhengigheter => {
-            return avhengigheter && avhengigheter.jaNeiSpm
-                ? (avhengigheter.jaNeiSpm as Felt<ESvar | undefined>).verdi ===
-                      avhengigSvarCondition
+            return avhengigheter && (avhengigheter.jaNeiSpm as Felt<ESvar | undefined>)
+                ? skalFeltetVises(avhengigheter.jaNeiSpm.verdi)
                 : true;
         },
         avhengigheter: { jaNeiSpm: avhengighet },
+        nullstillVedAvhengighetEndring: false,
     });
+
+    useEffect(() => {
+        !skalFeltetVises(avhengighet.verdi) && dato.validerOgSettFelt('');
+    }, [avhengighet]);
+
+    return dato;
 };
 
 export default useDatovelgerFeltMedJaNeiAvhengighet;

--- a/src/frontend/components/SøknadsSteg/OmDeg/useOmdeg.tsx
+++ b/src/frontend/components/SøknadsSteg/OmDeg/useOmdeg.tsx
@@ -32,16 +32,16 @@ export interface IOmDegFeltTyper {
     borPåRegistrertAdresse: ESvar | undefined;
     telefonnummer: string;
     oppholderSegINorge: ESvar | undefined;
-    oppholdsland: Alpha3Code | undefined;
+    oppholdsland: Alpha3Code | '';
     oppholdslandDato: ISODateString;
     værtINorgeITolvMåneder: ESvar | undefined;
     komTilNorgeDato: ISODateString;
     planleggerÅBoINorgeTolvMnd: ESvar | undefined;
     erAsylsøker: ESvar | undefined;
     jobberPåBåt: ESvar | undefined;
-    arbeidsland: Alpha3Code | undefined;
+    arbeidsland: Alpha3Code | '';
     mottarUtenlandspensjon: ESvar | undefined;
-    pensjonsland: Alpha3Code | undefined;
+    pensjonsland: Alpha3Code | '';
 }
 
 export const useOmdeg = (): {

--- a/src/frontend/hooks/useJaNeiSpmFelt.test.ts
+++ b/src/frontend/hooks/useJaNeiSpmFelt.test.ts
@@ -17,7 +17,7 @@ describe('erRelevanteAvhengigheterValidert', () => {
         const oppholderSegINorgeFeltMock = mock<Felt<ESvar | undefined>>({
             valideringsstatus: Valideringsstatus.OK,
         });
-        const oppholdslandFeltMock = mock<Felt<Alpha3Code | undefined>>({
+        const oppholdslandFeltMock = mock<Felt<Alpha3Code | ''>>({
             valideringsstatus: Valideringsstatus.OK,
             erSynlig: true,
         });
@@ -45,7 +45,7 @@ describe('erRelevanteAvhengigheterValidert', () => {
         const oppholderSegINorgeFeltMock = mock<Felt<ESvar | undefined>>({
             valideringsstatus: Valideringsstatus.OK,
         });
-        const oppholdslandFeltMock = mock<Felt<Alpha3Code | undefined>>({
+        const oppholdslandFeltMock = mock<Felt<Alpha3Code | ''>>({
             valideringsstatus: Valideringsstatus.OK,
             erSynlig: true,
         });
@@ -73,7 +73,7 @@ describe('erRelevanteAvhengigheterValidert', () => {
         const oppholderSegINorgeFeltMock = mock<Felt<ESvar | undefined>>({
             valideringsstatus: Valideringsstatus.IKKE_VALIDERT,
         });
-        const oppholdslandFeltMock = mock<Felt<Alpha3Code | undefined>>({
+        const oppholdslandFeltMock = mock<Felt<Alpha3Code | ''>>({
             valideringsstatus: Valideringsstatus.IKKE_VALIDERT,
             erSynlig: false,
         });
@@ -101,7 +101,7 @@ describe('erRelevanteAvhengigheterValidert', () => {
         const oppholderSegINorgeFeltMock = mock<Felt<ESvar | undefined>>({
             valideringsstatus: Valideringsstatus.OK,
         });
-        const oppholdslandFeltMock = mock<Felt<Alpha3Code | undefined>>({
+        const oppholdslandFeltMock = mock<Felt<Alpha3Code | ''>>({
             valideringsstatus: Valideringsstatus.OK,
             erSynlig: false,
         });

--- a/src/frontend/hooks/useLanddropdownFelt.tsx
+++ b/src/frontend/hooks/useLanddropdownFelt.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { Alpha3Code } from 'i18n-iso-countries';
 
@@ -9,27 +9,35 @@ import SpråkTekst from '../components/Felleskomponenter/SpråkTekst/SpråkTekst
 import { ISøknadSpørsmål } from '../typer/søknad';
 
 const useLandDropdownFelt = (
-    søknadsfelt: ISøknadSpørsmål<Alpha3Code | undefined>,
+    søknadsfelt: ISøknadSpørsmål<Alpha3Code | ''>,
     språkTekstIdForFeil: string,
     avhengigSvarCondition: ESvar,
-    avhengighet?: Felt<ESvar | undefined>
+    avhengighet: Felt<ESvar | undefined>
 ) => {
-    return useFelt<Alpha3Code | undefined>({
+    const skalFeltetVises = jaNeiSpmVerdi => jaNeiSpmVerdi === avhengigSvarCondition;
+
+    const landDropdown = useFelt<Alpha3Code | ''>({
         feltId: søknadsfelt.id,
         verdi: søknadsfelt.svar,
         skalFeltetVises: (avhengigheter: Avhengigheter) => {
-            return avhengigheter && avhengigheter.jaNeiSpm
-                ? (avhengigheter.jaNeiSpm as Felt<ESvar | undefined>).verdi ===
-                      avhengigSvarCondition
+            return avhengigheter && (avhengigheter.jaNeiSpm as Felt<ESvar | undefined>)
+                ? skalFeltetVises(avhengigheter.jaNeiSpm.verdi)
                 : true;
         },
-        valideringsfunksjon: (felt: FeltState<Alpha3Code | undefined>) => {
-            return felt.verdi !== undefined
+        valideringsfunksjon: (felt: FeltState<Alpha3Code | ''>) => {
+            return felt.verdi !== ''
                 ? ok(felt)
                 : feil(felt, <SpråkTekst id={språkTekstIdForFeil} />);
         },
         avhengigheter: { jaNeiSpm: avhengighet },
+        nullstillVedAvhengighetEndring: false,
     });
+
+    useEffect(() => {
+        !skalFeltetVises(avhengighet.verdi) && landDropdown.validerOgSettFelt('');
+    }, [avhengighet]);
+
+    return landDropdown;
 };
 
 export default useLandDropdownFelt;

--- a/src/frontend/typer/person.ts
+++ b/src/frontend/typer/person.ts
@@ -33,16 +33,16 @@ export interface ISøker extends ISøkerRespons {
     telefonnummer: ISøknadSpørsmål<string>;
     borPåRegistrertAdresse: ISøknadSpørsmål<ESvar | undefined>;
     oppholderSegINorge: ISøknadSpørsmål<ESvar | undefined>;
-    oppholdsland: ISøknadSpørsmål<Alpha3Code | undefined>;
+    oppholdsland: ISøknadSpørsmål<Alpha3Code | ''>;
     oppholdslandDato: ISøknadSpørsmål<ISODateString>;
     værtINorgeITolvMåneder: ISøknadSpørsmål<ESvar | undefined>;
     komTilNorgeDato: ISøknadSpørsmål<ISODateString>;
     planleggerÅBoINorgeTolvMnd: ISøknadSpørsmål<ESvar | undefined>;
     erAsylsøker: ISøknadSpørsmål<ESvar | undefined>;
     jobberPåBåt: ISøknadSpørsmål<ESvar | undefined>;
-    arbeidsland: ISøknadSpørsmål<Alpha3Code | undefined>;
+    arbeidsland: ISøknadSpørsmål<Alpha3Code | ''>;
     mottarUtenlandspensjon: ISøknadSpørsmål<ESvar | undefined>;
-    pensjonsland: ISøknadSpørsmål<Alpha3Code | undefined>;
+    pensjonsland: ISøknadSpørsmål<Alpha3Code | ''>;
 }
 
 export interface IAdresse {

--- a/src/frontend/typer/søknad.ts
+++ b/src/frontend/typer/søknad.ts
@@ -90,7 +90,7 @@ export const initialStateSøknad: ISøknad = {
         },
         oppholdsland: {
             id: OmDegSpørsmålId.oppholdsland,
-            svar: undefined,
+            svar: '',
         },
         oppholdslandDato: {
             id: OmDegSpørsmålId.oppholdslandDato,
@@ -118,7 +118,7 @@ export const initialStateSøknad: ISøknad = {
         },
         arbeidsland: {
             id: OmDegSpørsmålId.arbeidsland,
-            svar: undefined,
+            svar: '',
         },
         mottarUtenlandspensjon: {
             id: OmDegSpørsmålId.mottarUtenlandspensjon,
@@ -126,7 +126,7 @@ export const initialStateSøknad: ISøknad = {
         },
         pensjonsland: {
             id: OmDegSpørsmålId.pensjonsland,
-            svar: undefined,
+            svar: '',
         },
     },
     erNoenAvBarnaFosterbarn: {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Denne løser en bug der land og dato ikke nullstilte seg dersom man valgte at man ikke oppholdt seg i f.eks utlandet likevel.


### 🔎️ Er det noe spesielt du ønsker å fremheve?
Endret land-defaultverdi fra undefined til tom string. Landdropdown'en takler ikke undefined som en value, så det var litt styr å få til nullstilling. Enten kunne jeg gjøre om fra undefined til en tom string hver gang man skulle bruke verdien fra søknadsfeltet - og så gjøre om fra tom string til undefined når den skulle bli satt. Synes dette ble litt unødvendig kronglete, så byttet om at default verdi i søknadsdata bare er en tom string, så slipper man å ta hensyn til undefined i det hele tatt.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har testet endringene mine med Arc Toolkit
- [ ] Jeg har testet endringene mine i mobilstørrelse
- [] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
