### PR TITLE
(fix) Direkte navigering i prod

### DIFF
--- a/src/webpack/webpack.common.config.js
+++ b/src/webpack/webpack.common.config.js
@@ -9,15 +9,21 @@ const { DefinePlugin } = webpackModule;
 
 export const publicUrl = '/public';
 
+export const createHtmlWebpackPlugin = prodMode => {
+    return new HtmlWebpackPlugin({
+        template: path.join(process.cwd(), 'src/frontend/public/index.html'),
+        inject: 'body',
+        alwaysWriteToDisk: true,
+        // Dette gjør at hvis vi navigerer direkte til /basepath/om-barna/ så henter vi fortsatt main.js fra /basepath/main.js
+        // Det trengs kun i prod-mode, i dev-mode tar webpackDevMiddleware seg av alt
+        publicPath: prodMode ? process.env.BASE_PATH ?? '/' : 'auto',
+    });
+};
+
 export default {
     mode: 'production',
     entry: ['./src/frontend/index.tsx'],
     plugins: [
-        new HtmlWebpackPlugin({
-            template: path.join(process.cwd(), 'src/frontend/public/index.html'),
-            inject: 'body',
-            alwaysWriteToDisk: true,
-        }),
         new InterpolateHtmlPlugin(HtmlWebpackPlugin, {
             PUBLIC_URL: (process.env.BASE_PATH ?? '/') + publicUrl.substr(1),
         }),

--- a/src/webpack/webpack.development.config.js
+++ b/src/webpack/webpack.development.config.js
@@ -2,7 +2,7 @@ import ReactRefreshWebpackPlugin from '@pmmmwh/react-refresh-webpack-plugin';
 import webpack from 'webpack';
 import { mergeWithRules } from 'webpack-merge';
 
-import baseConfig, { publicUrl } from './webpack.common.config.js';
+import baseConfig, { createHtmlWebpackPlugin, publicUrl } from './webpack.common.config.js';
 
 const devConfig = mergeWithRules({
     module: {
@@ -15,7 +15,11 @@ const devConfig = mergeWithRules({
     mode: 'development',
     entry: ['webpack-hot-middleware/client'],
     devtool: 'inline-source-map',
-    plugins: [new webpack.HotModuleReplacementPlugin(), new ReactRefreshWebpackPlugin()],
+    plugins: [
+        createHtmlWebpackPlugin(false),
+        new webpack.HotModuleReplacementPlugin(),
+        new ReactRefreshWebpackPlugin(),
+    ],
     output: {
         publicPath: publicUrl,
     },

--- a/src/webpack/webpack.production.config.js
+++ b/src/webpack/webpack.production.config.js
@@ -3,7 +3,7 @@ import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import TerserWebpackPlugin from 'terser-webpack-plugin';
 import { mergeWithRules } from 'webpack-merge';
 
-import baseConfig from './webpack.common.config.js';
+import baseConfig, { createHtmlWebpackPlugin } from './webpack.common.config.js';
 
 const prodConfig = mergeWithRules({
     module: {
@@ -15,6 +15,7 @@ const prodConfig = mergeWithRules({
 })(baseConfig, {
     mode: 'production',
     plugins: [
+        createHtmlWebpackPlugin(true),
         new MiniCssExtractPlugin({
             filename: '[name].css',
         }),


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Sette eksplisitte paths til kompilerte js-chunks i preprod og prod slik at man ikke bare får index.html hvis man navigerer direkte til en subpath.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
Det går sikkert an å skrive tester for webpack, men jeg veit ikke hvordan

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
