### PR TITLE
Fix/react router dom mock

### DIFF
--- a/src/__mocks__/react-router-dom.ts
+++ b/src/__mocks__/react-router-dom.ts
@@ -1,18 +1,28 @@
+const reactRouterDom = jest.createMockFromModule('react-router-dom');
+
 const mockHistoryArray: string[] = [];
 
-const reactRouterDom = jest.mock('react-router-dom', () => ({
-    ...(jest.requireActual('react-router-dom') as object),
-    useLocation: () => ({
-        pathname: mockHistoryArray[mockHistoryArray.length - 1],
-    }),
-    useHistory: () => mockHistoryArray,
-    __setHistory: (history: string[]): string[] => {
-        while (mockHistoryArray.length > 0) {
-            mockHistoryArray.pop();
-        }
-        mockHistoryArray.push(...history);
-        return mockHistoryArray;
-    },
-}));
+const useLocation = () => ({
+    pathname: mockHistoryArray[mockHistoryArray.length - 1],
+});
 
-export default reactRouterDom;
+const useHistory = () => mockHistoryArray;
+
+const __setHistory = (history: string[]): string[] => {
+    while (mockHistoryArray.length > 0) {
+        mockHistoryArray.pop();
+    }
+    mockHistoryArray.push(...history);
+    return mockHistoryArray;
+};
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+reactRouterDom.useHistory = useHistory;
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+reactRouterDom.useLocation = useLocation;
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+reactRouterDom.__setHistory = __setHistory;
+
+module.exports = reactRouterDom;

--- a/src/frontend/components/SøknadsSteg/OmBarnet/OmBarnet.test.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/OmBarnet.test.tsx
@@ -11,10 +11,6 @@ import { AlternativtSvarForInput, barnDataKeySpørsmål } from '../../../typer/p
 import { mockHistory, silenceConsoleErrors, spyOnUseApp } from '../../../utils/testing';
 import OmBarnet from './OmBarnet';
 
-jest.mock('../../../context/AppContext');
-
-const mockedHistory = mockHistory(['/om-barnet/barn-1']);
-
 silenceConsoleErrors();
 
 const jens = {
@@ -105,6 +101,7 @@ const line = {
 };
 
 test(`Kan rendre Om Barnet Utfyllende`, () => {
+    mockHistory(['/om-barnet/barn-1']);
     spyOnUseApp({
         barnInkludertISøknaden: [jens],
         sisteUtfylteStegIndex: 4,
@@ -122,9 +119,11 @@ test(`Kan rendre Om Barnet Utfyllende`, () => {
 });
 
 test(`Kan navigere mellom to barn`, () => {
+    const mockedHistory = mockHistory(['/om-barnet/barn-1']);
     spyOnUseApp({
         barnInkludertISøknaden: [jens, line],
         sisteUtfylteStegIndex: 4,
+        dokumentasjon: [],
     });
     const { getByText } = render(
         <SprakProvider
@@ -151,11 +150,13 @@ test(`Kan navigere mellom to barn`, () => {
 });
 
 test(`Kan navigere fra barn til oppsummering`, () => {
+    const mockedHistory = mockHistory(['/om-barnet/barn-1']);
     mockHistory(['/om-barnet/barn-1']);
 
     spyOnUseApp({
         barnInkludertISøknaden: [jens],
         sisteUtfylteStegIndex: 4,
+        dokumentasjon: [],
     });
 
     const { getByText } = render(

--- a/src/frontend/context/Routes.test.tsx
+++ b/src/frontend/context/Routes.test.tsx
@@ -2,16 +2,10 @@ import React from 'react';
 
 import { renderHook } from '@testing-library/react-hooks';
 
-import { spyOnUseApp } from '../utils/testing';
+import { mockHistory, spyOnUseApp } from '../utils/testing';
 import { useRoutes, RouteEnum, RoutesProvider } from './RoutesContext';
 
-jest.mock('../context/AppContext');
-jest.mock('react-router-dom', () => ({
-    ...(jest.requireActual('react-router-dom') as object),
-    useLocation: () => ({
-        pathname: '/barnet/Jens',
-    }),
-}));
+mockHistory(['/om-barnet/barn-1']);
 
 describe('Routes', () => {
     test(`Kan hente routes før barn er valgt`, () => {
@@ -20,7 +14,7 @@ describe('Routes', () => {
         });
         const wrapper = ({ children }) => <RoutesProvider>{children}</RoutesProvider>;
         const { result } = renderHook(() => useRoutes(), { wrapper });
-        expect(result.current.routes.length).toEqual(7);
+        expect(result.current.routes.length).toEqual(8);
     });
 
     test(`hentStegObjekterForStegIndikator skal returnere en liste uten forside`, () => {
@@ -29,7 +23,7 @@ describe('Routes', () => {
         });
         const wrapper = ({ children }) => <RoutesProvider>{children}</RoutesProvider>;
         const { result } = renderHook(() => useRoutes(), { wrapper });
-        expect(result.current.hentStegObjekterForStegIndikator().length).toEqual(6);
+        expect(result.current.hentStegObjekterForStegIndikator().length).toEqual(7);
     });
 
     test(`Kan hente neste route fra forsiden`, () => {


### PR DESCRIPTION
Endringer for å få react-router-dom mock til å funke, også fikset testene som feilet fordi dokumentasjon manglet på søknadsobjekt