### PR TITLE
(fix) Asset loading lokalt, forenkla devloader++

### DIFF
--- a/src/backend/dekorator.ts
+++ b/src/backend/dekorator.ts
@@ -1,3 +1,4 @@
+import { RequestHandler } from 'express';
 import jsdom from 'jsdom';
 import NodeCache from 'node-cache';
 import request from 'request';
@@ -15,9 +16,16 @@ const cache = new NodeCache({
     checkperiod: SECONDS_PER_MINUTE,
 });
 
-const getDecorator = () =>
+interface DekoratørRespons {
+    NAV_SCRIPTS: string;
+    NAV_STYLES: string;
+    NAV_HEADING: string;
+    NAV_FOOTER: string;
+}
+
+const getDecorator = (): Promise<DekoratørRespons> =>
     new Promise((resolve, reject) => {
-        const decorator = cache.get('main-cache');
+        const decorator = cache.get<DekoratørRespons>('main-cache');
         if (decorator) {
             resolve(decorator);
         } else {
@@ -40,4 +48,17 @@ const getDecorator = () =>
         }
     });
 
-export default getDecorator;
+export const indexHandler: RequestHandler = (_req, res) => {
+    getDecorator()
+        .then(fragments => {
+            // eslint-disable-next-line
+            // @ts-ignore
+            res.render('index.html', fragments);
+        })
+        .catch(e => {
+            console.log(e);
+            const error = `En feil oppstod. Klikk <a href="https://www.nav.no">her</a> for å gå tilbake til nav.no. Kontakt kundestøtte hvis problemet vedvarer.`;
+            res.status(500).send(error);
+        });
+};
+export default indexHandler;

--- a/src/webpack/webpack.common.config.js
+++ b/src/webpack/webpack.common.config.js
@@ -9,6 +9,17 @@ const { DefinePlugin } = webpackModule;
 
 export const publicUrl = '/public';
 
+const unslash = value => {
+    let returnValue = value;
+    while (returnValue.indexOf('/') === 0) {
+        returnValue = returnValue.substr(1);
+    }
+    while (returnValue.lastIndexOf('/') === returnValue.length - 1) {
+        returnValue = returnValue.substring(0, returnValue.length - 1);
+    }
+    return returnValue;
+};
+
 export const createHtmlWebpackPlugin = prodMode => {
     return new HtmlWebpackPlugin({
         template: path.join(process.cwd(), 'src/frontend/public/index.html'),
@@ -58,7 +69,10 @@ export default {
             {
                 test: /\.(png|svg|jpg|jpeg|gif|ico)$/,
                 exclude: /node_modules/,
-                use: [`file-loader?name=${publicUrl}/[name].[ext]`],
+                loader: 'file-loader',
+                options: {
+                    name: `${unslash(publicUrl)}/[name].[ext]`,
+                },
             },
             {
                 test: /\.(jsx|tsx|ts|js)?$/,

--- a/src/webpack/webpack.development.config.js
+++ b/src/webpack/webpack.development.config.js
@@ -2,7 +2,7 @@ import ReactRefreshWebpackPlugin from '@pmmmwh/react-refresh-webpack-plugin';
 import webpack from 'webpack';
 import { mergeWithRules } from 'webpack-merge';
 
-import baseConfig, { createHtmlWebpackPlugin, publicUrl } from './webpack.common.config.js';
+import baseConfig, { createHtmlWebpackPlugin } from './webpack.common.config.js';
 
 const devConfig = mergeWithRules({
     module: {
@@ -20,9 +20,6 @@ const devConfig = mergeWithRules({
         new webpack.HotModuleReplacementPlugin(),
         new ReactRefreshWebpackPlugin(),
     ],
-    output: {
-        publicPath: publicUrl,
-    },
     module: {
         rules: [
             {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fikse at vi har dobbel `/` i svg img-paths både lokalt og i prod, fikse asset loading lokalt, fikse at man ikke kan laste manifest.json og sånn lokalt fordi dev-mode og prod-mode hadde ulik output-mode.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Før rendret vi kun index.html som fallback, nå rendrer vi den først hvis request path er `/`. Siden express-handlere kalles i sekvens lar det oss forenkle devloaderen slik at den funker mer likt prod-mode :tada: 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
Usikker på om vi trenger tester for tynn backend, men begynner å tro at vi kanskje burde ha det.

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
