### PR TITLE
fix vedlegg ANNEN_DOKUMENTASJON visning

### DIFF
--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg.test.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import { HttpProvider } from '@navikt/familie-http';
+import { LocaleType, SprakProvider } from '@navikt/familie-sprakvelger';
+
+import { RoutesProvider } from '../../../context/RoutesContext';
+import { Dokumentasjonsbehov, IDokumentasjon } from '../../../typer/dokumentasjon';
+import { silenceConsoleErrors, spyOnUseApp } from '../../../utils/testing';
+import LastOppVedlegg from './LastOppVedlegg';
+
+silenceConsoleErrors();
+
+describe('LastOppVedlegg', () => {
+    it('Viser ikke info-tekst og checkbox knapp for ANNEN_DOKUMENTASJON', () => {
+        spyOnUseApp({});
+
+        const tittelSpråkId = 'id på tittel for ANNEN_DOKUMENTASJON';
+        const beskrivelseSpråkId = 'id på beskrivelse for ANNEN_DOKUMENTASJON';
+        const dokumentasjon: IDokumentasjon = {
+            dokumentasjonsbehov: Dokumentasjonsbehov.ANNEN_DOKUMENTASJON,
+            gjelderForBarnId: [],
+            gjelderForSøker: false,
+            harSendtInn: false,
+            opplastedeVedlegg: [],
+            tittelSpråkId: tittelSpråkId,
+            beskrivelseSpråkId: beskrivelseSpråkId,
+        };
+        const { getByText, queryByText } = render(
+            <SprakProvider tekster={{}} defaultLocale={LocaleType.nb}>
+                <HttpProvider>
+                    <RoutesProvider>
+                        <LastOppVedlegg dokumentasjon={dokumentasjon} vedleggNr={1} />
+                    </RoutesProvider>
+                </HttpProvider>
+            </SprakProvider>
+        );
+
+        const tittel = getByText(tittelSpråkId);
+        expect(tittel).toBeInTheDocument();
+        const infoTekst: HTMLElement | null = queryByText(beskrivelseSpråkId);
+        expect(infoTekst).toBeNull();
+        const checkBoxTitle: HTMLElement | null = queryByText('dokumentasjon.har-sendt-inn.spm');
+        expect(checkBoxTitle).toBeNull();
+    });
+});

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg.tsx
@@ -104,12 +104,14 @@ const LastOppVedlegg: React.FC<Props> = ({ dokumentasjon, vedleggNr }) => {
                 )}
                 {dokTittel}
             </Undertittel>
-            <SpråkTekst
-                id={dokumentasjon.beskrivelseSpråkId}
-                values={{
-                    barn: formatertListeMedBarn(),
-                }}
-            />
+            {dokumentasjon.dokumentasjonsbehov !== Dokumentasjonsbehov.ANNEN_DOKUMENTASJON && (
+                <SpråkTekst
+                    id={dokumentasjon.beskrivelseSpråkId}
+                    values={{
+                        barn: formatertListeMedBarn(),
+                    }}
+                />
+            )}
             {!dokumentasjon.harSendtInn && (
                 <Filopplaster
                     oppdaterDokumentasjon={oppdaterDokumentasjon}
@@ -119,14 +121,16 @@ const LastOppVedlegg: React.FC<Props> = ({ dokumentasjon, vedleggNr }) => {
                 />
             )}
             <br />
-            <Checkbox
-                label={<SpråkTekst id={'dokumentasjon.har-sendt-inn.spm'} />}
-                aria-label={`${formatMessage({
-                    id: 'dokumentasjon.har-sendt-inn.spm',
-                })} (${dokTittel})`}
-                checked={dokumentasjon.harSendtInn}
-                onChange={settHarSendtInnTidligere}
-            />
+            {dokumentasjon.dokumentasjonsbehov !== Dokumentasjonsbehov.ANNEN_DOKUMENTASJON && (
+                <Checkbox
+                    label={<SpråkTekst id={'dokumentasjon.har-sendt-inn.spm'} />}
+                    aria-label={`${formatMessage({
+                        id: 'dokumentasjon.har-sendt-inn.spm',
+                    })} (${dokTittel})`}
+                    checked={dokumentasjon.harSendtInn}
+                    onChange={settHarSendtInnTidligere}
+                />
+            )}
         </Container>
     );
 };


### PR DESCRIPTION
rendrer ikke infotekst og har-sendt-inn-før-checkbox for ANNEN_DOKUMENTASJON

### 💰 Hva forsøker du å løse i denne PR'en
Fjerner infotekst og checkbox for ANNEN_DOKUMENTASJON

### 🔎️ Er det noe spesielt du ønsker å fremheve?
nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Før
<img width="563" alt="vedlegg annet - current" src="https://user-images.githubusercontent.com/17552002/123645811-f2469180-d826-11eb-8342-066b02cf3252.png">

Etter
<img width="610" alt="vedlegg annet - updated" src="https://user-images.githubusercontent.com/17552002/123645817-f5418200-d826-11eb-8a62-09f749db3a56.png">


