### PR TITLE
Fix/omsorgsperson synlighet

### DIFF
--- a/src/frontend/assets/lang/en.json
+++ b/src/frontend/assets/lang/en.json
@@ -83,6 +83,8 @@
   "eøs-om-barn.barnidnummer.spm": "What is the ID-number of {barn} in {land}?",
   "eøs-om-barn.borbarnmedandreforelder.feilmelding": "You must state whether {barn} is staying with their other parent in order to be able to proceed",
   "eøs-om-barn.borbarnmedandreforelder.spm": "Is {barn} staying with their other parent?",
+  "eøs-om-barn.bormedannenomsorgsperson.feilmelding": "You must state whether {barn} is staying with another caregiver in order to be able to proceed",
+  "eøs-om-barn.bormedannenomsorgsperson.spm": "Is {barn} staying with another caregiver?",
   "eøs-om-barn.bosituasjon.samme-info": "You have stated that {barn} has the same living situation as {barn}.",
   "eøs-om-barn.dinrelasjon.feilmelding": "You must state what your relation to {barn} is in order to be able to proceed",
   "eøs-om-barn.dinrelasjon.spm": "What is your relation to {barn}?",

--- a/src/frontend/assets/lang/nb.json
+++ b/src/frontend/assets/lang/nb.json
@@ -83,6 +83,8 @@
   "eøs-om-barn.barnidnummer.spm": "Hva er id-nummeret til {barn} i {land}?",
   "eøs-om-barn.borbarnmedandreforelder.feilmelding": "Du må oppgi om {barn} bor sammen med den andre forelderen for å gå videre",
   "eøs-om-barn.borbarnmedandreforelder.spm": "Bor {barn} sammen med den andre forelderen?",
+  "eøs-om-barn.bormedannenomsorgsperson.feilmelding": "Du må oppgi om {barn} bor sammen med en annen omsorgsperson for å gå videre",
+  "eøs-om-barn.bormedannenomsorgsperson.spm": "Bor {barn} sammen med en annen omsorgsperson?",
   "eøs-om-barn.bosituasjon.samme-info": "Du har opplyst at {barn} har samme bosituasjon som {barn}.",
   "eøs-om-barn.dinrelasjon.feilmelding": "Du må oppgi hvilken relasjon du har til {barn} for å gå videre",
   "eøs-om-barn.dinrelasjon.spm": "Hvilken relasjon har du til {barn}?",

--- a/src/frontend/assets/lang/nn.json
+++ b/src/frontend/assets/lang/nn.json
@@ -83,6 +83,8 @@
   "eøs-om-barn.barnidnummer.spm": "Kva er id-nummeret til {barn} i {land}?",
   "eøs-om-barn.borbarnmedandreforelder.feilmelding": "Du må oppgje om {barn} bur saman med den andre forelderen for å gå vidare",
   "eøs-om-barn.borbarnmedandreforelder.spm": "Bur {barn} saman med den andre forelderen?",
+  "eøs-om-barn.bormedannenomsorgsperson.feilmelding": "Du må oppgje om {barn} bur saman med ein anna omsorgsperson for å gå vidare",
+  "eøs-om-barn.bormedannenomsorgsperson.spm": "Bur {barn} saman med ein anna omsorgsperson?",
   "eøs-om-barn.bosituasjon.samme-info": "Du har opplyst at {barn} har same busituasjon som {barn}.",
   "eøs-om-barn.dinrelasjon.feilmelding": "Du må oppgje kva relasjon du har til {barn} for å gå vidare",
   "eøs-om-barn.dinrelasjon.spm": "Kva relasjon har du til {barn}?",

--- a/src/frontend/components/Felleskomponenter/UtbetalingerModal/språkUtils.ts
+++ b/src/frontend/components/Felleskomponenter/UtbetalingerModal/språkUtils.ts
@@ -1,4 +1,8 @@
 import { EøsBarnSpørsmålId, eøsBarnSpørsmålSpråkId } from '../../SøknadsSteg/EøsSteg/Barn/spørsmål';
+import {
+    EøsSøkerSpørsmålId,
+    eøsSøkerSpørsmålSpråkId,
+} from '../../SøknadsSteg/EøsSteg/Søker/spørsmål';
 
 export const mottarEllerMottattUtbetalingSpråkId = (
     gjelderAndreForelder: boolean,
@@ -9,7 +13,7 @@ export const mottarEllerMottattUtbetalingSpråkId = (
             ? eøsBarnSpørsmålSpråkId[EøsBarnSpørsmålId.andreForelderAndreUtbetalingerEnke]
             : eøsBarnSpørsmålSpråkId[EøsBarnSpørsmålId.andreForelderAndreUtbetalinger];
     } else {
-        return 'eøs-om-deg.utbetalinger.spm'; // TODO: legg inn i eøsSpråkId[SpørsmålId..] for søker
+        return eøsSøkerSpørsmålSpråkId[EøsSøkerSpørsmålId.utbetalinger];
     }
 };
 

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Barn/EøsForBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Barn/EøsForBarn.tsx
@@ -107,6 +107,12 @@ const EøsForBarn: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
                     spørsmålTekstId={eøsBarnSpørsmålSpråkId[EøsBarnSpørsmålId.borMedAndreForelder]}
                     språkValues={{ barn: barnetsNavnValue(barn, intl) }}
                 />
