### PR TITLE
(chore) Endre start:dev til å ha en base-path for å utvikle på utvidet

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "format-all": "prettier --write \"src/**/*.{js,jsx,ts,tsx}\"",
     "build_and_serve": "yarn build; yarn start",
-    "start:dev": "yarn clean && concurrently \"npm:dev:*\"",
-    "start:dev:ts-server": "yarn clean && concurrently \"npm:dev:webpack\" \"npm:ts:server\"",
+    "start:dev": "BASE_PATH=/familie/barnetrygd/soknad/ordinaer/ yarn clean && concurrently \"npm:dev:*\"",
+    "start:dev:ts-server": "BASE_PATH=/familie/barnetrygd/soknad/ordinaer/ yarn clean && concurrently \"npm:dev:webpack\" \"npm:ts:server\"",
     "dev:server": "tsc -p tsconfig.backend.json && NODE_ENV=development node --es-module-specifier-resolution=node build/backend/server.js",
     "ts:server": "NODE_ENV=development TS_NODE_PROJECT=tsconfig.backend.json nodemon --exec 'node' --watch src/backend -e ts --es-module-specifier-resolution=node --loader ts-node/esm src/backend/server.ts",
     "dev:webpack": "TS_NODE_PROJECT=src/webpack/tsconfig.json NODE_ENV=development webpack -c src/webpack/webpack.development.config.ts",


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Sette BASE_PATH når man kjører start:dev slik at både ordinær og utvidet kan testes lokalt uten kodeendring

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Dette krasjer litt med docker-tingene og må kanskje byttes ut med en distribuert intellij runconfiguration senere.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
Ingen kodeendring

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
