### PR TITLE
(hotfix) Fiks at advarsel om at man må ha fnr vises

### DIFF
--- a/src/frontend/components/Felleskomponenter/SkjemaCheckbox/SkjemaCheckbox.tsx
+++ b/src/frontend/components/Felleskomponenter/SkjemaCheckbox/SkjemaCheckbox.tsx
@@ -12,10 +12,13 @@ export const SkjemaCheckbox: React.FC<{
     felt: Felt<any>;
     visFeilmeldinger: boolean;
     labelSpråkTekstId: string;
-}> = ({ felt, visFeilmeldinger, labelSpråkTekstId }) => {
+    invers?: boolean;
+}> = ({ felt, visFeilmeldinger, labelSpråkTekstId, invers = false }) => {
     const onChange = event => {
         const { onChange: feltOnChange } = felt.hentNavInputProps(false);
-        feltOnChange(event.target.checked ? ESvar.JA : ESvar.NEI);
+        const jaNei: boolean = invers ? !event.target.checked : event.target.checked;
+
+        feltOnChange(jaNei ? ESvar.JA : ESvar.NEI);
     };
 
     return (

--- a/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/LeggTilBarnModal.test.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/LeggTilBarnModal.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { act, render } from '@testing-library/react';
+
+import { silenceConsoleErrors, TestProvidere } from '../../../../utils/testing';
+import LeggTilBarnModal from './LeggTilBarnModal';
+
+describe('LeggTilBarnModal', function () {
+    test('Test at advarsel om fnr vises hvis man huker av for at barnet ikke har fått fnr enda', () => {
+        silenceConsoleErrors();
+        const { getByText } = render(
+            <TestProvidere>
+                <LeggTilBarnModal modalÅpen={true} settModalÅpen={jest.fn()} />
+            </TestProvidere>
+        );
+        const erFødtJa = getByText(/felles.svaralternativ.ja/);
+        act(() => erFødtJa.click());
+        const harIkkFnrCheckbox = getByText(/hvilkebarn.leggtilbarn.ikke-fått-fnr.spm/);
+        act(() => harIkkFnrCheckbox.click());
+
+        const advarsel = getByText(/hvilkebarn.leggtilbarn.ikke-fått-fnr.alert/);
+        expect(advarsel).toBeInTheDocument();
+    });
+});

--- a/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/LeggTilBarnModal.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/LeggTilBarnModal.tsx
@@ -182,6 +182,7 @@ const LeggTilBarnModal: React.FC<{
                                     felt={skjema.felter.harBarnetFåttIdNummer}
                                     visFeilmeldinger={false}
                                     labelSpråkTekstId={'hvilkebarn.leggtilbarn.ikke-fått-fnr.spm'}
+                                    invers={true}
                                 />
                             )}
                             {skjema.felter.harBarnetFåttIdNummer.verdi === ESvar.NEI && (


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
At advarsel ikke vises når man huker av for at barn ikke har fått fødselsnummer

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [x] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  