+                <JaNeiSpm
+                    skjema={skjema}
+                    felt={skjema.felter.borMedOmsorgsperson}
+                    spørsmålTekstId={eøsBarnSpørsmålSpråkId[EøsBarnSpørsmålId.borMedOmsorgsperson]}
+                    språkValues={{ barn: barnetsNavnValue(barn, intl) }}
+                />
                 {skjema.felter.omsorgspersonNavn.erSynlig && (
                     <SkjemaFieldset
                         tittelId={'eøs-om-barn.annenomsorgsperson.gjenlevende'}

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Barn/EøsForBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Barn/EøsForBarn.tsx
@@ -107,20 +107,18 @@ const EøsForBarn: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
                     spørsmålTekstId={eøsBarnSpørsmålSpråkId[EøsBarnSpørsmålId.borMedAndreForelder]}
                     språkValues={{ barn: barnetsNavnValue(barn, intl) }}
                 />
-                {skjema.felter.borMedAndreForelder.verdi === ESvar.NEI && (
+                {skjema.felter.omsorgspersonNavn.erSynlig && (
                     <SkjemaFieldset
                         tittelId={'eøs-om-barn.annenomsorgsperson.gjenlevende'}
                         språkValues={{ barn: barnetsNavnValue(barn, intl) }}
                     >
-                        {skjema.felter.omsorgspersonNavn.erSynlig && (
-                            <SkjemaFeltInput
-                                felt={skjema.felter.omsorgspersonNavn}
-                                visFeilmeldinger={skjema.visFeilmeldinger}
-                                labelSpråkTekstId={
-                                    eøsBarnSpørsmålSpråkId[EøsBarnSpørsmålId.omsorgspersonNavn]
-                                }
-                            />
-                        )}
+                        <SkjemaFeltInput
+                            felt={skjema.felter.omsorgspersonNavn}
+                            visFeilmeldinger={skjema.visFeilmeldinger}
+                            labelSpråkTekstId={
+                                eøsBarnSpørsmålSpråkId[EøsBarnSpørsmålId.omsorgspersonNavn]
+                            }
+                        />
                         {skjema.felter.omsorgspersonSlektsforhold.erSynlig && (
                             <SlektsforholdDropdown
                                 felt={skjema.felter.omsorgspersonSlektsforhold}

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Barn/spørsmål.ts
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Barn/spørsmål.ts
@@ -10,6 +10,7 @@ export enum EøsBarnSpørsmålId {
     søkersSlektsforhold = 'søkers-slektsforhold',
     søkersSlektsforholdSpesifisering = 'søkers-slektsforhold-spesifisering',
     borMedAndreForelder = 'bor-med-andre-forelder',
+    borMedOmsorgsperson = 'bor-med-omsorgsperson',
     omsorgspersonNavn = 'omsorgsperson-navn',
     omsorgspersonSlektsforhold = 'omsorgsperson-slektsforhold',
     omsorgspersonSlektsforholdSpesifisering = 'omsorgsperson-slektsforhold-spesifisering',
@@ -50,4 +51,5 @@ export const eøsBarnSpørsmålSpråkId: Record<EøsBarnSpørsmålId, string> = 
         'eøs-om-barn.andreforelderoppholdssted.sjekkboks',
     [EøsBarnSpørsmålId.barnetsAdresse]: 'eøs.hvorborbarn.spm',
     [EøsBarnSpørsmålId.barnetsAdresseVetIkke]: 'eøs.kjennerikkeadresse.sjekkboks',
+    [EøsBarnSpørsmålId.borMedOmsorgsperson]: 'todo: bor barn med omsorgsperson',
 };

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Barn/spørsmål.ts
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Barn/spørsmål.ts
@@ -51,5 +51,5 @@ export const eøsBarnSpørsmålSpråkId: Record<EøsBarnSpørsmålId, string> = 
         'eøs-om-barn.andreforelderoppholdssted.sjekkboks',
     [EøsBarnSpørsmålId.barnetsAdresse]: 'eøs.hvorborbarn.spm',
     [EøsBarnSpørsmålId.barnetsAdresseVetIkke]: 'eøs.kjennerikkeadresse.sjekkboks',
-    [EøsBarnSpørsmålId.borMedOmsorgsperson]: 'todo: bor barn med omsorgsperson',
+    [EøsBarnSpørsmålId.borMedOmsorgsperson]: 'eøs-om-barn.bormedannenomsorgsperson.spm',
 };

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Barn/useEøsForBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Barn/useEøsForBarn.tsx
@@ -121,7 +121,7 @@ export const useEøsForBarn = (
 
     const borMedOmsorgsperson = useJaNeiSpmFelt({
         søknadsfelt: gjeldendeBarn[barnDataKeySpørsmål.borMedOmsorgsperson],
-        feilmeldingSpråkId: 'todo: oppgi om barn bor med omsorgsperson',
+        feilmeldingSpråkId: 'eøs-om-barn.bormedannenomsorgsperson.feilmelding',
         feilmeldingSpråkVerdier: { barn: barnetsNavnValue(gjeldendeBarn, intl) },
         nullstillVedAvhengighetEndring: true,
         skalSkjules: !(

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Barn/useEøsForBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Barn/useEøsForBarn.tsx
@@ -79,6 +79,7 @@ export const useEøsForBarn = (
                 ? ok(felt)
                 : feil(felt, <SpråkTekst id={'felles.velgslektsforhold.feilmelding'} />);
         },
+        skalFeltetVises: () => gjeldendeBarn.erFosterbarn.svar === ESvar.NEI,
     });
     const søkersSlektsforholdSpesifisering = useInputFelt({
         søknadsfelt: gjeldendeBarn[barnDataKeySpørsmål.søkersSlektsforholdSpesifisering],
@@ -110,17 +111,19 @@ export const useEøsForBarn = (
         nullstillVedAvhengighetEndring: true,
         skalSkjules:
             gjeldendeBarn.erFosterbarn.svar === ESvar.JA ||
-            !(
-                gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
-                gjeldendeBarn.andreForelderErDød.svar === ESvar.NEI &&
-                gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.NEI
-            ),
+            gjeldendeBarn.andreForelderErDød.svar === ESvar.JA ||
+            gjeldendeBarn.borFastMedSøker.svar === ESvar.JA ||
+            gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.JA,
     });
 
     const omsorgspersonNavn = useInputFelt({
         søknadsfelt: omsorgsperson && omsorgsperson.navn,
         feilmeldingSpråkId: 'eøs-om-barn.annenomsorgspersonnavn.feilmelding',
-        skalVises: borMedAndreForelder.verdi === ESvar.NEI,
+        skalVises:
+            borMedAndreForelder.verdi === ESvar.NEI ||
+            (gjeldendeBarn.andreForelderErDød.svar === ESvar.JA &&
+                gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
+                gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.NEI),
         customValidering: (felt: FeltState<string>) => {
             const verdi = trimWhiteSpace(felt.verdi);
             return verdi.match(/^[A-Za-zæøåÆØÅ\s\-\\,\\.]{1,60}$/)
@@ -146,7 +149,12 @@ export const useEøsForBarn = (
                 ? ok(felt)
                 : feil(felt, <SpråkTekst id={'felles.velgslektsforhold.feilmelding'} />);
         },
-        skalFeltetVises: avhengigheter => avhengigheter.borMedAndreForelder.verdi === ESvar.NEI,
+        skalFeltetVises: avhengigheter =>
+            gjeldendeBarn.erFosterbarn.svar === ESvar.NEI &&
+            (avhengigheter.borMedAndreForelder.verdi === ESvar.NEI ||
+                (gjeldendeBarn.andreForelderErDød.svar === ESvar.JA &&
+                    gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
+                    gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.NEI)),
         avhengigheter: { borMedAndreForelder },
     });
 
@@ -177,7 +185,11 @@ export const useEøsForBarn = (
     const omsorgspersonIdNummerVetIkke = useFelt<ESvar>({
         verdi: formaterVerdiForCheckbox(omsorgsperson?.idNummer.svar),
         feltId: EøsBarnSpørsmålId.omsorgspersonIdNummerVetIkke,
-        skalFeltetVises: avhengigheter => avhengigheter.borMedAndreForelder.verdi === ESvar.NEI,
+        skalFeltetVises: avhengigheter =>
+            avhengigheter.borMedAndreForelder.verdi === ESvar.NEI ||
+            (gjeldendeBarn.andreForelderErDød.svar === ESvar.JA &&
+                gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
+                gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.NEI),
         avhengigheter: { borMedAndreForelder },
     });
 
@@ -185,7 +197,11 @@ export const useEøsForBarn = (
         søknadsfelt: omsorgsperson && omsorgsperson.idNummer,
         avhengighet: omsorgspersonIdNummerVetIkke,
         feilmeldingSpråkId: 'eøs-om-barn.annenomsorgspersonidnummer.feilmelding',
-        skalVises: borMedAndreForelder.verdi === ESvar.NEI,
+        skalVises:
+            borMedAndreForelder.verdi === ESvar.NEI ||
+            (gjeldendeBarn.andreForelderErDød.svar === ESvar.JA &&
+                gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
+                gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.NEI),
         customValidering: (felt: FeltState<string>) => {
             const verdi = trimWhiteSpace(felt.verdi);
             return verdi.match(/^[0-9A-Za-zæøåÆØÅ\s\-.\\/]{4,20}$/)
@@ -205,7 +221,11 @@ export const useEøsForBarn = (
     const omsorgspersonAdresse = useInputFelt({
         søknadsfelt: omsorgsperson && omsorgsperson.adresse,
         feilmeldingSpråkId: 'eøs-om-barn.annenomsorgspersonoppholdssted.feilmelding',
-        skalVises: borMedAndreForelder.verdi === ESvar.NEI,
+        skalVises:
+            borMedAndreForelder.verdi === ESvar.NEI ||
+            (gjeldendeBarn.andreForelderErDød.svar === ESvar.JA &&
+                gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
+                gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.NEI),
         customValidering: valideringAdresse,
         nullstillVedAvhengighetEndring: true,
     });

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Barn/useEøsForBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Barn/useEøsForBarn.tsx
@@ -116,14 +116,22 @@ export const useEøsForBarn = (
             gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.JA,
     });
 
+    console.log(
+        borMedAndreForelder.verdi === ESvar.NEI ||
+            (gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
+                gjeldendeBarn.andreForelderErDød.svar === ESvar.JA &&
+                gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.NEI)
+    );
+
     const omsorgspersonNavn = useInputFelt({
         søknadsfelt: omsorgsperson && omsorgsperson.navn,
         feilmeldingSpråkId: 'eøs-om-barn.annenomsorgspersonnavn.feilmelding',
         skalVises:
             borMedAndreForelder.verdi === ESvar.NEI ||
-            (gjeldendeBarn.andreForelderErDød.svar === ESvar.JA &&
-                gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
-                gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.NEI),
+            (gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
+                ((gjeldendeBarn.andreForelderErDød.svar === ESvar.JA &&
+                    gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.NEI) ||
+                    gjeldendeBarn.erFosterbarn.svar === ESvar.JA)),
         customValidering: (felt: FeltState<string>) => {
             const verdi = trimWhiteSpace(felt.verdi);
             return verdi.match(/^[A-Za-zæøåÆØÅ\s\-\\,\\.]{1,60}$/)
@@ -187,9 +195,10 @@ export const useEøsForBarn = (
         feltId: EøsBarnSpørsmålId.omsorgspersonIdNummerVetIkke,
         skalFeltetVises: avhengigheter =>
             avhengigheter.borMedAndreForelder.verdi === ESvar.NEI ||
-            (gjeldendeBarn.andreForelderErDød.svar === ESvar.JA &&
-                gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
-                gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.NEI),
+            (gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
+                ((gjeldendeBarn.andreForelderErDød.svar === ESvar.JA &&
+                    gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.NEI) ||
+                    gjeldendeBarn.erFosterbarn.svar === ESvar.JA)),
         avhengigheter: { borMedAndreForelder },
     });
 
@@ -199,9 +208,10 @@ export const useEøsForBarn = (
         feilmeldingSpråkId: 'eøs-om-barn.annenomsorgspersonidnummer.feilmelding',
         skalVises:
             borMedAndreForelder.verdi === ESvar.NEI ||
-            (gjeldendeBarn.andreForelderErDød.svar === ESvar.JA &&
-                gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
-                gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.NEI),
+            (gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
+                ((gjeldendeBarn.andreForelderErDød.svar === ESvar.JA &&
+                    gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.NEI) ||
+                    gjeldendeBarn.erFosterbarn.svar === ESvar.JA)),
         customValidering: (felt: FeltState<string>) => {
             const verdi = trimWhiteSpace(felt.verdi);
             return verdi.match(/^[0-9A-Za-zæøåÆØÅ\s\-.\\/]{4,20}$/)
@@ -223,9 +233,10 @@ export const useEøsForBarn = (
         feilmeldingSpråkId: 'eøs-om-barn.annenomsorgspersonoppholdssted.feilmelding',
         skalVises:
             borMedAndreForelder.verdi === ESvar.NEI ||
-            (gjeldendeBarn.andreForelderErDød.svar === ESvar.JA &&
-                gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
-                gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.NEI),
+            (gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
+                ((gjeldendeBarn.andreForelderErDød.svar === ESvar.JA &&
+                    gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.NEI) ||
+                    gjeldendeBarn.erFosterbarn.svar === ESvar.JA)),
         customValidering: valideringAdresse,
         nullstillVedAvhengighetEndring: true,
     });

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Barn/useEøsForBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Barn/useEøsForBarn.tsx
@@ -112,26 +112,20 @@ export const useEøsForBarn = (
         skalSkjules:
             gjeldendeBarn.erFosterbarn.svar === ESvar.JA ||
             gjeldendeBarn.andreForelderErDød.svar === ESvar.JA ||
-            gjeldendeBarn.borFastMedSøker.svar === ESvar.JA ||
             gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.JA,
     });
 
-    console.log(
-        borMedAndreForelder.verdi === ESvar.NEI ||
-            (gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
-                gjeldendeBarn.andreForelderErDød.svar === ESvar.JA &&
-                gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.NEI)
-    );
+    const skalViseOmsorgsperson = (borMedAndreForelderFelt: Felt<ESvar | null>) =>
+        borMedAndreForelderFelt.verdi === ESvar.NEI ||
+        (gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
+            gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.NEI &&
+            (gjeldendeBarn.andreForelderErDød.svar === ESvar.JA ||
+                gjeldendeBarn.erFosterbarn.svar === ESvar.JA));
 
     const omsorgspersonNavn = useInputFelt({
         søknadsfelt: omsorgsperson && omsorgsperson.navn,
         feilmeldingSpråkId: 'eøs-om-barn.annenomsorgspersonnavn.feilmelding',
-        skalVises:
-            borMedAndreForelder.verdi === ESvar.NEI ||
-            (gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
-                ((gjeldendeBarn.andreForelderErDød.svar === ESvar.JA &&
-                    gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.NEI) ||
-                    gjeldendeBarn.erFosterbarn.svar === ESvar.JA)),
+        skalVises: skalViseOmsorgsperson(borMedAndreForelder),
         customValidering: (felt: FeltState<string>) => {
             const verdi = trimWhiteSpace(felt.verdi);
             return verdi.match(/^[A-Za-zæøåÆØÅ\s\-\\,\\.]{1,60}$/)
@@ -159,10 +153,7 @@ export const useEøsForBarn = (
         },
         skalFeltetVises: avhengigheter =>
             gjeldendeBarn.erFosterbarn.svar === ESvar.NEI &&
-            (avhengigheter.borMedAndreForelder.verdi === ESvar.NEI ||
-                (gjeldendeBarn.andreForelderErDød.svar === ESvar.JA &&
-                    gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
-                    gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.NEI)),
+            skalViseOmsorgsperson(avhengigheter.borMedAndreForelder),
         avhengigheter: { borMedAndreForelder },
     });
 
@@ -193,12 +184,7 @@ export const useEøsForBarn = (
     const omsorgspersonIdNummerVetIkke = useFelt<ESvar>({
         verdi: formaterVerdiForCheckbox(omsorgsperson?.idNummer.svar),
         feltId: EøsBarnSpørsmålId.omsorgspersonIdNummerVetIkke,
-        skalFeltetVises: avhengigheter =>
-            avhengigheter.borMedAndreForelder.verdi === ESvar.NEI ||
-            (gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
-                ((gjeldendeBarn.andreForelderErDød.svar === ESvar.JA &&
-                    gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.NEI) ||
-                    gjeldendeBarn.erFosterbarn.svar === ESvar.JA)),
+        skalFeltetVises: avhengigheter => skalViseOmsorgsperson(avhengigheter.borMedAndreForelder),
         avhengigheter: { borMedAndreForelder },
     });
 
@@ -206,12 +192,7 @@ export const useEøsForBarn = (
         søknadsfelt: omsorgsperson && omsorgsperson.idNummer,
         avhengighet: omsorgspersonIdNummerVetIkke,
         feilmeldingSpråkId: 'eøs-om-barn.annenomsorgspersonidnummer.feilmelding',
-        skalVises:
-            borMedAndreForelder.verdi === ESvar.NEI ||
-            (gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
-                ((gjeldendeBarn.andreForelderErDød.svar === ESvar.JA &&
-                    gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.NEI) ||
-                    gjeldendeBarn.erFosterbarn.svar === ESvar.JA)),
+        skalVises: skalViseOmsorgsperson(borMedAndreForelder),
         customValidering: (felt: FeltState<string>) => {
             const verdi = trimWhiteSpace(felt.verdi);
             return verdi.match(/^[0-9A-Za-zæøåÆØÅ\s\-.\\/]{4,20}$/)
@@ -231,12 +212,7 @@ export const useEøsForBarn = (
     const omsorgspersonAdresse = useInputFelt({
         søknadsfelt: omsorgsperson && omsorgsperson.adresse,
         feilmeldingSpråkId: 'eøs-om-barn.annenomsorgspersonoppholdssted.feilmelding',
-        skalVises:
-            borMedAndreForelder.verdi === ESvar.NEI ||
-            (gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
-                ((gjeldendeBarn.andreForelderErDød.svar === ESvar.JA &&
-                    gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.NEI) ||
-                    gjeldendeBarn.erFosterbarn.svar === ESvar.JA)),
+        skalVises: skalViseOmsorgsperson(borMedAndreForelder),
         customValidering: valideringAdresse,
         nullstillVedAvhengighetEndring: true,
     });

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Barn/useEøsForBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Barn/useEøsForBarn.tsx
@@ -115,12 +115,30 @@ export const useEøsForBarn = (
             gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.JA,
     });
 
-    const skalViseOmsorgsperson = (borMedAndreForelderFelt: Felt<ESvar | null>) =>
-        borMedAndreForelderFelt.verdi === ESvar.NEI ||
-        (gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
+    const borMedOmsorgsperson = useJaNeiSpmFelt({
+        søknadsfelt: gjeldendeBarn[barnDataKeySpørsmål.borMedOmsorgsperson],
+        feilmeldingSpråkId: 'todo: oppgi om barn bor med omsorgsperson',
+        feilmeldingSpråkVerdier: { barn: barnetsNavnValue(gjeldendeBarn, intl) },
+        nullstillVedAvhengighetEndring: true,
+        skalSkjules: !(
+            gjeldendeBarn.borFastMedSøker.svar === ESvar.JA &&
+            borMedAndreForelder.verdi === ESvar.NEI
+        ),
+    });
+
+    const skalViseOmsorgsperson = (borMedAndreForelderFelt: Felt<ESvar | null>) => {
+        const andreSituasjonerSomUtløserOmsorgsperson =
+            gjeldendeBarn.borFastMedSøker.svar === ESvar.NEI &&
             gjeldendeBarn.oppholderSegIInstitusjon.svar === ESvar.NEI &&
             (gjeldendeBarn.andreForelderErDød.svar === ESvar.JA ||
-                gjeldendeBarn.erFosterbarn.svar === ESvar.JA));
+                gjeldendeBarn.erFosterbarn.svar === ESvar.JA);
+
+        return (
+            (borMedAndreForelderFelt.verdi === ESvar.NEI &&
+                (!borMedOmsorgsperson.erSynlig || borMedOmsorgsperson.verdi === ESvar.JA)) ||
+            andreSituasjonerSomUtløserOmsorgsperson
+        );
+    };
 
     const omsorgspersonNavn = useInputFelt({
         søknadsfelt: omsorgsperson && omsorgsperson.navn,
@@ -140,7 +158,7 @@ export const useEøsForBarn = (
                       />
                   );
         },
-        nullstillVedAvhengighetEndring: true,
+        nullstillVedAvhengighetEndring: false,
     });
 
     const omsorgspersonSlektsforhold = useFelt<Slektsforhold | ''>({
@@ -207,6 +225,7 @@ export const useEøsForBarn = (
                       />
                   );
         },
+        nullstillVedAvhengighetEndring: false,
     });
 
     const omsorgspersonAdresse = useInputFelt({
@@ -214,7 +233,7 @@ export const useEøsForBarn = (
         feilmeldingSpråkId: 'eøs-om-barn.annenomsorgspersonoppholdssted.feilmelding',
         skalVises: skalViseOmsorgsperson(borMedAndreForelder),
         customValidering: valideringAdresse,
-        nullstillVedAvhengighetEndring: true,
+        nullstillVedAvhengighetEndring: false,
     });
 
     /*--- BARNETS ADRESSE ---*/
@@ -433,6 +452,10 @@ export const useEøsForBarn = (
                 ...barn.borMedAndreForelder,
                 svar: borMedAndreForelder.verdi,
             },
+            borMedOmsorgsperson: {
+                ...barn.borMedOmsorgsperson,
+                svar: borMedOmsorgsperson.verdi,
+            },
             adresse: {
                 ...barn.adresse,
                 svar: trimWhiteSpace(
@@ -505,6 +528,7 @@ export const useEøsForBarn = (
             omsorgspersonAdresse,
             barnetsAdresse,
             barnetsAdresseVetIkke,
+            borMedOmsorgsperson,
         },
         skjemanavn: 'eøsForBarn',
     });

--- a/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.tsx
@@ -42,6 +42,7 @@ import {
     filtrerteRelevanteIdNummerForBarn,
     genererInitiellAndreForelder,
     nullstilteEøsFelterForBarn,
+    skalViseOmsorgspersonHof,
 } from '../../../utils/barn';
 import { dagensDato } from '../../../utils/dato';
 import { trimWhiteSpace } from '../../../utils/hjelpefunksjoner';
@@ -838,8 +839,17 @@ export const useOmBarnet = (
                 : [];
         const utenlandsperioder = registrerteUtenlandsperioder.verdi;
 
-        const borMedAndreForelder =
-            borFastMedSøker.verdi === ESvar.JA ? null : barn.borMedAndreForelder.svar;
+        const borMedOmsorgsperson =
+            borFastMedSøker.verdi === ESvar.NEI ? null : barn.borMedOmsorgsperson.svar;
+
+        const skalViseOmsorgsperson = skalViseOmsorgspersonHof(
+            barn.borMedAndreForelder.svar,
+            borMedOmsorgsperson,
+            borFastMedSøker.verdi,
+            barn.oppholderSegIInstitusjon.svar,
+            barn.andreForelderErDød.svar,
+            barn.erFosterbarn.svar
+        );
 
         return {
             ...barn,
@@ -913,16 +923,17 @@ export const useOmBarnet = (
                 ...barn.borFastMedSøker,
                 svar: borFastMedSøker.verdi,
             },
-            borMedAndreForelder: {
-                ...barn.borMedAndreForelder,
-                svar: borMedAndreForelder,
+            borMedOmsorgsperson: {
+                ...barn.borMedOmsorgsperson,
+                svar: borFastMedSøker.verdi === ESvar.NEI ? null : barn.borMedOmsorgsperson.svar,
             },
-            omsorgsperson: borFastMedSøker.verdi === ESvar.JA ? null : barn.omsorgsperson,
+            omsorgsperson: skalViseOmsorgsperson() ? barn.omsorgsperson : null,
             adresse: {
                 ...barn.adresse,
                 svar:
                     barn.erFosterbarn.svar === ESvar.JA ||
-                    (borMedAndreForelder && kanIkkeGiOpplysningerOmAndreForelder())
+                    (barn.borMedAndreForelder.svar === ESvar.JA &&
+                        kanIkkeGiOpplysningerOmAndreForelder())
                         ? barn.adresse.svar
                         : '',
             },

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsBarnOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsBarnOppsummering.tsx
@@ -71,6 +71,12 @@ const EøsBarnOppsummering: React.FC<Props> = ({ settFeilAnchors, nummer, barn }
                         søknadsvar={barn.borMedAndreForelder.svar}
                     />
                 )}
+                {barn.borMedOmsorgsperson.svar && (
+                    <OppsummeringFelt
+                        tittel={tittelSpm(barn.borMedOmsorgsperson.id)}
+                        søknadsvar={barn.borMedOmsorgsperson.svar}
+                    />
+                )}
                 {barn.omsorgsperson && (
                     <KomponentGruppe>
                         <OppsummeringFelt

--- a/src/frontend/hooks/useInputFeltMedUkjent.tsx
+++ b/src/frontend/hooks/useInputFeltMedUkjent.tsx
@@ -21,6 +21,7 @@ const useInputFeltMedUkjent = ({
     skalVises = true,
     customValidering = undefined,
     språkVerdier = {},
+    nullstillVedAvhengighetEndring = true,
 }: {
     søknadsfelt: ISøknadSpørsmål<DatoMedUkjent> | { id: IdNummerKey; svar: string } | null;
     avhengighet: Felt<ESvar>;
@@ -29,6 +30,7 @@ const useInputFeltMedUkjent = ({
     skalVises?: boolean;
     customValidering?: ((felt: FeltState<string>) => FeltState<string>) | undefined;
     språkVerdier?: Record<string, ReactNode>;
+    nullstillVedAvhengighetEndring?: boolean;
 }) => {
     const inputFelt = useFelt<string>({
         feltId: søknadsfelt ? søknadsfelt.id : guid(),
@@ -59,6 +61,7 @@ const useInputFeltMedUkjent = ({
         },
         avhengigheter: { vetIkkeCheckbox: avhengighet, skalVises },
         skalFeltetVises: avhengigheter => avhengigheter && avhengigheter.skalVises,
+        nullstillVedAvhengighetEndring,
     });
     useEffect(() => {
         if (avhengighet.verdi === ESvar.JA) {

--- a/src/frontend/typer/barn.ts
+++ b/src/frontend/typer/barn.ts
@@ -60,6 +60,7 @@ export enum barnDataKeySpørsmål {
     søkersSlektsforhold = 'søkersSlektsforhold',
     søkersSlektsforholdSpesifisering = 'søkersSlektsforholdSpesifisering',
     borMedAndreForelder = 'borMedAndreForelder',
+    borMedOmsorgsperson = 'borMedOmsorgsperson',
     adresse = 'adresse',
 }
 
@@ -138,6 +139,7 @@ export interface IBarnMedISøknad extends IBarn {
     [barnDataKeySpørsmål.søkersSlektsforhold]: ISøknadSpørsmål<Slektsforhold | ''>;
     [barnDataKeySpørsmål.søkersSlektsforholdSpesifisering]: ISøknadSpørsmål<string>;
     [barnDataKeySpørsmål.borMedAndreForelder]: ISøknadSpørsmål<ESvar | null>;
+    [barnDataKeySpørsmål.borMedOmsorgsperson]: ISøknadSpørsmål<ESvar | null>;
     [barnDataKeySpørsmål.adresse]: ISøknadSpørsmål<string | AlternativtSvarForInput.UKJENT>;
 }
 

--- a/src/frontend/typer/perioder.ts
+++ b/src/frontend/typer/perioder.ts
@@ -14,7 +14,7 @@ export interface IUtenlandsperiode {
 }
 
 export interface IArbeidsperiode {
-    arbeidsperiodeAvsluttet?: ISøknadSpørsmål<ESvar>; //TODO skrive om til å være null
+    arbeidsperiodeAvsluttet?: ISøknadSpørsmål<ESvar>;
     arbeidsperiodeland?: ISøknadSpørsmål<Alpha3Code | ''>;
     arbeidsgiver?: ISøknadSpørsmål<string>;
     fraDatoArbeidsperiode?: ISøknadSpørsmål<ISODateString>;

--- a/src/frontend/typer/skjema.ts
+++ b/src/frontend/typer/skjema.ts
@@ -135,6 +135,7 @@ export interface IEøsForBarnFeltTyper {
     søkersSlektsforhold: Slektsforhold | '';
     søkersSlektsforholdSpesifisering: string;
     borMedAndreForelder: ESvar | null;
+    borMedOmsorgsperson: ESvar | null;
     [key: IdNummerKey]: IIdNummer;
     omsorgspersonNavn: string;
     omsorgspersonSlektsforhold: Slektsforhold | '';

--- a/src/frontend/utils/barn.ts
+++ b/src/frontend/utils/barn.ts
@@ -191,15 +191,22 @@ export const genererOppdaterteBarn = (
                 ? null
                 : genererInitiellAndreForelder(barn.andreForelder, andreForelderErDød),
             omsorgsperson:
-                oppholderSegIInstitusjon === ESvar.JA || andreForelderErDød
-                    ? null
-                    : barn.omsorgsperson,
+                oppholderSegIInstitusjon === ESvar.NEI && (andreForelderErDød || erFosterbarn)
+                    ? barn.omsorgsperson
+                    : null,
             [barnDataKeySpørsmål.borMedAndreForelder]: {
                 ...barn[barnDataKeySpørsmål.borMedAndreForelder],
                 svar:
                     erFosterbarn || oppholderSegIInstitusjon === ESvar.JA || andreForelderErDød
                         ? null
                         : barn[barnDataKeySpørsmål.borMedAndreForelder].svar,
+            },
+            [barnDataKeySpørsmål.borMedOmsorgsperson]: {
+                ...barn[barnDataKeySpørsmål.borMedOmsorgsperson],
+                svar:
+                    erFosterbarn || oppholderSegIInstitusjon === ESvar.JA || andreForelderErDød
+                        ? null
+                        : barn[barnDataKeySpørsmål.borMedOmsorgsperson].svar,
             },
             [barnDataKeySpørsmål.erFosterbarn]: {
                 ...barn[barnDataKeySpørsmål.erFosterbarn],
@@ -564,6 +571,7 @@ export const nullstilteEøsFelterForBarn = (barn: IBarnMedISøknad) => ({
         svar: '',
     },
     borMedAndreForelder: { ...barn.borMedAndreForelder, svar: null },
+    borMedOmsorgsperson: { ...barn.borMedOmsorgsperson, svar: null },
     omsorgsperson: null,
     adresse: { ...barn.adresse, svar: '' },
     ...(barn.andreForelder && {

--- a/src/frontend/utils/barn.ts
+++ b/src/frontend/utils/barn.ts
@@ -462,6 +462,10 @@ export const genererInitialBarnMedISøknad = (barn: IBarn): IBarnMedISøknad => 
             id: EøsBarnSpørsmålId.borMedAndreForelder,
             svar: null,
         },
+        [barnDataKeySpørsmål.borMedOmsorgsperson]: {
+            id: EøsBarnSpørsmålId.borMedOmsorgsperson,
+            svar: null,
+        },
         [barnDataKeySpørsmål.adresse]: {
             id: EøsBarnSpørsmålId.barnetsAdresse,
             svar: '',

--- a/src/shared-utils/modellversjon.ts
+++ b/src/shared-utils/modellversjon.ts
@@ -1,6 +1,6 @@
 import { ApiRessurs, Ressurs, RessursStatus } from '@navikt/familie-typer';
 
-export const modellVersjon = 44;
+export const modellVersjon = 45;
 
 export const modellVersjonHeaderName = 'Soknad-Modell-Versjon';
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._

Implementerer nye regler for spørsmål om omsorgsperson og om barn bor med den andre forelderen

Spørsmålet “Bor barnet med den andre forelderen?” skal skjules i alle tilfeller der minst én av disse er sanne:
- Den andre forelderen er død
- Barnet er fosterbarn
- Barnet oppholder seg i institusjon

- Omsorgsperson skal vises i alle tilfeller der spørsmålet om “Bor barnet med den andre forelderen?” er blitt vist og bruker har svart “Nei” på dette BORTSETT fra når barnet også bor fast med søker. Da må vi først spørre om barnet bor med en annen omsorgsperson.

Dersom “Bor barnet med den andre forelderen?” ikke har blitt vist, skal omsorgsperson vises dersom:
- Alle disse tre er sanne samtidig: Barnet bor ikke fast med søker OG barnet oppholder seg ikke institusjon OG den andre forelderen er død
- ELLER disse tre er sanne samtidig: Barnet bor ikke fast med søker OG barnet oppholder seg ikke institusjon OG barnet er fosterbarn

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
