### PR TITLE
(fix) Endre til å ikke bruke fnr/dnr som id for barn

### DIFF
--- a/package.json
+++ b/package.json
@@ -219,6 +219,7 @@
     "style-loader": "^2.0.0",
     "terser": "^5.6.0-beta",
     "terser-webpack-plugin": "^5.1.1",
+    "ts-essentials": "^7.0.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^8.0.16",
     "ts-node": "^9.1.1",

--- a/src/frontend/Miljø.ts
+++ b/src/frontend/Miljø.ts
@@ -6,7 +6,7 @@ interface MiljøProps {
     modellVersjon: number;
     dokumentUrl: string;
 }
-const modellVersjon = 4;
+const modellVersjon = 5;
 
 export const basePath = process.env.BASE_PATH;
 

--- a/src/frontend/Miljø.ts
+++ b/src/frontend/Miljø.ts
@@ -6,7 +6,7 @@ interface MiljøProps {
     modellVersjon: number;
     dokumentUrl: string;
 }
-const modellVersjon = 3;
+const modellVersjon = 4;
 
 export const basePath = process.env.BASE_PATH;
 

--- a/src/frontend/components/Felleskomponenter/BlokkerTilbakeKnappModal/BlokkerTilbakeKnappModal.test.tsx
+++ b/src/frontend/components/Felleskomponenter/BlokkerTilbakeKnappModal/BlokkerTilbakeKnappModal.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { act, render, waitFor } from '@testing-library/react';
 import { BrowserRouter, Route } from 'react-router-dom';
 
