### PR TITLE
(fix) Bruk masonry for å gjøre barnekort-layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,6 +204,7 @@
     "mini-css-extract-plugin": "^1.3.6",
     "nav-frontend-chevron": "^1.0.28",
     "prettier": "^2.0.5",
+    "react-masonry-css": "^1.0.16",
     "style-loader": "^2.0.0",
     "terser": "^5.6.0-beta",
     "terser-webpack-plugin": "^5.1.1",

--- a/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/Barnekort.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/Barnekort.tsx
@@ -30,7 +30,6 @@ export const StyledBarnekort = styled.div`
     padding: 2rem;
     margin: 0 auto 0.625rem;
     background-color: ${navFarger.navLysGra};
-    break-inside: avoid;
     @media all and ${device.mobile} {
         width: 100%;
     }

--- a/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
+import Masonry from 'react-masonry-css';
 import styled from 'styled-components/macro';
 
 import { useApp } from '../../../context/AppContext';
-import { device } from '../../../Theme';
 import { mapBarnResponsTilBarn } from '../../../utils/person';
 import AlertStripe from '../../Felleskomponenter/AlertStripe/AlertStripe';
 import EksternLenke from '../../Felleskomponenter/EksternLenke/EksternLenke';
@@ -13,13 +13,14 @@ import Barnekort from './Barnekort/Barnekort';
 import { NyttBarnKort } from './LeggTilBarn/NyttBarnKort';
 import { useVelgBarn } from './useVelgBarn';
 
-const BarnekortContainer = styled.div`
-    columns: 2;
-    column-gap: 0.3rem;
+/**
+ * Vi har prøvd mye for å få til masonry, men før denne teknologien blir implementert
+ * av nettlesere ser det ut til at javascript må til for å få godt pakka barnekortkontainer.
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Masonry_Layout
+ */
+const BarnekortContainer = styled(Masonry)`
+    display: flex;
     margin-top: 5rem;
-    @media all and ${device.mobile} {
-        columns: 1;
-    }
 `;
 
 const VelgBarn: React.FC = () => {
@@ -58,7 +59,14 @@ const VelgBarn: React.FC = () => {
                 lenkeTekstSpråkId={'hvilkebarn.endre-opplysninger.lenketekst'}
             />
 
-            <BarnekortContainer id={'barnMedISøknad'}>
+            <BarnekortContainer
+                id={'barnMedISøknad'}
+                className={'BarnekortContainer'}
+                breakpointCols={{
+                    default: 2,
+                    480: 1,
+                }}
+            >
                 {barn.map(barn => (
                     <Barnekort
                         key={barn.ident}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9329,6 +9329,11 @@ react-lifecycles-compat@^3.0.0:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-masonry-css@^1.0.16:
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/react-masonry-css/-/react-masonry-css-1.0.16.tgz#72b28b4ae3484e250534700860597553a10f1a2c"
+  integrity sha512-KSW0hR2VQmltt/qAa3eXOctQDyOu7+ZBevtKgpNDSzT7k5LA/0XntNa9z9HKCdz3QlxmJHglTZ18e4sX4V8zZQ==
+
 react-modal@^3.11.2:
   version "3.12.1"
   resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.12.1.tgz#38c33f70d81c33d02ff1ed115530443a3dc2afd3"
@@ -10028,11 +10033,6 @@ slice-ansi@^4.0.0:
     ansi-styles "^4.0.0"
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
-
-slugify@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.5.0.tgz#5f3c8e2a84105b54eb51486db1b468a599b3c9b8"
-  integrity sha512-Q2UPZ2udzquy1ElHfOLILMBMqBEXkiD3wE75qtBvV+FsDdZZjUqPZ44vqLTejAVq+wLLHacOMcENnP8+ZbzmIA==
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fikse at barnekort kommer i denne rekkefølgen
![image](https://user-images.githubusercontent.com/77009351/117255333-cf60b800-ae49-11eb-9ae4-f40d954dae23.png)


### 🔎️ Er det noe spesielt du ønsker å fremheve?
Tar i bruk det libraryet som ser ut til å være best maintained og passer best med react. Kan røskes ut igjen når https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Masonry_Layout blir vanlig i alle browsere.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne

_Jeg har ikke skrevet tester fordi:_
Tar i bruk 3rd party komponent for layout, ser ikke behov for å skrive tester for annet lib.

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Før:
![image](https://user-images.githubusercontent.com/77009351/117255333-cf60b800-ae49-11eb-9ae4-f40d954dae23.png)
Nå:
![image](https://user-images.githubusercontent.com/77009351/117255775-54e46800-ae4a-11eb-8504-435f87bd3243.png)
![image](https://user-images.githubusercontent.com/77009351/117255875-76ddea80-ae4a-11eb-98e5-7283695ee792.png)


