### PR TITLE
(feat) Vis eøs-notiser på OmDeg land-dropdowns

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+    "configurations": [
+        {
+            "name": "chrome",
+            "request": "launch",
+            "type": "pwa-chrome",
+            "url": "http://localhost:3000",
+            "webRoot": "${workspaceFolder}"
+        },
+        {
+            "name": "start:dev:ts-server",
+            "request": "launch",
+            "runtimeArgs": [
+                "start:dev:ts-server",
+            ],
+            "runtimeExecutable": "yarn",
+            "type": "node"
+        },
+        {
+            "type": "node",
+            "name": "vscode-jest-tests",
+            "request": "launch",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "disableOptimisticBPs": true,
+            "cwd": "${workspaceFolder}",
+            "runtimeExecutable": "yarn",
+            "args": [
+                "test",
+                "--runInBand",
+                "--watchAll=false"
+            ]
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
         "typescript",
         "typescriptreact"
     ],
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "jest.jestCommandLine": "yarn test"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       context: dockerstuff/soknad-api
       args:
         <<: *common-build-variables
-        git_commit: 561599222c559bdb9a411d18628431a8ba99c941
+        git_commit: 09c726bd5cf037f6a51a96ddbcda76befdd9eec0
     depends_on:
       - key_generator
       - oauthmock

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg.test.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg.test.tsx
@@ -6,7 +6,7 @@ import { mockDeep } from 'jest-mock-extended';
 import { Dokumentasjonsbehov, IDokumentasjon } from '../../../typer/dokumentasjon';
 import { ESivilstand, ISøker } from '../../../typer/person';
 import { ESøknadstype } from '../../../typer/søknad';
-import { silenceConsoleErrors, spyOnUseApp, TestProvidere } from '../../../utils/testing';
+import { mockEøs, silenceConsoleErrors, spyOnUseApp, TestProvidere } from '../../../utils/testing';
 import LastOppVedlegg from './LastOppVedlegg';
 
 const hentAnnenDokumentasjon = (): IDokumentasjon => {
@@ -31,6 +31,7 @@ describe('LastOppVedlegg', () => {
     beforeEach(() => {
         silenceConsoleErrors();
         jest.resetModules();
+        mockEøs();
     });
 
     it('Viser ikke info-tekst og checkbox knapp for ANNEN_DOKUMENTASJON', () => {

--- a/src/frontend/components/SøknadsSteg/OmBarnet/OmBarnet.test.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/OmBarnet.test.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../../typer/person';
 import {
     mekkGyldigSøknad,
+    mockEøs,
     mockHistory,
     silenceConsoleErrors,
     spyOnUseApp,
@@ -123,6 +124,10 @@ const line = {
 };
 
 describe('OmBarnet', () => {
+    beforeEach(() => {
+        mockEøs();
+    });
+
     test(`Kan rendre Om Barnet og alle tekster finnes i språkfil`, () => {
         mockHistory(['/om-barnet/barn-1']);
         spyOnUseApp({

--- a/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.test.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.test.tsx
@@ -9,12 +9,13 @@ import {
     IBarnMedISøknad,
 } from '../../../typer/person';
 import { genererInitialBarnMedISøknad } from '../../../utils/barn';
-import { silenceConsoleErrors, spyOnUseApp, TestProvidere } from '../../../utils/testing';
+import { mockEøs, silenceConsoleErrors, spyOnUseApp, TestProvidere } from '../../../utils/testing';
 import { OmBarnaDineSpørsmålId } from '../OmBarnaDine/spørsmål';
 import { OmBarnetSpørsmålsId } from './spørsmål';
 import { useOmBarnet } from './useOmBarnet';
 
 describe('useOmBarnet', () => {
+    beforeEach(() => mockEøs());
     const barnFraPdl: IBarn = {
         id: 'random-id-1',
         navn: 'Barn Barnessen',

--- a/src/frontend/components/SøknadsSteg/OmDeg/OmDeg.tsx
+++ b/src/frontend/components/SøknadsSteg/OmDeg/OmDeg.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { useApp } from '../../../context/AppContext';
+import { useEøs } from '../../../context/EøsContext';
 import AlertStripe from '../../Felleskomponenter/AlertStripe/AlertStripe';
 import Datovelger from '../../Felleskomponenter/Datovelger/Datovelger';
 import { LandDropdown } from '../../Felleskomponenter/Dropdowns/LandDropdown';
@@ -20,6 +21,7 @@ const OmDeg: React.FC = () => {
     const { skjema, validerFelterOgVisFeilmelding, valideringErOk, oppdaterSøknad } = useOmdeg();
     const { søknad } = useApp();
     const { søker } = søknad;
+    const { erEøsLand } = useEøs();
     return (
         <Steg
             tittel={<SpråkTekst id={'omdeg.sidetittel'} />}
@@ -87,6 +89,9 @@ const OmDeg: React.FC = () => {
                                     />
                                 }
                             />
+                            {erEøsLand(skjema.felter.oppholdsland.verdi) && (
+                                <VedleggNotis språkTekstId={'omdeg.opphold-i-norge.eøs-info'} />
+                            )}
                             <Datovelger
                                 avgrensDatoFremITid={true}
                                 felt={skjema.felter.oppholdslandDato}
@@ -151,6 +156,9 @@ const OmDeg: React.FC = () => {
                         }
                         dynamisk
                     />
+                    {erEøsLand(skjema.felter.arbeidsland.verdi) && (
+                        <VedleggNotis språkTekstId={'omdeg.arbeid-utland.eøs-info'} />
+                    )}
 
                     <JaNeiSpm
                         skjema={skjema}
@@ -167,6 +175,9 @@ const OmDeg: React.FC = () => {
                         }
                         dynamisk
                     />
+                    {erEøsLand(skjema.felter.pensjonsland.verdi) && (
+                        <VedleggNotis språkTekstId={'omdeg.utenlandspensjon.eøs-info'} />
+                    )}
                 </KomponentGruppe>
             )}
         </Steg>

--- a/src/frontend/components/SøknadsSteg/OmDeg/Personopplysninger.test.tsx
+++ b/src/frontend/components/SøknadsSteg/OmDeg/Personopplysninger.test.tsx
@@ -6,7 +6,7 @@ import { IntlProvider } from 'react-intl';
 import { LocaleType } from '@navikt/familie-sprakvelger';
 
 import { ESivilstand, ISøker } from '../../../typer/person';
-import { silenceConsoleErrors, spyOnUseApp, TestProvidere } from '../../../utils/testing';
+import { mockEøs, silenceConsoleErrors, spyOnUseApp, TestProvidere } from '../../../utils/testing';
 import { Personopplysninger } from './Personopplysninger';
 
 const mockedSivilstand = ESivilstand.GIFT;
@@ -14,6 +14,7 @@ const mockedSivilstand = ESivilstand.GIFT;
 silenceConsoleErrors();
 
 describe('Personopplysninger', () => {
+    beforeEach(() => mockEøs());
     test('Rendrer adresse i personopplysninger', async () => {
         const søker: Partial<ISøker> = {
             adresse: {

--- a/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/FjernBarnKnapp.test.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/FjernBarnKnapp.test.tsx
@@ -4,6 +4,7 @@ import { act, render } from '@testing-library/react';
 
 import { IBarn } from '../../../../typer/person';
 import {
+    mockEøs,
     mockHistory,
     silenceConsoleErrors,
     spyOnUseApp,
@@ -12,7 +13,10 @@ import {
 import VelgBarn from '../VelgBarn';
 
 describe('FjernBarnKnapp', () => {
-    mockHistory(['/velg-barn']);
+    beforeEach(() => {
+        mockHistory(['/velg-barn']);
+        mockEøs();
+    });
 
     test(`Kan fjern-knapp dukker kun opp på manuelt registrerte barn`, () => {
         silenceConsoleErrors();

--- a/src/frontend/utils/eøs.test.ts
+++ b/src/frontend/utils/eøs.test.ts
@@ -1,6 +1,7 @@
 import { Alpha3Code } from 'i18n-iso-countries';
 
 import { OmBarnetSpørsmålsId } from '../components/SøknadsSteg/OmBarnet/spørsmål';
+import { ISøknad } from '../typer/søknad';
 import { landSvarSomKanTriggeEøs } from './eøs';
 import { mekkGyldigSøknad } from './testing';
 
@@ -8,8 +9,14 @@ describe('eøs', () => {
     describe('landSvarSomKanTriggeEøs', () => {
         it('should ', () => {
             const søknad = mekkGyldigSøknad();
-            const mockSøknad = {
+            const mockSøknad: ISøknad = {
                 ...søknad,
+                søker: {
+                    ...søknad.søker,
+                    oppholdsland: { ...søknad.søker.oppholdsland, svar: 'ALA' },
+                    arbeidsland: { ...søknad.søker.arbeidsland, svar: 'ALA' },
+                    pensjonsland: { ...søknad.søker.pensjonsland, svar: 'ALA' },
+                },
                 barnInkludertISøknaden: [
                     {
                         ...søknad.barnInkludertISøknaden[0],
@@ -36,7 +43,15 @@ describe('eøs', () => {
                 ],
             };
 
-            expect(landSvarSomKanTriggeEøs(mockSøknad)).toEqual(['BEL', 'BEL', 'BEL', 'BEL']);
+            expect(landSvarSomKanTriggeEøs(mockSøknad)).toEqual([
+                'ALA',
+                'ALA',
+                'ALA',
+                'BEL',
+                'BEL',
+                'BEL',
+                'BEL',
+            ]);
         });
     });
 });

--- a/src/frontend/utils/eøs.ts
+++ b/src/frontend/utils/eøs.ts
@@ -1,8 +1,16 @@
 import { IBarnMedISøknad } from '../typer/person';
 import { ISøknad } from '../typer/søknad';
 
-export const landSvarSomKanTriggeEøs = (søknad: ISøknad) =>
-    søknad.barnInkludertISøknaden.flatMap((barn: IBarnMedISøknad) => [
+export const landSvarSomKanTriggeEøs = (søknad: ISøknad) => {
+    const fraOmDeg = [
+        søknad.søker.oppholdsland.svar,
+        søknad.søker.arbeidsland.svar,
+        søknad.søker.pensjonsland.svar,
+    ];
+    const fraOmBarnet = søknad.barnInkludertISøknaden.flatMap((barn: IBarnMedISøknad) => [
         barn.oppholdsland.svar,
         barn.barnetrygdFraEøslandHvilketLand.svar,
     ]);
+
+    return fraOmDeg.concat(fraOmBarnet);
+};

--- a/src/frontend/utils/testing.tsx
+++ b/src/frontend/utils/testing.tsx
@@ -21,6 +21,7 @@ import {
 import * as appContext from '../context/AppContext';
 import { AppProvider } from '../context/AppContext';
 import { AppNavigationProvider } from '../context/AppNavigationContext';
+import * as eøsContext from '../context/EøsContext';
 import { EøsProvider } from '../context/EøsContext';
 import { InnloggetProvider } from '../context/InnloggetContext';
 import { LastRessurserProvider } from '../context/LastRessurserContext';
@@ -29,6 +30,7 @@ import { IKvittering } from '../typer/kvittering';
 import { AlternativtSvarForInput, barnDataKeySpørsmål } from '../typer/person';
 import { ESøknadstype, initialStateSøknad, ISøknad, Årsak } from '../typer/søknad';
 import { genererInitialBarnMedISøknad } from './barn';
+import * as eøsUtils from './eøs';
 
 export const spyOnUseApp = søknad => {
     const settSøknad = jest.fn();
@@ -74,6 +76,19 @@ export const spyOnUseApp = søknad => {
         erPåKvitteringsside,
         axiosRequestMock,
     };
+};
+
+export const mockEøs = (eøsSkruddAv = false) => {
+    // Prøvde å gjøre dette med __mocks__ uten hell, mocken ble ikke brukt av jest. Gjerne prøv igjen.
+    const landSvarSomKanTriggeEøs = jest
+        .spyOn(eøsUtils, 'landSvarSomKanTriggeEøs')
+        .mockReturnValue([]);
+    const erEøsLand = jest.fn();
+    const useEøs = jest.spyOn(eøsContext, 'useEøs').mockReturnValue({
+        erEøsLand,
+        eøsSkruddAv,
+    });
+    return { landSvarSomKanTriggeEøs, useEøs, erEøsLand };
 };
 
 export const brukUseAppMedTomSøknadForRouting = () => spyOnUseApp({ barnInkludertISøknaden: [] });


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Vise vedleggsnotis om EØS når man velger EØS-land i dropdowns på OmDeg

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Fikset litt test-greier og laget en ny testing-util `mockEøs`
Selve vedleggsnotisene byttes ut med felleskomponent i Nora sin branch

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
