### PR TITLE
(fix) Tryggere forenklet feature-toggle middleware

### DIFF
--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -32,6 +32,9 @@ app.use(compression());
 // Parse cookies for bruk i dekoratør-fetch
 app.use(cookieParser());
 
+// Serve alle statiske filer utenom index.html direkte fra dist-mappen
+app.use(basePath, express.static(frontendMappe, { index: false }));
+
 // Middleware for unleash kill-switch
 app.use(expressToggleInterceptor);
 
@@ -42,9 +45,6 @@ app.use(`${basePath}api`, createApiForwardingFunction());
 
 // Rendrer index.html med dekoratøren
 app.get('/', indexHandler);
-
-// Serve alle statiske filer utenom index.html direkte fra dist-mappen
-app.use(basePath, express.static(frontendMappe, { index: false }));
 
 // Nais functions
 app.get(/^\/(internal\/)?(isAlive|isReady)\/?$/, (_req, res) => res.sendStatus(200));


### PR DESCRIPTION
Flytt static-handler før feature-toggle-middleware, slik at middlewaren
ikke trenger å vite hvilke filtyper som må slippes igjennom. Legg til
environment-variabel som kan force kill-switch behavior for utvikling.

### 💰 Hva forsøker du å løse i denne PR'en
Løser at css ikke kan lastes når disable kill-switchen er på.
Løser også at man måtte endre kode for å teste disabled-appen lokalt uten å toggle kill-switchen i unleash.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
Har ikke tester for backend

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  