### PR TITLE
fix datovelger feilmelding visning

### DIFF
--- a/src/frontend/components/Felleskomponenter/Datovelger/Datovelger.tsx
+++ b/src/frontend/components/Felleskomponenter/Datovelger/Datovelger.tsx
@@ -125,7 +125,9 @@ const Datovelger: React.FC<DatoVelgerProps> = ({
                 locale={valgtLocale}
                 allowNavigationToDisabledMonths={true}
             />
-            {felt.feilmelding && <Feilmelding>{feilmeldingstekst}</Feilmelding>}
+            {!!(felt.feilmelding && skjema.visFeilmeldinger) && (
+                <Feilmelding>{feilmeldingstekst}</Feilmelding>
+            )}
         </span>
     ) : null;
 };


### PR DESCRIPTION
ikke vise feilmelding under datovelger hvis skjema.visFeilmeldinger er false

### 💰 Hva forsøker du å løse i denne PR'en
Feilmelding for dato vises uten at skjema.visFeilmeldinger er true

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Vil tro at dette kunne ført til bug mange andre steder i søknaden. Så trenger å gå grundig igjennom at dette ikke brekker noe andre steder, og samtidig finne ut hvorfor det ikke er oppdaget som et problem et annet sted

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
