### PR TITLE
(fix) Bruk 'Ikke oppgitt' for svar på søknadsperiode når ukjent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       context: dockerstuff/mottak
       args:
         <<: *common-build-variables
-        git_commit: aaead17d59c33d58576a8753279a5343498a1a65
+        git_commit: 816281fd7e40c94087b5010b2bbe6bbea9e68f10
     depends_on:
       - key_generator
       - postgres
@@ -100,7 +100,7 @@ services:
   dokgen:
     container_name: dokgen
     build:
-      context: "https://${GITHUB_TOKEN}:@github.com/navikt/familie-ba-dokgen.git#7f1015f4f657330e5ba606a179621d155e4937bc"
+      context: "https://${GITHUB_TOKEN}:@github.com/navikt/familie-ba-dokgen.git#072ecc7ccc37fc7d9485f89ef95a6d3a24790c05"
     environment:
       RUNTIME_OPTS: "--write.access=true"
     ports:

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/useSendInnSkjema.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/useSendInnSkjema.tsx
@@ -1,6 +1,6 @@
 import { useIntl } from 'react-intl';
 
-import { ESvar } from '@navikt/familie-form-elements';
+import { ESvar, ISODateString } from '@navikt/familie-form-elements';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import * as bokmålSpråktekster from '../../../assets/lang/nb.json';
@@ -38,6 +38,7 @@ import { erTidligereSamboer } from '../../../utils/person';
 import { språkIndexListe } from '../../../utils/spørsmål';
 import { formaterFnr, landkodeTilSpråk } from '../../../utils/visning';
 import { OmBarnaDineSpørsmålId } from '../OmBarnaDine/spørsmål';
+import { OmBarnetSpørsmålsId } from '../OmBarnet/spørsmål';
 import {
     SamboerSpørsmålId,
     TidligereSamboerSpørsmålId,
@@ -106,6 +107,9 @@ export const useSendInnSkjema = (): { sendInnSkjema: () => Promise<boolean> } =>
         } = barn;
         const typetBarnSpørsmål = (barnSpørsmål as unknown) as SpørsmålMap;
 
+        const søkerFraTilDatoVerdi = (svar: ISODateString | AlternativtSvarForInput) =>
+            svar === AlternativtSvarForInput.UKJENT ? 'Ikke oppgitt' : svar;
+
         return {
             navn: søknadsfelt('Navn', adressebeskyttelse ? `Barn ${formaterFnr(ident)}` : navn),
             ident: søknadsfelt('Ident', ident ?? 'Ikke oppgitt'),
@@ -115,7 +119,17 @@ export const useSendInnSkjema = (): { sendInnSkjema: () => Promise<boolean> } =>
                     typetBarnSpørsmål[barnDataKeySpørsmål.borFastMedSøker].svar === ESvar.JA
             ),
             alder: søknadsfelt('Alder', alder ?? AlternativtSvarForInput.UKJENT),
-            spørsmål: spørmålISøknadsFormat(typetBarnSpørsmål),
+            spørsmål: {
+                ...spørmålISøknadsFormat(typetBarnSpørsmål),
+                [barnDataKeySpørsmål.søkerForTidsromStartdato]: søknadsfelt(
+                    språktekstFraSpørsmålId(OmBarnetSpørsmålsId.søkerForTidsromStartdato),
+                    søkerFraTilDatoVerdi(barn[barnDataKeySpørsmål.søkerForTidsromStartdato].svar)
+                ),
+                [barnDataKeySpørsmål.søkerForTidsromSluttdato]: søknadsfelt(
+                    språktekstFraSpørsmålId(OmBarnetSpørsmålsId.søkerForTidsromSluttdato),
+                    søkerFraTilDatoVerdi(barn[barnDataKeySpørsmål.søkerForTidsromSluttdato].svar)
+                ),
+            },
             utvidet: utvidet ? spørmålISøknadsFormat(utvidet) : undefined,
         };
     };


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Bruk "ikke oppgitt" istedenfor "ukjent" i PDF for søknadsperiode. Har også bumpet commit-hashes i docker-compose.yml

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
Egen branch for testing av denne funksjonen

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
![ikke oppgitt](https://user-images.githubusercontent.com/77009351/131995471-75f0f990-e346-4730-935f-46a77000c4df.png)