+import { IBarn, IBarnRespons } from '../../../typer/person';
 import { ISøknad } from '../../../typer/søknad';
 import {
     mockHistory,
@@ -12,11 +13,11 @@ import {
 } from '../../../utils/testing';
 import BlokkerTilbakeKnappModal from './BlokkerTilbakeKnappModal';
 
-const manueltRegistrert = {
+const manueltRegistrert: Partial<IBarn> = {
     ident: '12345',
     navn: 'A',
 };
-const fraPdl = {
+const fraPdl: Partial<IBarnRespons> = {
     ident: '54321',
     navn: 'B',
 };

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/useSendInnSkjema.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/useSendInnSkjema.tsx
@@ -79,7 +79,7 @@ export const useSendInnSkjema = (): { sendInnSkjema: () => Promise<boolean> } =>
 
         return {
             navn: søknadsfelt('Navn', navn),
-            ident: søknadsfelt('Ident', ident),
+            ident: søknadsfelt('Ident', ident ?? 'Ikke oppgitt'),
             borMedSøker: søknadsfelt(
                 'Bor med søker',
                 borMedSøker ??

--- a/src/frontend/components/SøknadsSteg/OmBarnaDine/HvilkeBarnCheckboxGruppe.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnaDine/HvilkeBarnCheckboxGruppe.tsx
@@ -8,11 +8,11 @@ import { Felt } from '@navikt/familie-skjema';
 import { useApp } from '../../../context/AppContext';
 import { barnDataKeySpørsmål } from '../../../typer/person';
 
-export type BarnetsIdent = string;
+export type BarnetsId = string;
 
 interface Props {
     legend: ReactNode;
-    skjemafelt: Felt<BarnetsIdent[]>;
+    skjemafelt: Felt<BarnetsId[]>;
     visFeilmelding: boolean;
     søknadsdatafelt: barnDataKeySpørsmål;
     nullstillValgteBarn: boolean;
@@ -26,10 +26,10 @@ const HvilkeBarnCheckboxGruppe: React.FC<Props> = ({
     visFeilmelding,
 }) => {
     const { søknad } = useApp();
-    const [valgteBarn, settValgteBarn] = useState<BarnetsIdent[]>(
+    const [valgteBarn, settValgteBarn] = useState<BarnetsId[]>(
         søknad.barnInkludertISøknaden
             .filter(barn => barn[søknadsdatafelt].svar === ESvar.JA)
-            .map(barn => barn.ident)
+            .map(barn => barn.id)
     );
 
     useEffect(() => {
@@ -40,20 +40,18 @@ const HvilkeBarnCheckboxGruppe: React.FC<Props> = ({
         nullstillValgteBarn && settValgteBarn([]);
     }, [nullstillValgteBarn]);
 
-    const oppdaterListeMedBarn = async (event: ChangeEvent) => {
-        const barnetsIdent = event.target.id.substring(`${skjemafelt.id}`.length);
-
-        const barnetFinnesIListen = !!valgteBarn.find(ident => ident === barnetsIdent);
+    const oppdaterListeMedBarn = async (event: ChangeEvent, barnetsId: BarnetsId) => {
+        const barnetFinnesIListen = !!valgteBarn.find(id => id === barnetsId);
         const barnChecked = (event.target as HTMLInputElement).checked;
 
         // Legg til barn i listen i lokal state
         if (barnChecked && !barnetFinnesIListen) {
-            settValgteBarn(prevState => [...prevState].concat(barnetsIdent));
+            settValgteBarn(prevState => [...prevState].concat(barnetsId));
         }
 
         // Fjern barn fra listen i lokal state
         if (!barnChecked && barnetFinnesIListen) {
-            settValgteBarn(prevState => [...prevState].filter(ident => ident !== barnetsIdent));
+            settValgteBarn(prevState => [...prevState].filter(id => id !== barnetsId));
         }
     };
 
@@ -69,9 +67,9 @@ const HvilkeBarnCheckboxGruppe: React.FC<Props> = ({
                     <Checkbox
                         key={index}
                         label={barnISøknad.navn}
-                        defaultChecked={!!valgteBarn.find(barn => barn === barnISøknad.ident)}
-                        id={`${skjemafelt.id}${barnISøknad.ident}`}
-                        onChange={event => oppdaterListeMedBarn(event)}
+                        defaultChecked={!!valgteBarn.find(barnId => barnId === barnISøknad.id)}
+                        id={`${skjemafelt.id}${barnISøknad.id}`}
+                        onChange={event => oppdaterListeMedBarn(event, barnISøknad.id)}
                     />
                 );
             })}

--- a/src/frontend/components/SøknadsSteg/OmBarnaDine/useBarnCheckboxFelt.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnaDine/useBarnCheckboxFelt.tsx
@@ -6,7 +6,7 @@ import { Avhengigheter, feil, Felt, FeltState, ok, useFelt } from '@navikt/famil
 import { useApp } from '../../../context/AppContext';
 import { barnDataKeySpørsmål } from '../../../typer/person';
 import SpråkTekst from '../../Felleskomponenter/SpråkTekst/SpråkTekst';
-import { BarnetsIdent } from './HvilkeBarnCheckboxGruppe';
+import { BarnetsId } from './HvilkeBarnCheckboxGruppe';
 
 const useBarnCheckboxFelt = (
     datafeltNavn: barnDataKeySpørsmål,
@@ -18,12 +18,12 @@ const useBarnCheckboxFelt = (
 
     const skalFeltetVises = jaNeiSpmVerdi => jaNeiSpmVerdi === avhengigJaNeiSpmSvarCondition;
 
-    const checkbox = useFelt<BarnetsIdent[]>({
+    const checkbox = useFelt<BarnetsId[]>({
         feltId: barn[0][datafeltNavn].id,
         verdi: søknad.barnInkludertISøknaden
             .filter(barn => barn[datafeltNavn].svar === ESvar.JA)
-            .map(barn => barn.ident),
-        valideringsfunksjon: (felt: FeltState<BarnetsIdent[]>) => {
+            .map(barn => barn.id),
+        valideringsfunksjon: (felt: FeltState<BarnetsId[]>) => {
             return felt.verdi.length > 0
                 ? ok(felt)
                 : feil(felt, <SpråkTekst id={'ombarna.barn-ikke-valgt.feilmelding'} />);

--- a/src/frontend/components/SøknadsSteg/OmBarnaDine/useOmBarnaDine.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnaDine/useOmBarnaDine.tsx
@@ -5,7 +5,7 @@ import { useApp } from '../../../context/AppContext';
 import useJaNeiSpmFelt from '../../../hooks/useJaNeiSpmFelt';
 import { Dokumentasjonsbehov } from '../../../typer/dokumentasjon';
 import { barnDataKeySpørsmål } from '../../../typer/person';
-import { BarnetsIdent } from './HvilkeBarnCheckboxGruppe';
+import { BarnetsId } from './HvilkeBarnCheckboxGruppe';
 import useBarnCheckboxFelt from './useBarnCheckboxFelt';
 import { genererOppdaterteBarn } from './utils';
 
@@ -17,13 +17,13 @@ export interface IOmBarnaDineFeltTyper {
     søktAsylForBarn: ESvar | undefined;
     barnOppholdtSegTolvMndSammenhengendeINorge: ESvar | undefined;
     mottarBarnetrygdForBarnFraAnnetEøsland: ESvar | undefined;
-    hvemErFosterbarn: BarnetsIdent[];
-    hvemOppholderSegIInstitusjon: BarnetsIdent[];
-    hvemErAdoptertFraUtland: BarnetsIdent[];
-    hvemOppholderSegIUtland: BarnetsIdent[];
-    hvemBarnetrygdFraAnnetEøsland: BarnetsIdent[];
-    hvemTolvMndSammenhengendeINorge: BarnetsIdent[];
-    hvemErSøktAsylFor: BarnetsIdent[];
+    hvemErFosterbarn: BarnetsId[];
+    hvemOppholderSegIInstitusjon: BarnetsId[];
+    hvemErAdoptertFraUtland: BarnetsId[];
+    hvemOppholderSegIUtland: BarnetsId[];
+    hvemBarnetrygdFraAnnetEøsland: BarnetsId[];
+    hvemTolvMndSammenhengendeINorge: BarnetsId[];
+    hvemErSøktAsylFor: BarnetsId[];
 }
 
 export const useOmBarnaDine = (): {
@@ -133,14 +133,6 @@ export const useOmBarnaDine = (): {
         mottarBarnetrygdForBarnFraAnnetEøsland
     );
 
-    const mapFraIdentTilBarnId = (identer: string[]): string[] => {
-        const mapTilBarnMedISøknad = søknad.barnInkludertISøknaden.filter(barn =>
-            identer.includes(barn.ident)
-        );
-
-        return mapTilBarnMedISøknad.map(barn => barn.id);
-    };
-
     const oppdaterSøknad = () => {
         settSøknad({
             ...søknad,
@@ -178,17 +170,17 @@ export const useOmBarnaDine = (): {
                     case Dokumentasjonsbehov.VEDTAK_OPPHOLDSTILLATELSE:
                         return {
                             ...dok,
-                            gjelderForBarnId: mapFraIdentTilBarnId(hvemErSøktAsylFor.verdi),
+                            gjelderForBarnId: hvemErSøktAsylFor.verdi,
                         };
                     case Dokumentasjonsbehov.ADOPSJON_DATO:
                         return {
                             ...dok,
-                            gjelderForBarnId: mapFraIdentTilBarnId(hvemErAdoptertFraUtland.verdi),
+                            gjelderForBarnId: hvemErAdoptertFraUtland.verdi,
                         };
                     case Dokumentasjonsbehov.BEKREFTELSE_FRA_BARNEVERN:
                         return {
                             ...dok,
-                            gjelderForBarnId: mapFraIdentTilBarnId(hvemErFosterbarn.verdi),
+                            gjelderForBarnId: hvemErFosterbarn.verdi,
                         };
                     default:
                         return dok;

--- a/src/frontend/components/SøknadsSteg/OmBarnaDine/utils.test.ts
+++ b/src/frontend/components/SøknadsSteg/OmBarnaDine/utils.test.ts
@@ -1,17 +1,20 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
-
-// Disabler ts for å kunne sende inn parametre med kun nødvendige felter i objektet, uten å måtte mocke hele objektet.
+import { mockDeep } from 'jest-mock-extended';
+import { DeepPartial } from 'ts-essentials';
 
 import { ESvar } from '@navikt/familie-form-elements';
+import { Felt, ISkjema } from '@navikt/familie-skjema';
 
-import { AlternativtSvarForInput } from '../../../typer/person';
+import { AlternativtSvarForInput, IBarnMedISøknad } from '../../../typer/person';
+import { ISøknad } from '../../../typer/søknad';
+import { IOmBarnaDineFeltTyper } from './useOmBarnaDine';
 import { genererOppdaterteBarn, genererSvarForSpørsmålBarn } from './utils';
 
 describe('genererSvarForSpørsmålBarn', () => {
-    const mockBarn = { ident: '12345678910' };
-    const mockFeltSomInkludererBarn = { verdi: ['12345678910'] };
-    const mockFeltSomIkkeInkludererBarn = { verdi: ['12345678911', '12345678912'] };
+    const mockBarn = mockDeep<IBarnMedISøknad>({ id: 'random-id' });
+    const mockFeltSomInkludererBarn = mockDeep<Felt<string[]>>({ verdi: ['random-id'] });
+    const mockFeltSomIkkeInkludererBarn = mockDeep<Felt<string[]>>({
+        verdi: ['random-id-1', 'random-id-2'],
+    });
 
     test('Returner JA dersom barn er inkludert i feltets verdi (array)', () => {
         expect(genererSvarForSpørsmålBarn(mockBarn, mockFeltSomInkludererBarn)).toEqual('JA');
@@ -22,10 +25,11 @@ describe('genererSvarForSpørsmålBarn', () => {
 });
 
 describe('genererOppdaterteBarn', () => {
-    const mockSøknad = {
+    const { objectContaining } = expect;
+    const mockSøknad = mockDeep<ISøknad>({
         barnInkludertISøknaden: [
             {
-                ident: '12345678910',
+                id: 'random-id',
                 institusjonsnavn: { svar: 'Narvesen' },
                 institusjonsadresse: { svar: 'Narvesen' },
                 institusjonspostnummer: { svar: '2020' },
@@ -39,16 +43,17 @@ describe('genererOppdaterteBarn', () => {
                 barnetrygdFraEøslandHvilketLand: { svar: 'AUS' },
             },
         ],
-    };
-    const mockSkjema = {
+    });
+
+    const mockSkjema = mockDeep<ISkjema<IOmBarnaDineFeltTyper, string>>({
         felter: {
-            hvemErFosterbarn: { verdi: ['12345678910'] },
-            hvemErSøktAsylFor: { verdi: ['12345678910'] },
+            hvemErFosterbarn: { verdi: ['random-id'] },
+            hvemErSøktAsylFor: { verdi: ['random-id'] },
             hvemErAdoptertFraUtland: { verdi: [] },
             hvemOppholderSegIInstitusjon: { verdi: [] },
             hvemTolvMndSammenhengendeINorge: { verdi: [] },
-            hvemOppholderSegIUtland: { verdi: ['12345678910'] },
-            hvemBarnetrygdFraAnnetEøsland: { verdi: ['12345678910'] },
+            hvemOppholderSegIUtland: { verdi: ['random-id'] },
+            hvemBarnetrygdFraAnnetEøsland: { verdi: ['random-id'] },
             erNoenAvBarnaFosterbarn: {
                 verdi: ESvar.JA,
             },
@@ -71,31 +76,31 @@ describe('genererOppdaterteBarn', () => {
                 verdi: ESvar.JA,
             },
         },
-    };
+    });
 
     test('Returner objekt med barn, med forventede verdier', () => {
         expect(genererOppdaterteBarn(mockSøknad, mockSkjema)).toEqual([
-            {
-                ident: '12345678910',
-                erFosterbarn: { svar: 'JA' },
-                erAsylsøker: { svar: 'JA' },
-                erAdoptertFraUtland: { svar: 'NEI' },
-                oppholderSegIInstitusjon: { svar: 'NEI' },
-                boddMindreEnn12MndINorge: { svar: 'NEI' },
-                oppholderSegIUtland: { svar: 'JA' },
-                barnetrygdFraAnnetEøsland: { svar: 'JA' },
-                institusjonsnavn: { svar: '' },
-                institusjonsadresse: { svar: '' },
-                institusjonspostnummer: { svar: '' },
-                institusjonOppholdStartdato: { svar: '' },
-                institusjonOppholdSluttdato: { svar: '' },
-                oppholdsland: { svar: 'AUS' },
-                oppholdslandStartdato: { svar: '2020-08-08' },
-                oppholdslandSluttdato: { svar: AlternativtSvarForInput.UKJENT },
-                nårKomBarnTilNorgeDato: { svar: '' },
-                planleggerÅBoINorge12Mnd: { svar: undefined },
-                barnetrygdFraEøslandHvilketLand: { svar: 'AUS' },
-            },
+            objectContaining<DeepPartial<IBarnMedISøknad>>({
+                id: 'random-id',
+                erFosterbarn: objectContaining({ svar: 'JA' }),
+                erAsylsøker: objectContaining({ svar: 'JA' }),
+                erAdoptertFraUtland: objectContaining({ svar: 'NEI' }),
+                oppholderSegIInstitusjon: objectContaining({ svar: 'NEI' }),
+                boddMindreEnn12MndINorge: objectContaining({ svar: 'NEI' }),
+                oppholderSegIUtland: objectContaining({ svar: 'JA' }),
+                barnetrygdFraAnnetEøsland: objectContaining({ svar: 'JA' }),
+                institusjonsnavn: objectContaining({ svar: '' }),
+                institusjonsadresse: objectContaining({ svar: '' }),
+                institusjonspostnummer: objectContaining({ svar: '' }),
+                institusjonOppholdStartdato: objectContaining({ svar: '' }),
+                institusjonOppholdSluttdato: objectContaining({ svar: '' }),
+                oppholdsland: objectContaining({ svar: 'AUS' }),
+                oppholdslandStartdato: objectContaining({ svar: '2020-08-08' }),
+                oppholdslandSluttdato: objectContaining({ svar: AlternativtSvarForInput.UKJENT }),
+                nårKomBarnTilNorgeDato: objectContaining({ svar: '' }),
+                planleggerÅBoINorge12Mnd: objectContaining({ svar: undefined }),
+                barnetrygdFraEøslandHvilketLand: objectContaining({ svar: 'AUS' }),
+            }),
         ]);
     });
 });

--- a/src/frontend/components/SøknadsSteg/OmBarnaDine/utils.ts
+++ b/src/frontend/components/SøknadsSteg/OmBarnaDine/utils.ts
@@ -1,12 +1,12 @@
 import { ESvar } from '@navikt/familie-form-elements';
 import { Felt, ISkjema } from '@navikt/familie-skjema';
 
-import { barnDataKeySpørsmål, IBarn, IBarnMedISøknad } from '../../../typer/person';
+import { barnDataKeySpørsmål, IBarnMedISøknad } from '../../../typer/person';
 import { ISøknad } from '../../../typer/søknad';
 import { IOmBarnaDineFeltTyper } from './useOmBarnaDine';
 
-export const genererSvarForSpørsmålBarn = (barn: IBarn, felt: Felt<string[]>): ESvar =>
-    felt.verdi.includes(barn.ident) ? ESvar.JA : ESvar.NEI;
+export const genererSvarForSpørsmålBarn = (barn: IBarnMedISøknad, felt: Felt<string[]>): ESvar =>
+    felt.verdi.includes(barn.id) ? ESvar.JA : ESvar.NEI;
 
 export const genererSvarForOppfølgningspørsmålBarn = (
     svarPåGrunnSpørsmål,

--- a/src/frontend/components/SøknadsSteg/OmBarnet/OmBarnet.test.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/OmBarnet.test.tsx
@@ -21,6 +21,7 @@ silenceConsoleErrors();
 
 const jens = {
     navn: 'Jens',
+    id: 'random-id-jens',
     ident: '12345678910',
     [barnDataKeySpørsmål.erFosterbarn]: { id: '1', svar: ESvar.NEI },
     [barnDataKeySpørsmål.oppholderSegIInstitusjon]: { id: '2', svar: ESvar.JA },
@@ -64,6 +65,7 @@ const jens = {
 };
 const line = {
     navn: 'Line',
+    id: 'random-id-line',
     ident: '12345678911',
     [barnDataKeySpørsmål.erFosterbarn]: { id: '', svar: ESvar.NEI },
     [barnDataKeySpørsmål.oppholderSegIInstitusjon]: { id: '', svar: ESvar.NEI },
@@ -115,7 +117,7 @@ test(`Kan rendre Om Barnet Utfyllende`, () => {
 
     render(
         <TestProvidere>
-            <OmBarnet barnetsIdent={'12345678910'} />
+            <OmBarnet barnetsId={'random-id-jens'} />
         </TestProvidere>
     );
 });
@@ -135,7 +137,7 @@ test(`Kan navigere mellom to barn`, () => {
             <HttpProvider>
                 <AppNavigationProvider>
                     <RoutesProvider>
-                        <OmBarnet barnetsIdent={'12345678910'} />
+                        <OmBarnet barnetsId={'random-id-jens'} />
                     </RoutesProvider>
                 </AppNavigationProvider>
             </HttpProvider>
@@ -171,7 +173,7 @@ test(`Kan navigere fra barn til oppsummering`, () => {
             <HttpProvider>
                 <AppNavigationProvider>
                     <RoutesProvider>
-                        <OmBarnet barnetsIdent={'12345678910'} />
+                        <OmBarnet barnetsId={'random-id-jens'} />
                     </RoutesProvider>
                 </AppNavigationProvider>
             </HttpProvider>

--- a/src/frontend/components/SøknadsSteg/OmBarnet/OmBarnet.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/OmBarnet.tsx
@@ -15,6 +15,7 @@ import SkjemaFieldset from '../../Felleskomponenter/SkjemaFieldset';
 import SpråkTekst from '../../Felleskomponenter/SpråkTekst/SpråkTekst';
 import Steg from '../../Felleskomponenter/Steg/Steg';
 import { VedleggNotis } from '../../Felleskomponenter/VedleggNotis';
+import { BarnetsId } from '../OmBarnaDine/HvilkeBarnCheckboxGruppe';
 import AndreForelder from './AndreForelder';
 import Oppfølgningsspørsmål from './Oppfølgningsspørsmål';
 import { OmBarnetSpørsmålsId, omBarnetSpørsmålSpråkId } from './spørsmål';
@@ -24,14 +25,14 @@ const EksternLenkeContainer = styled.div`
     margin-bottom: 4rem;
 `;
 
-const OmBarnet: React.FC<{ barnetsIdent: string }> = ({ barnetsIdent }) => {
+const OmBarnet: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
     const {
         skjema,
         validerFelterOgVisFeilmelding,
         valideringErOk,
         oppdaterSøknad,
         barn,
-    } = useOmBarnet(barnetsIdent);
+    } = useOmBarnet(barnetsId);
 
     return barn ? (
         <Steg

--- a/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.test.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.test.tsx
@@ -10,6 +10,7 @@ import { useOmBarnet } from './useOmBarnet';
 
 describe('useOmBarnet', () => {
     const barnFraPdl: IBarn = {
+        id: 'random-id-1',
         navn: 'Barn Barnessen',
         ident: '1234',
         borMedSøker: true,
@@ -34,7 +35,7 @@ describe('useOmBarnet', () => {
 
         const { result } = renderHook(
             () => {
-                return useOmBarnet('1234');
+                return useOmBarnet('random-id-1');
             },
             { wrapper: TestProvidere }
         );
@@ -78,7 +79,7 @@ describe('useOmBarnet', () => {
 
         const { result } = renderHook(
             () => {
-                return useOmBarnet('1234');
+                return useOmBarnet('random-id-1');
             },
             { wrapper: TestProvidere }
         );
@@ -112,7 +113,7 @@ describe('useOmBarnet', () => {
 
         const { result } = renderHook(
             () => {
-                return useOmBarnet('1234');
+                return useOmBarnet('random-id-1');
             },
             { wrapper: TestProvidere }
         );

--- a/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.tsx
@@ -27,6 +27,7 @@ import {
     IBarnMedISøknad,
 } from '../../../typer/person';
 import SpråkTekst from '../../Felleskomponenter/SpråkTekst/SpråkTekst';
+import { BarnetsId } from '../OmBarnaDine/HvilkeBarnCheckboxGruppe';
 import useLanddropdownFeltMedJaNeiAvhengighet from '../OmDeg/useLanddropdownFeltMedJaNeiAvhengighet';
 import { OmBarnetSpørsmålsId } from './spørsmål';
 import useDatovelgerFelt from './useDatovelgerFelt';
@@ -66,7 +67,7 @@ export interface IOmBarnetUtvidetFeltTyper {
 }
 
 export const useOmBarnet = (
-    barnetsIdent: string
+    barnetsUuid: BarnetsId
 ): {
     skjema: ISkjema<IOmBarnetUtvidetFeltTyper, string>;
     barn: IBarnMedISøknad | undefined;
@@ -80,7 +81,7 @@ export const useOmBarnet = (
     const location = useLocation<ILokasjon>();
 
     const [barn] = useState<IBarnMedISøknad | undefined>(
-        søknad.barnInkludertISøknaden.find(barn => barn.ident === barnetsIdent)
+        søknad.barnInkludertISøknaden.find(barn => barn.id === barnetsUuid)
     );
 
     if (!barn) {
@@ -440,7 +441,7 @@ export const useOmBarnet = (
     const oppdaterSøknad = () => {
         const oppdatertBarnInkludertISøknaden: IBarnMedISøknad[] = søknad.barnInkludertISøknaden.map(
             barn =>
-                barn.ident === barnetsIdent
+                barn.id === barnetsUuid
                     ? {
                           ...barn,
                           institusjonsnavn: {

--- a/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummering.tsx
@@ -337,7 +337,7 @@ const Oppsummering: React.FC = () => {
                         key={index}
                         route={hentStegObjektForBarn(barn)}
                         skjemaHook={useOmBarnet}
-                        ident={barn.ident}
+                        barnId={barn.id}
                         settFeilAnchors={settFeilAnchors}
                     >
                         {barn[barnDataKeySpørsmål.erFosterbarn].svar === ESvar.JA && (

--- a/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummeringsbolk.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummeringsbolk.tsx
@@ -26,7 +26,7 @@ interface Props {
     språkValues?: { [key: string]: string };
     route?: IRoute;
     skjemaHook: (...args: string[]) => IHookReturn;
-    ident?: string;
+    barnId?: string;
     settFeilAnchors?: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
@@ -51,13 +51,13 @@ const Oppsummeringsbolk: React.FC<Props> = ({
     språkValues,
     route,
     skjemaHook,
-    ident,
+    barnId,
     settFeilAnchors,
 }) => {
     const { hentStegNummer } = useRoutes();
     const { søknad } = useApp();
-    const { validerAlleSynligeFelter, valideringErOk, skjema } = ident
-        ? skjemaHook(ident)
+    const { validerAlleSynligeFelter, valideringErOk, skjema } = barnId
+        ? skjemaHook(barnId)
         : skjemaHook();
     const [visFeil, settVisFeil] = useState(false);
 

--- a/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/Barnekort.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/Barnekort.tsx
@@ -92,12 +92,10 @@ const Barnekort: React.FC<IBarnekortProps> = ({
         søknad: { barnRegistrertManuelt },
     } = useApp();
 
-    const erMedISøknad = !!barnSomSkalVæreMed.find(
-        barnMedISøknad => barnMedISøknad.ident === barn.ident
-    );
+    const erMedISøknad = !!barnSomSkalVæreMed.find(barnMedISøknad => barnMedISøknad.id === barn.id);
 
     const erRegistrertManuelt = !!barnRegistrertManuelt.find(
-        manueltRegistrertBarn => manueltRegistrertBarn.ident === barn.ident
+        manueltRegistrertBarn => manueltRegistrertBarn.id === barn.id
     );
 
     return (
@@ -110,10 +108,12 @@ const Barnekort: React.FC<IBarnekortProps> = ({
             </BarnekortHeader>
             <InformasjonsboksInnhold>
                 <StyledUndertittel>{barn.navn}</StyledUndertittel>
-                <BarneKortInfo
-                    labelId={'hvilkebarn.barn.fødselsnummer'}
-                    verdi={formaterFnr(barn.ident)}
-                />
+                {barn.ident && (
+                    <BarneKortInfo
+                        labelId={'hvilkebarn.barn.fødselsnummer'}
+                        verdi={formaterFnr(barn.ident)}
+                    />
+                )}
                 {barn.alder && ( // Barn som søker har lagt inn selv har ikke fødselsdato
                     <BarneKortInfo labelId={'hvilkebarn.barn.alder'} verdi={barn.alder} />
                 )}
@@ -141,7 +141,7 @@ const Barnekort: React.FC<IBarnekortProps> = ({
                 />
             </InformasjonsboksInnhold>
             {erRegistrertManuelt && (
-                <FjernBarnKnapp ident={barn.ident} fjernBarnCallback={fjernBarnCallback} />
+                <FjernBarnKnapp barnId={barn.id} fjernBarnCallback={fjernBarnCallback} />
             )}
         </StyledBarnekort>
     );

--- a/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/FjernBarnKnapp.test.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/FjernBarnKnapp.test.tsx
@@ -22,6 +22,7 @@ describe('FjernBarnKnapp', () => {
         silenceConsoleErrors();
 
         const registrertBarn: IBarn = {
+            id: 'random-id-manuell',
             ident: '12345',
             navn: 'Test',
             borMedSøker: true,
@@ -29,6 +30,7 @@ describe('FjernBarnKnapp', () => {
             adressebeskyttelse: false,
         };
         const pdlBarn: IBarn = {
+            id: 'random-id-pdl',
             ident: '54321',
             navn: 'Også test',
             borMedSøker: true,
@@ -60,6 +62,7 @@ describe('FjernBarnKnapp', () => {
         silenceConsoleErrors();
 
         const registrertBarn: IBarn = {
+            id: 'random-id',
             ident: '12345',
             navn: 'Test',
             borMedSøker: true,

--- a/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/FjernBarnKnapp.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/FjernBarnKnapp.tsx
@@ -7,21 +7,22 @@ import { Flatknapp } from 'nav-frontend-knapper';
 import { DeleteFilled } from '@navikt/ds-icons';
 
 import SpråkTekst from '../../../Felleskomponenter/SpråkTekst/SpråkTekst';
+import { BarnetsId } from '../../OmBarnaDine/HvilkeBarnCheckboxGruppe';
 
 const StyledFlatknapp = styled(Flatknapp)`
     margin: 1rem 0 -1rem -0.75rem; // -0.75 left kompanserer for padding-left fra .knapp--kompakt
 `;
 
 export const FjernBarnKnapp: React.FC<{
-    ident: string;
+    barnId: BarnetsId;
     fjernBarnCallback: (ident: string) => void;
-}> = ({ ident, fjernBarnCallback }) => {
+}> = ({ barnId, fjernBarnCallback }) => {
     return (
         <StyledFlatknapp
             htmlType={'button'}
             mini={true}
             kompakt={true}
-            onClick={() => fjernBarnCallback(ident)}
+            onClick={() => fjernBarnCallback(barnId)}
         >
             <DeleteFilled />
             <span>

--- a/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/useLeggTilBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/useLeggTilBarn.tsx
@@ -11,6 +11,7 @@ import { useApp } from '../../../../context/AppContext';
 import Miljø from '../../../../Miljø';
 import { barnDataKeySpørsmål, IBarn } from '../../../../typer/person';
 import { erBarnRegistrertFraFør } from '../../../../utils/person';
+import { hentUid } from '../../../../utils/uuid';
 import SpråkTekst from '../../../Felleskomponenter/SpråkTekst/SpråkTekst';
 import { ESvarMedUbesvart } from '../../OmDeg/useOmdeg';
 import useNavnInputFelt from './useNavnInputFelt';
@@ -19,8 +20,9 @@ import useNavnInputFelt from './useNavnInputFelt';
 export interface ILeggTilBarnTyper
     extends Omit<
         IBarn,
-        'borMedSøker' | 'alder' | 'navn' | 'adressebeskyttelse' | barnDataKeySpørsmål
+        'borMedSøker' | 'alder' | 'navn' | 'adressebeskyttelse' | 'id' | barnDataKeySpørsmål
     > {
+    ident: string;
     erFødt: ESvarMedUbesvart;
     navnetErUbestemt: ESvar;
     harBarnetFåttIdNummer: ESvar;
@@ -145,6 +147,7 @@ export const useLeggTilBarn = (): {
                 ...søknad,
                 barnRegistrertManuelt: søknad.barnRegistrertManuelt.concat([
                     {
+                        id: hentUid(),
                         navn:
                             fulltNavn() ||
                             intl.formatMessage({ id: 'hvilkebarn.barn.ingen-navn.placeholder' }),

--- a/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.tsx
@@ -4,7 +4,6 @@ import Masonry from 'react-masonry-css';
 import styled from 'styled-components/macro';
 
 import { useApp } from '../../../context/AppContext';
-import { mapBarnResponsTilBarn } from '../../../utils/person';
 import AlertStripe from '../../Felleskomponenter/AlertStripe/AlertStripe';
 import EksternLenke from '../../Felleskomponenter/EksternLenke/EksternLenke';
 import SpråkTekst from '../../Felleskomponenter/SpråkTekst/SpråkTekst';
@@ -43,9 +42,7 @@ const VelgBarn: React.FC = () => {
 
     const [modalÅpen, settModalÅpen] = useState<boolean>(false);
 
-    const barnFraRespons = mapBarnResponsTilBarn(søknad.søker.barn).filter(
-        barn => !barn.adressebeskyttelse
-    );
+    const barnFraRespons = søknad.søker.barn.filter(barn => !barn.adressebeskyttelse);
     const barnManueltLagtTil = søknad.barnRegistrertManuelt;
     const barn = barnFraRespons.concat(barnManueltLagtTil);
     const harBarnMedBeskyttaAdresse = !!søknad.søker.barn.find(barn => barn.adressebeskyttelse);
@@ -84,10 +81,10 @@ const VelgBarn: React.FC = () => {
                         480: 1,
                     }}
                 >
-                    {barn.map(barn => (
+                    {barn.map(barnet => (
                         <Barnekort
-                            key={barn.ident}
-                            barn={barn}
+                            key={barnet.id}
+                            barn={barnet}
                             velgBarnCallback={håndterVelgBarnToggle}
                             barnSomSkalVæreMed={barnSomSkalVæreMed}
                             fjernBarnCallback={fjernBarn}

--- a/src/frontend/components/SøknadsSteg/VelgBarn/useVelgBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/useVelgBarn.tsx
@@ -7,6 +7,7 @@ import { useRoutes } from '../../../context/RoutesContext';
 import { IBarn, IBarnMedISøknad } from '../../../typer/person';
 import { genererInitialBarnMedISøknad } from '../../../utils/person';
 import SpråkTekst from '../../Felleskomponenter/SpråkTekst/SpråkTekst';
+import { BarnetsId } from '../OmBarnaDine/HvilkeBarnCheckboxGruppe';
 import { VelgBarnSpørsmålId } from './spørsmål';
 
 export interface IVelgBarnFeltTyper {
@@ -34,14 +35,12 @@ export const useVelgBarn = (): {
         settBarnForRoutes(barnSomSkalVæreMed);
     }, [barnSomSkalVæreMed]);
 
-    const fjernBarn = (ident: string) => {
+    const fjernBarn = (id: BarnetsId) => {
         settSøknad({
             ...søknad,
-            barnRegistrertManuelt: søknad.barnRegistrertManuelt.filter(
-                barn => ident !== barn.ident
-            ),
+            barnRegistrertManuelt: søknad.barnRegistrertManuelt.filter(barn => id !== barn.id),
         });
-        settBarnSomSkalVæreMed(barnSomSkalVæreMed.filter(barn => ident !== barn.ident));
+        settBarnSomSkalVæreMed(barnSomSkalVæreMed.filter(barn => id !== barn.id));
     };
 
     const barnMedISøknad = useFelt<IBarn[]>({
@@ -58,13 +57,13 @@ export const useVelgBarn = (): {
     const oppdaterSøknad = () => {
         const barnSomAlleredeErLagtTil = barnSomSkalVæreMed.filter(
             barnSomSkalVæreMed =>
-                !!barnInkludertISøknaden.find(barn => barn.ident === barnSomSkalVæreMed.ident)
+                !!barnInkludertISøknaden.find(barn => barn.id === barnSomSkalVæreMed.id)
         );
 
         const nyeBarnSomSkalLeggesTil = barnSomSkalVæreMed.filter(
             barnSomSkalVæreMed =>
                 !barnSomAlleredeErLagtTil.find(
-                    barnLagtTil => barnLagtTil.ident === barnSomSkalVæreMed.ident
+                    barnLagtTil => barnLagtTil.id === barnSomSkalVæreMed.id
                 )
         );
 
@@ -93,7 +92,7 @@ export const useVelgBarn = (): {
         settBarnSomSkalVæreMed(prevState =>
             skalVæreMed
                 ? prevState.concat(genererInitialBarnMedISøknad(barn))
-                : prevState.filter(barnMedISøknad => barnMedISøknad.ident !== barn.ident)
+                : prevState.filter(barnMedISøknad => barnMedISøknad.id !== barn.id)
         );
     };
 

--- a/src/frontend/context/AppContext.ts
+++ b/src/frontend/context/AppContext.ts
@@ -18,6 +18,7 @@ import { IMellomlagretBarnetrygd } from '../typer/mellomlager';
 import { ISøkerRespons } from '../typer/person';
 import { initialStateSøknad, ISøknad } from '../typer/søknad';
 import { autentiseringsInterceptor, InnloggetStatus } from '../utils/autentisering';
+import { mapBarnResponsTilBarn } from '../utils/person';
 import { håndterApiRessurs, loggFeil, preferredAxios } from './axios';
 
 const [AppProvider, useApp] = createUseContext(() => {
@@ -59,7 +60,7 @@ const [AppProvider, useApp] = createUseContext(() => {
                             ...søknad.søker,
                             navn: ressurs.data.navn,
                             statsborgerskap: ressurs.data.statsborgerskap,
-                            barn: ressurs.data.barn,
+                            barn: mapBarnResponsTilBarn(ressurs.data.barn),
                             ident: ressurs.data.ident,
                             adresse: ressurs.data.adresse,
                             sivilstand: ressurs.data.sivilstand,

--- a/src/frontend/context/RoutesContext.tsx
+++ b/src/frontend/context/RoutesContext.tsx
@@ -19,7 +19,7 @@ export interface IRoute {
     path: string;
     label: string;
     route: RouteEnum;
-    komponent: React.FC | React.FC<{ barnetsIdent: string }>;
+    komponent: React.FC | React.FC<{ barnetsId: string }>;
     // Vi kan ha routes som ser helt like ut (to barn uten navn f.eks), trenger å kunne skille mellom dem
     spesifisering?: string;
 }
@@ -55,7 +55,7 @@ const [RoutesProvider, useRoutes] = createUseContext(() => {
                   label: `Om ${barn.navn}`,
                   route: RouteEnum.OmBarnet,
                   komponent: () => {
-                      return <OmBarnet barnetsIdent={barn.ident} />;
+                      return <OmBarnet barnetsId={barn.id} />;
                   },
                   spesifisering: barn.id,
               };

--- a/src/frontend/typer/person.ts
+++ b/src/frontend/typer/person.ts
@@ -2,6 +2,7 @@ import { Alpha3Code } from 'i18n-iso-countries';
 
 import { ESvar, ISODateString } from '@navikt/familie-form-elements';
 
+import { BarnetsId } from '../components/SøknadsSteg/OmBarnaDine/HvilkeBarnCheckboxGruppe';
 import { ISøknadSpørsmål } from './søknad';
 
 export enum ESivilstand {
@@ -30,7 +31,8 @@ export interface ISøkerRespons extends IPerson {
     sivilstand: { type: ESivilstand };
 }
 
-export interface ISøker extends ISøkerRespons {
+export interface ISøker extends Omit<ISøkerRespons, 'barn'> {
+    barn: IBarn[];
     telefonnummer: ISøknadSpørsmål<string>;
     borPåRegistrertAdresse: ISøknadSpørsmål<ESvar | undefined>;
     oppholderSegINorge: ISøknadSpørsmål<ESvar | undefined>;
@@ -87,12 +89,15 @@ export enum barnDataKeySpørsmål {
     søkerForTidsromSluttdato = 'søkerForTidsromSluttdato',
 }
 
-export interface IBarnRespons extends IPerson {
+export interface IBarnRespons extends Omit<IPerson, 'ident'> {
+    ident?: string;
     borMedSøker: boolean;
     fødselsdato: string | undefined;
 }
 
-export interface IBarn extends IPerson {
+export interface IBarn extends Omit<IPerson, 'ident'> {
+    ident?: string;
+    id: BarnetsId;
     borMedSøker: boolean | undefined;
     alder: string | undefined;
 }
@@ -104,7 +109,6 @@ export enum AlternativtSvarForInput {
 export type DatoMedUkjent = ISODateString | AlternativtSvarForInput.UKJENT;
 
 export interface IBarnMedISøknad extends IBarn {
-    id: string;
     [barnDataKeySpørsmål.erFosterbarn]: ISøknadSpørsmål<ESvar | undefined>;
     [barnDataKeySpørsmål.erAdoptertFraUtland]: ISøknadSpørsmål<ESvar | undefined>;
     [barnDataKeySpørsmål.barnetrygdFraAnnetEøsland]: ISøknadSpørsmål<ESvar | undefined>;

--- a/src/frontend/utils/person.ts
+++ b/src/frontend/utils/person.ts
@@ -74,7 +74,6 @@ export const hentSivilstatus = (statuskode?: ESivilstand) => {
 export const genererInitialBarnMedISøknad = (barn: IBarn): IBarnMedISøknad => {
     return {
         ...barn,
-        id: hentUid(),
         [barnDataKeySpørsmål.erFosterbarn]: {
             id: OmBarnaDineSpørsmålId.hvemErFosterbarn,
             svar: undefined,
@@ -196,6 +195,7 @@ export const genererInitialBarnMedISøknad = (barn: IBarn): IBarnMedISøknad => 
 
 export const mapBarnResponsTilBarn = (barn: IBarnRespons[]): IBarn[] => {
     return barn.map(barnRespons => ({
+        id: hentUid(),
         navn: barnRespons.navn,
         ident: barnRespons.ident,
         alder: barnRespons.fødselsdato && hentAlder(barnRespons.fødselsdato),

--- a/src/frontend/utils/testing.tsx
+++ b/src/frontend/utils/testing.tsx
@@ -184,6 +184,7 @@ export const mekkGyldigSøknad = (): ISøknad => {
         barnInkludertISøknaden: [
             {
                 ...genererInitialBarnMedISøknad({
+                    id: 'random-id',
                     ident: '1234',
                     navn: 'Datter Dattersdottir',
                     adressebeskyttelse: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10893,6 +10893,11 @@ ts-essentials@^4.0.0:
   resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-4.0.0.tgz#506c42b270bbd0465574b90416533175b09205ab"
   integrity sha512-uQJX+SRY9mtbKU+g9kl5Fi7AEMofPCvHfJkQlaygpPmHPZrtgaBqbWFOYyiA47RhnSwwnXdepUJrgqUYxoUyhQ==
 
+ts-essentials@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-7.0.2.tgz#e21142df8034dbd444cb9573ed204d0b85fc64fb"
+  integrity sha512-qWPVC1xZGdefbsgFP7tPo+bsgSA2ZIXL1XeEe5M2WoMZxIOr/HbsHxP/Iv75IFhiMHMDGL7cOOwi5SXcgx9mHw==
+
 ts-jest@^26.4.4:
   version "26.4.4"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.4.4.tgz#61f13fb21ab400853c532270e52cc0ed7e502c49"


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Endre til å bruke generert uid for barn istedenfor fnr/dnr til å identifisere barn i frontend

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Har endret funksjonalitet og søknadskontrakt slik at barn blir tildelt uid så snart vi mottar barnet fra backend. Dette for å unngå problematikk med at barn fikk nye id'er hver render/refresh slik at man fortsatt kan bruke mellomlagring.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [x] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei