### PR TITLE
(hotfix) Fix killswitches og cache-problemer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       <<: *common-token-environment
       BASE_PATH: /familie/barnetrygd/soknad/ordinaer/
       ENV: docker-compose
+      # FORCE_DISABLED: 1 # Uncomment for å utvikle disabled-appen
     volumes:
       - ./src:/var/server/src
       - secure-logs:/secure-logs

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -24,10 +24,11 @@ app.use(compression());
 // Parse cookies for bruk i dekoratør-fetch
 app.use(cookieParser());
 
+konfigurerStatic(app);
+
 // Middleware for unleash kill-switch
 app.use(expressToggleInterceptor);
 
-konfigurerStatic(app);
 konfigurerIndex(app);
 konfigurerNais(app);
 konfigurerApi(app);

--- a/src/webpack/webpack.production.config.ts
+++ b/src/webpack/webpack.production.config.ts
@@ -19,7 +19,7 @@ const prodConfig: webpack.Configuration = mergeWithRules({
     devtool: 'source-map',
     plugins: [
         new MiniCssExtractPlugin({
-            filename: '[name].css',
+            filename: '[name].[contenthash].css',
         }),
         new CssMinimizerWebpackPlugin(),
         process.env.SENTRY_AUTH_TOKEN


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Gjør det mulig å bruke killswtichene igjen, fikse caching av css mellom deploys
Ved å kjøre static-handleren før feature-toggle handleren lar vi browsere laste ned js/css-filer uavhengig av killswitch status, som gjør at vi ikke cacher index.html som svar på js/css-filer som hang igjen når vi skrudde switchene av ighen

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
Anser unødvendig mye arbeid

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  