### PR TITLE
(fix) Sett fra-til-felter til UKJENT istedenfor blank string

### DIFF
--- a/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.tsx
@@ -31,7 +31,7 @@ import {
     DatoMedUkjent,
     IBarnMedISøknad,
 } from '../../../typer/person';
-import { validerDatoAvgrensetFremITid } from '../../../utils/dato';
+import { validerDatoMedUkjentAvgrensetFremITid } from '../../../utils/dato';
 import { trimWhiteSpace } from '../../../utils/hjelpefunksjoner';
 import { svarForSpørsmålMedUkjent } from '../../../utils/spørsmål';
 import { barnetsNavnValue } from '../../../utils/visning';
@@ -506,7 +506,7 @@ export const useOmBarnet = (
         barn[barnDataKeySpørsmål.søkerForTidsromStartdato],
         ESvar.JA,
         søkerForTidsrom,
-        validerDatoAvgrensetFremITid
+        validerDatoMedUkjentAvgrensetFremITid
     );
     const søkerForTidsromSluttdato = useDatovelgerFeltMedJaNeiAvhengighet(
         barn[barnDataKeySpørsmål.søkerForTidsromSluttdato],
@@ -515,7 +515,7 @@ export const useOmBarnet = (
         felt => {
             // Feltet er valgfritt. Tom streng betyr ikke besvart
             if (felt.verdi === '') return ok(felt);
-            return validerDatoAvgrensetFremITid(felt);
+            return validerDatoMedUkjentAvgrensetFremITid(felt);
         }
     );
 
@@ -759,14 +759,15 @@ export const useOmBarnet = (
                               svar:
                                   søkerForTidsrom.verdi === ESvar.JA
                                       ? søkerForTidsromStartdato.verdi
-                                      : '',
+                                      : AlternativtSvarForInput.UKJENT,
                           },
                           søkerForTidsromSluttdato: {
                               ...barn.søkerForTidsromSluttdato,
                               svar:
-                                  søkerForTidsrom.verdi === ESvar.JA
+                                  søkerForTidsrom.verdi === ESvar.JA &&
+                                  søkerForTidsromSluttdato.verdi !== ''
                                       ? søkerForTidsromSluttdato.verdi
-                                      : '',
+                                      : AlternativtSvarForInput.UKJENT,
                           },
                           utvidet: {
                               søkerHarBoddMedAndreForelder: {

--- a/src/frontend/components/SøknadsSteg/OmDeg/useDatovelgerFeltMedJaNeiAvhengighet.ts
+++ b/src/frontend/components/SøknadsSteg/OmDeg/useDatovelgerFeltMedJaNeiAvhengighet.ts
@@ -3,19 +3,20 @@ import { useEffect } from 'react';
 import { ESvar, ISODateString } from '@navikt/familie-form-elements';
 import { Felt, useFelt, ValiderFelt } from '@navikt/familie-skjema';
 
+import { AlternativtSvarForInput, DatoMedUkjent } from '../../../typer/person';
 import { ISøknadSpørsmål } from '../../../typer/søknad';
 
 const useDatovelgerFeltMedJaNeiAvhengighet = (
-    søknadsfelt: ISøknadSpørsmål<ISODateString>,
+    søknadsfelt: ISøknadSpørsmål<ISODateString> | ISøknadSpørsmål<DatoMedUkjent>,
     avhengigSvarCondition: ESvar,
     avhengighet: Felt<ESvar | null>,
-    valideringsfunksjon?: ValiderFelt<ISODateString>
+    valideringsfunksjon?: ValiderFelt<ISODateString | DatoMedUkjent>
 ) => {
     const skalFeltetVises = jaNeiSpmVerdi => jaNeiSpmVerdi === avhengigSvarCondition;
 
-    const dato = useFelt<ISODateString>({
+    const dato = useFelt<ISODateString | DatoMedUkjent>({
         feltId: søknadsfelt.id,
-        verdi: søknadsfelt.svar,
+        verdi: søknadsfelt.svar === AlternativtSvarForInput.UKJENT ? '' : søknadsfelt.svar,
         valideringsfunksjon,
         skalFeltetVises: avhengigheter => {
             return avhengigheter && (avhengigheter.jaNeiSpm as Felt<ESvar | null>)

--- a/src/frontend/typer/person.ts
+++ b/src/frontend/typer/person.ts
@@ -171,7 +171,7 @@ export interface IBarnMedISøknad extends IBarn {
     [barnDataKeySpørsmål.borFastMedSøker]: ISøknadSpørsmål<ESvar | null>;
     [barnDataKeySpørsmål.skriftligAvtaleOmDeltBosted]: ISøknadSpørsmål<ESvar | null>;
     [barnDataKeySpørsmål.søkerForTidsrom]: ISøknadSpørsmål<ESvar | null>;
-    [barnDataKeySpørsmål.søkerForTidsromStartdato]: ISøknadSpørsmål<ISODateString>;
+    [barnDataKeySpørsmål.søkerForTidsromStartdato]: ISøknadSpørsmål<DatoMedUkjent>;
     [barnDataKeySpørsmål.søkerForTidsromSluttdato]: ISøknadSpørsmål<DatoMedUkjent>;
     utvidet: {
         [barnDataKeySpørsmålUtvidet.søkerHarBoddMedAndreForelder]: ISøknadSpørsmål<ESvar | null>;

--- a/src/frontend/utils/dato.tsx
+++ b/src/frontend/utils/dato.tsx
@@ -6,6 +6,7 @@ import { ISODateString } from '@navikt/familie-form-elements';
 import { feil, FeltState, ok, ValiderFelt } from '@navikt/familie-skjema';
 
 import SpråkTekst from '../components/Felleskomponenter/SpråkTekst/SpråkTekst';
+import { AlternativtSvarForInput, DatoMedUkjent } from '../typer/person';
 
 export const erDatoFormatGodkjent = (verdi: string) => {
     /*FamilieDatoVelger har allerede sin egen validering.
@@ -41,3 +42,6 @@ export const formaterDato = (isoDateString: ISODateString) =>
 export const validerDatoAvgrensetFremITid: ValiderFelt<ISODateString> = (
     felt: FeltState<ISODateString>
 ) => validerDato(felt, true);
+
+export const validerDatoMedUkjentAvgrensetFremITid: ValiderFelt<DatoMedUkjent> = felt =>
+    felt.verdi === AlternativtSvarForInput.UKJENT ? ok(felt) : validerDatoAvgrensetFremITid(felt);

--- a/src/frontend/utils/person.ts
+++ b/src/frontend/utils/person.ts
@@ -1,6 +1,7 @@
 import { OmBarnaDineSpørsmålId } from '../components/SøknadsSteg/OmBarnaDine/spørsmål';
 import { OmBarnetSpørsmålsId } from '../components/SøknadsSteg/OmBarnet/spørsmål';
 import {
+    AlternativtSvarForInput,
     barnDataKeySpørsmål,
     barnDataKeySpørsmålUtvidet,
     ESivilstand,
@@ -195,11 +196,11 @@ export const genererInitialBarnMedISøknad = (barn: IBarn): IBarnMedISøknad => 
         },
         [barnDataKeySpørsmål.søkerForTidsromStartdato]: {
             id: OmBarnetSpørsmålsId.søkerForTidsromStartdato,
-            svar: '',
+            svar: AlternativtSvarForInput.UKJENT,
         },
         [barnDataKeySpørsmål.søkerForTidsromSluttdato]: {
             id: OmBarnetSpørsmålsId.søkerForTidsromSluttdato,
-            svar: '',
+            svar: AlternativtSvarForInput.UKJENT,
         },
     };
 };


### PR DESCRIPTION
Endrer slik at søker-fra-dato og søker-til-dato blir satt til UKJENT hvis de ikke er synlige eller hvis til-dato ikke fylles ut, slik at useSendInnSkjema kan fange dem opp og sette riktig ukjent-verdi i innsending.
Kommer tilhørende PR i dokgen.