### PR TITLE
Ta bort min-høyde som gjør at får se alt i modalen ved scroll

### DIFF
--- a/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/LeggTilBarnModal.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/LeggTilBarnModal.tsx
@@ -32,7 +32,6 @@ const StyledModal = styled(Modal)`
     }
 
     width: 45rem;
-    min-height: 35rem;
     @media all and ${device.mobile} {
         width: 95%;
     }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Man kunne i nå alt i modal når man hadde valgt 200% og "very large" tekst størrelse. Det var pga, min høyden som gjorde at man ikke fikk scrollet helt ned/opp.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._
nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
nei/niet/nay/no

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
