### PR TITLE
Fix/dokumentasjonsbehov skilt utvidet

### DIFF
--- a/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.tsx
@@ -24,7 +24,7 @@ import {
     IUtenlandsperiode,
 } from '../../../typer/person';
 import { IOmBarnetUtvidetFeltTyper } from '../../../typer/skjema';
-import { IBarnMedISøknad } from '../../../typer/søknad';
+import { ESøknadstype, IBarnMedISøknad } from '../../../typer/søknad';
 import { regexNorskEllerUtenlandskPostnummer } from '../../../utils/adresse';
 import { barnetsNavnValue } from '../../../utils/barn';
 import { dagensDato } from '../../../utils/dato';
@@ -756,7 +756,8 @@ export const useOmBarnet = (
                         return genererOppdatertDokumentasjon(
                             dok,
                             søkerForTidsrom.verdi === ESvar.JA &&
-                                søknad.søker.sivilstand.type === ESivilstand.SKILT,
+                                søknad.søker.sivilstand.type === ESivilstand.SKILT &&
+                                søknad.søknadstype === ESøknadstype.UTVIDET,
                             barn.id
                         );
                     default:

--- a/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.tsx
@@ -20,6 +20,7 @@ import { Dokumentasjonsbehov, IDokumentasjon } from '../../../typer/dokumentasjo
 import {
     barnDataKeySpørsmål,
     barnDataKeySpørsmålUtvidet,
+    ESivilstand,
     IUtenlandsperiode,
 } from '../../../typer/person';
 import { IOmBarnetUtvidetFeltTyper } from '../../../typer/skjema';
@@ -749,6 +750,13 @@ export const useOmBarnet = (
                             barn[barnDataKeySpørsmål.andreForelderErDød].svar === ESvar.NEI &&
                                 søkerHarBoddMedAndreForelder.verdi === ESvar.JA &&
                                 borMedAndreForelderCheckbox.verdi === ESvar.NEI,
+                            barn.id
+                        );
+                    case Dokumentasjonsbehov.SEPARERT_SKILT_ENKE:
+                        return genererOppdatertDokumentasjon(
+                            dok,
+                            søkerForTidsrom.verdi === ESvar.JA &&
+                                søknad.søker.sivilstand.type === ESivilstand.SKILT,
                             barn.id
                         );
                     default:


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Dukker opp vedleggsseksjon for separert/skilt/enke for søker om man er skilt og søker om utvidet. Tidligere dukket det kun opp notis på spesielt tidsrom at man måtte legge ved dette, men seksjonen dukket ikke opp på vedleggssiden. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
Før dukket det ikke opp:


Nå dukker det opp: 
![image](https://user-images.githubusercontent.com/11887409/143196787-ae10c3dc-1567-49d3-9248-6eea415b74b9.png)
