### PR TITLE
Nullstill andre forelder dersom man huker av at barnet er fosterbarn

### DIFF
--- a/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.tsx
@@ -17,6 +17,7 @@ import {
 
 import { useApp } from '../../../context/AppContext';
 import { useRoutes } from '../../../context/RoutesContext';
+import useFørsteRender from '../../../hooks/useFørsteRender';
 import useJaNeiSpmFelt from '../../../hooks/useJaNeiSpmFelt';
 import { Dokumentasjonsbehov, IDokumentasjon } from '../../../typer/dokumentasjon';
 import { ILokasjon } from '../../../typer/lokasjon';
@@ -108,6 +109,13 @@ export const useOmBarnet = (
             barnISøknad.id !== barn.id &&
             barnISøknad[barnDataKeySpørsmål.erFosterbarn].svar === ESvar.NEI
     );
+
+    useFørsteRender(() => {
+        if (barn[barnDataKeySpørsmål.erFosterbarn].svar === ESvar.JA) {
+            nullstillAndreForelderFelter();
+            skriftligAvtaleOmDeltBosted.validerOgSettFelt(null);
+        }
+    });
 
     /*---INSTITUSJON---*/
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._

Fikse en bug der andre forelder ikke blir nullstilt dersom man velger ikke fosterbarn -> fyller ut forelder -> går til oppsummering -> går tilbake -> velger at barn er fosterbarn -> trykker seg videre

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
