### PR TITLE
Sett barnets navn når vi henter det fra pdl, og ikke overalt ellers i…

### DIFF
--- a/src/frontend/assets/lang/en.json
+++ b/src/frontend/assets/lang/en.json
@@ -123,7 +123,7 @@
   "eøs.tilleggsskjema.lenketekst": "Download supplementary form",
   "eøs.utbetalinger.feilmelding": "You must state whether you are currently receiving benefits in order to be able to proceed",
   "eøs.utbetalinger.spm": "Are you currently receiving benefits?",
-  "felles.anonym.barn.fnr": "CHILD {fødselsnummer}",
+  "felles.anonym.barn.fnr": "Child {fødselsnummer}",
   "felles.banner": "Application for ordinary child benefit",
   "felles.banner.utvidet": "Application for extended child benefit",
   "felles.barneillustrasjon.tittel": "Child illustration",

--- a/src/frontend/assets/lang/nb.json
+++ b/src/frontend/assets/lang/nb.json
@@ -123,7 +123,7 @@
   "eøs.tilleggsskjema.lenketekst": "Last ned tilleggsskjema",
   "eøs.utbetalinger.feilmelding": "Du må oppgi om du får utbetalinger nå for å gå videre",
   "eøs.utbetalinger.spm": "Får du utbetalinger nå?",
-  "felles.anonym.barn.fnr": "BARN {fødselsnummer}",
+  "felles.anonym.barn.fnr": "Barn {fødselsnummer}",
   "felles.banner": "Søknad om ordinær barnetrygd",
   "felles.banner.utvidet": "Søknad om utvidet barnetrygd",
   "felles.barneillustrasjon.tittel": "Barneillustrasjon",

--- a/src/frontend/assets/lang/nn.json
+++ b/src/frontend/assets/lang/nn.json
@@ -123,7 +123,7 @@
   "eøs.tilleggsskjema.lenketekst": "Last ned tilleggsskjema",
   "eøs.utbetalinger.feilmelding": "Du må oppgje om du får utbetalingar no for å gå vidare",
   "eøs.utbetalinger.spm": "Får du utbetalingar no?",
-  "felles.anonym.barn.fnr": "BARN {fødselsnummer}",
+  "felles.anonym.barn.fnr": "Barn {fødselsnummer}",
   "felles.banner": "Søknad om ordinær barnetrygd",
   "felles.banner.utvidet": "Søknad om utvida barnetrygd",
   "felles.barneillustrasjon.tittel": "Barneillustrasjon",

--- a/src/frontend/components/Felleskomponenter/Arbeidsperiode/Arbeidsperiode.tsx
+++ b/src/frontend/components/Felleskomponenter/Arbeidsperiode/Arbeidsperiode.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { useIntl } from 'react-intl';
-
 import { Element } from 'nav-frontend-typografi';
 
 import { ESvar } from '@navikt/familie-form-elements';
@@ -15,7 +13,6 @@ import {
     IEøsForSøkerFeltTyper,
     IOmBarnetUtvidetFeltTyper,
 } from '../../../typer/skjema';
-import { barnetsNavnValue } from '../../../utils/barn';
 import JaNeiSpm from '../JaNeiSpm/JaNeiSpm';
 import { LeggTilKnapp } from '../LeggTilKnapp/LeggTilKnapp';
 import useModal from '../SkjemaModal/useModal';
@@ -56,12 +53,10 @@ export const Arbeidsperiode: React.FC<ArbeidsperiodeProps> = ({
     registrerteArbeidsperioder,
 }) => {
     const { erÅpen: arbeidsmodalErÅpen, toggleModal: toggleArbeidsmodal } = useModal();
-    const intl = useIntl();
-
     const gjelderAndreForelder = !!andreForelderData;
     const andreForelderErDød = !!andreForelderData?.erDød;
     const barn = andreForelderData?.barn;
-    const barnetsNavn = !!barn && barnetsNavnValue(barn, intl);
+    const barnetsNavn = !!barn && barn.navn;
 
     return (
         <>

--- a/src/frontend/components/Felleskomponenter/Barnetrygdperiode/Barnetrygdperiode.tsx
+++ b/src/frontend/components/Felleskomponenter/Barnetrygdperiode/Barnetrygdperiode.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { useIntl } from 'react-intl';
-
 import { Element } from 'nav-frontend-typografi';
 
 import { ESvar } from '@navikt/familie-form-elements';
@@ -10,7 +8,6 @@ import { Felt, ISkjema } from '@navikt/familie-skjema';
 import { IBarnMedISøknad } from '../../../typer/barn';
 import { IEøsBarnetrygdsperiode } from '../../../typer/perioder';
 import { IOmBarnetUtvidetFeltTyper } from '../../../typer/skjema';
-import { barnetsNavnValue } from '../../../utils/barn';
 import { OmBarnetSpørsmålsId, omBarnetSpørsmålSpråkId } from '../../SøknadsSteg/OmBarnet/spørsmål';
 import JaNeiSpm from '../JaNeiSpm/JaNeiSpm';
 import { LeggTilKnapp } from '../LeggTilKnapp/LeggTilKnapp';
@@ -36,7 +33,6 @@ export const Barnetrygdperiode: React.FC<BarnetrygdperiodeProps> = ({
     barn,
 }) => {
     const { erÅpen: barnetrygdsmodalErÅpen, toggleModal: toggleBarnetrygdsmodal } = useModal();
-    const intl = useIntl();
 
     return (
         <>
@@ -55,7 +51,7 @@ export const Barnetrygdperiode: React.FC<BarnetrygdperiodeProps> = ({
                             barnetrygdsperiode={periode}
                             fjernPeriodeCallback={fjernBarnetrygdsperiode}
                             nummer={index + 1}
-                            barnetsNavn={barnetsNavnValue(barn, intl)}
+                            barnetsNavn={barn.navn}
                         />
                     ))}
 

--- a/src/frontend/components/Felleskomponenter/Barnetrygdperiode/BarnetrygdperiodeModal.tsx
+++ b/src/frontend/components/Felleskomponenter/Barnetrygdperiode/BarnetrygdperiodeModal.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 
-import { useIntl } from 'react-intl';
 import styled from 'styled-components';
 
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { IBarnMedISøknad } from '../../../typer/barn';
 import { IEøsBarnetrygdsperiode } from '../../../typer/perioder';
-import { barnetsNavnValue } from '../../../utils/barn';
 import { dagensDato, gårsdagensDato } from '../../../utils/dato';
 import { trimWhiteSpace, visFeiloppsummering } from '../../../utils/hjelpefunksjoner';
 import AlertStripe from '../AlertStripe/AlertStripe';
@@ -48,8 +46,6 @@ export const BarnetrygdperiodeModal: React.FC<Props> = ({
         tilDatoBarnetrygdperiode,
         månedligBeløp,
     } = skjema.felter;
-
-    const intl = useIntl();
 
     const onLeggTil = () => {
         if (!validerFelterOgVisFeilmelding()) {
@@ -156,7 +152,7 @@ export const BarnetrygdperiodeModal: React.FC<Props> = ({
                         }
                         språkValues={{
                             ...(barn && {
-                                barn: barnetsNavnValue(barn, intl),
+                                barn: barn.navn,
                             }),
                         }}
                         tilleggsinfo={

--- a/src/frontend/components/Felleskomponenter/BlokkerTilbakeKnappModal/BlokkerTilbakeKnappModal.test.tsx
+++ b/src/frontend/components/Felleskomponenter/BlokkerTilbakeKnappModal/BlokkerTilbakeKnappModal.test.tsx
@@ -43,6 +43,7 @@ const manueltRegistrertSomIBarnMedISøknad: Partial<IBarnMedISøknad> = {
 
 const fraPdlSomIBarnMedISøknad: Partial<IBarnMedISøknad> = {
     ...fraPdl,
+    navn: fraPdl.navn ?? 'ukjent',
     id: 'random-id-2',
     barnetrygdFraEøslandHvilketLand: {
         id: OmBarnetSpørsmålsId.barnetrygdFraEøslandHvilketLand,

--- a/src/frontend/components/Felleskomponenter/Pensjonsmodal/Pensjonsmodal.tsx
+++ b/src/frontend/components/Felleskomponenter/Pensjonsmodal/Pensjonsmodal.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
 
-import { useIntl } from 'react-intl';
-
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { IBarnMedISøknad } from '../../../typer/barn';
 import { IPensjonsperiode } from '../../../typer/perioder';
-import { barnetsNavnValue } from '../../../utils/barn';
 import { dagensDato, gårsdagensDato } from '../../../utils/dato';
 import { visFeiloppsummering } from '../../../utils/hjelpefunksjoner';
 import Datovelger from '../Datovelger/Datovelger';
@@ -37,7 +34,6 @@ export const PensjonModal: React.FC<Props> = ({
     gjelderUtland = false,
     andreForelderData,
 }) => {
-    const intl = useIntl();
     const { skjema, valideringErOk, nullstillSkjema, validerFelterOgVisFeilmelding } =
         usePensjonSkjema({
             gjelderUtland,
@@ -111,7 +107,7 @@ export const PensjonModal: React.FC<Props> = ({
                                       PensjonSpørsmålId.mottarPensjonNå
                                   ]
                         }
-                        språkValues={{ ...(barn && { barn: barnetsNavnValue(barn, intl) }) }}
+                        språkValues={{ ...(barn && { barn: barn.navn }) }}
                     />
                 )}
                 {pensjonsland.erSynlig && (
@@ -129,7 +125,7 @@ export const PensjonModal: React.FC<Props> = ({
                                               PensjonSpørsmålId.pensjonsland
                                           ]
                                 }
-                                values={{ ...(barn && { barn: barnetsNavnValue(barn, intl) }) }}
+                                values={{ ...(barn && { barn: barn.navn }) }}
                             />
                         }
                         dynamisk
@@ -151,7 +147,7 @@ export const PensjonModal: React.FC<Props> = ({
                                               PensjonSpørsmålId.fraDatoPensjon
                                           ]
                                 }
-                                values={{ ...(barn && { barn: barnetsNavnValue(barn, intl) }) }}
+                                values={{ ...(barn && { barn: barn.navn }) }}
                             />
                         }
                         skjema={skjema}
@@ -173,7 +169,7 @@ export const PensjonModal: React.FC<Props> = ({
                                               PensjonSpørsmålId.tilDatoPensjon
                                           ]
                                 }
-                                values={{ ...(barn && { barn: barnetsNavnValue(barn, intl) }) }}
+                                values={{ ...(barn && { barn: barn.navn }) }}
                             />
                         }
                         skjema={skjema}

--- a/src/frontend/components/Felleskomponenter/Pensjonsmodal/Pensjonsperiode.tsx
+++ b/src/frontend/components/Felleskomponenter/Pensjonsmodal/Pensjonsperiode.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { useIntl } from 'react-intl';
-
 import { Element } from 'nav-frontend-typografi';
 
 import { ESvar } from '@navikt/familie-form-elements';
@@ -15,7 +13,6 @@ import {
     IEøsForSøkerFeltTyper,
     IOmBarnetUtvidetFeltTyper,
 } from '../../../typer/skjema';
-import { barnetsNavnValue } from '../../../utils/barn';
 import JaNeiSpm from '../JaNeiSpm/JaNeiSpm';
 import { LeggTilKnapp } from '../LeggTilKnapp/LeggTilKnapp';
 import useModal from '../SkjemaModal/useModal';
@@ -55,13 +52,11 @@ export const Pensjonsperiode: React.FC<PensjonsperiodeProps> = ({
     mottarEllerMottattPensjonFelt,
     registrertePensjonsperioder,
 }) => {
-    const intl = useIntl();
     const { erÅpen: pensjonsmodalErÅpen, toggleModal: togglePensjonsmodal } = useModal();
 
     const gjelderAndreForelder = !!andreForelderData;
     const barn = andreForelderData?.barn;
     const andreForelderErDød = !!andreForelderData?.erDød;
-    const barnetsNavn = barn && barnetsNavnValue(barn, intl);
 
     return (
         <>
@@ -76,8 +71,8 @@ export const Pensjonsperiode: React.FC<PensjonsperiodeProps> = ({
                 inkluderVetIkke={gjelderAndreForelder}
                 språkValues={{
                     ...(barn && {
-                        navn: barnetsNavn,
-                        barn: barnetsNavn,
+                        navn: barn.navn,
+                        barn: barn.navn,
                     }),
                 }}
             />
@@ -101,7 +96,7 @@ export const Pensjonsperiode: React.FC<PensjonsperiodeProps> = ({
                                     gjelderAndreForelder
                                 )}
                                 values={{
-                                    ...(barn && { barn: barnetsNavn }),
+                                    ...(barn && { barn: barn.navn }),
                                 }}
                             />
                         </Element>

--- a/src/frontend/components/Felleskomponenter/Pensjonsmodal/PensjonsperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/Pensjonsmodal/PensjonsperiodeOppsummering.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
 
-import { useIntl } from 'react-intl';
-
 import { ESvar } from '@navikt/familie-form-elements';
 import { useSprakContext } from '@navikt/familie-sprakvelger';
 
 import { IBarnMedISøknad } from '../../../typer/barn';
 import { IPensjonsperiode } from '../../../typer/perioder';
-import { barnetsNavnValue } from '../../../utils/barn';
 import { formaterDato } from '../../../utils/dato';
 import { landkodeTilSpråk } from '../../../utils/språk';
 import { OppsummeringFelt } from '../../SøknadsSteg/Oppsummering/OppsummeringFelt';
@@ -30,7 +27,6 @@ export const PensjonsperiodeOppsummering: React.FC<{
     gjelderUtlandet = false,
 }) => {
     const [valgtLocale] = useSprakContext();
-    const intl = useIntl();
     const { mottarPensjonNå, pensjonsland, pensjonFra, pensjonTil } = pensjonsperiode;
 
     const gjelderAndreForelder = !!andreForelderData;
@@ -46,7 +42,7 @@ export const PensjonsperiodeOppsummering: React.FC<{
                 ]
             }
             values={{
-                ...(barn && { barn: barnetsNavnValue(barn, intl) }),
+                ...(barn && { barn: barn.navn }),
             }}
         />
     );

--- a/src/frontend/components/Felleskomponenter/Pensjonsmodal/usePensjonSkjema.tsx
+++ b/src/frontend/components/Felleskomponenter/Pensjonsmodal/usePensjonSkjema.tsx
@@ -1,7 +1,5 @@
 import { useEffect } from 'react';
 
-import { useIntl } from 'react-intl';
-
 import { ESvar } from '@navikt/familie-form-elements';
 import { useSkjema, Valideringsstatus } from '@navikt/familie-skjema';
 
@@ -11,7 +9,6 @@ import useJaNeiSpmFelt from '../../../hooks/useJaNeiSpmFelt';
 import useLanddropdownFelt from '../../../hooks/useLanddropdownFelt';
 import { IBarnMedISøknad } from '../../../typer/barn';
 import { IPensjonsperiodeFeltTyper } from '../../../typer/skjema';
-import { barnetsNavnValue } from '../../../utils/barn';
 import { dagensDato, gårsdagensDato, dagenEtterDato } from '../../../utils/dato';
 import { pensjonFraDatoFeilmeldingSpråkId, pensjonslandFeilmeldingSpråkId } from './språkUtils';
 import { PensjonSpørsmålId } from './spørsmål';
@@ -26,7 +23,6 @@ export const usePensjonSkjema = ({
     andreForelderData,
 }: IUsePensjonSkjemaParams) => {
     const { erEøsLand } = useEøs();
-    const intl = useIntl();
 
     const gjelderAndreForelder = !!andreForelderData;
     const barn = andreForelderData?.barn;
@@ -37,7 +33,7 @@ export const usePensjonSkjema = ({
         feilmeldingSpråkId: gjelderAndreForelder
             ? 'ombarnet.andre-forelder.pensjonnå.feilmelding'
             : 'modal.fårdupensjonnå.feilmelding',
-        feilmeldingSpråkVerdier: barn ? { barn: barnetsNavnValue(barn, intl) } : undefined,
+        feilmeldingSpråkVerdier: barn ? { barn: barn.navn } : undefined,
         skalSkjules: erAndreForelderDød,
     });
 

--- a/src/frontend/components/Felleskomponenter/UtbetalingerModal/UtbetalingerModal.tsx
+++ b/src/frontend/components/Felleskomponenter/UtbetalingerModal/UtbetalingerModal.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
 
-import { useIntl } from 'react-intl';
-
 import { ESvar } from '@navikt/familie-form-elements';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 
 import { IBarnMedISøknad } from '../../../typer/barn';
 import { IUtbetalingsperiode } from '../../../typer/perioder';
-import { barnetsNavnValue } from '../../../utils/barn';
 import { dagensDato, gårsdagensDato } from '../../../utils/dato';
 import { visFeiloppsummering } from '../../../utils/hjelpefunksjoner';
 import { minTilDatoForUtbetalingEllerArbeidsperiode } from '../../../utils/perioder';
@@ -37,7 +34,6 @@ export const UtbetalingerModal: React.FC<UtbetalingerModalProps> = ({
 }) => {
     const { skjema, valideringErOk, nullstillSkjema, validerFelterOgVisFeilmelding } =
         useUtbetalingerSkjema(andreForelderData);
-    const intl = useIntl();
 
     const gjelderAndreForelder = !!andreForelderData;
     const barn = andreForelderData?.barn;
@@ -95,7 +91,7 @@ export const UtbetalingerModal: React.FC<UtbetalingerModalProps> = ({
                             periodenErAvsluttet
                         )[UtbetalingerSpørsmålId.fårUtbetalingNå]
                     }
-                    språkValues={{ ...(barn && { barn: barnetsNavnValue(barn, intl) }) }}
+                    språkValues={{ ...(barn && { barn: barn.navn }) }}
                 />
             </KomponentGruppe>
             {(skjema.felter.fårUtbetalingNå.valideringsstatus === Valideringsstatus.OK ||
@@ -112,7 +108,7 @@ export const UtbetalingerModal: React.FC<UtbetalingerModalProps> = ({
                                         periodenErAvsluttet
                                     )[UtbetalingerSpørsmålId.utbetalingLand]
                                 }
-                                values={{ ...(barn && { barn: barnetsNavnValue(barn, intl) }) }}
+                                values={{ ...(barn && { barn: barn.navn }) }}
                             />
                         }
                         dynamisk

--- a/src/frontend/components/Felleskomponenter/UtbetalingerModal/Utbetalingsperiode.tsx
+++ b/src/frontend/components/Felleskomponenter/UtbetalingerModal/Utbetalingsperiode.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { useIntl } from 'react-intl';
-
 import { Element } from 'nav-frontend-typografi';
 
 import { ESvar } from '@navikt/familie-form-elements';
@@ -10,7 +8,6 @@ import { Felt, ISkjema } from '@navikt/familie-skjema';
 import { IBarnMedISøknad } from '../../../typer/barn';
 import { IUtbetalingsperiode } from '../../../typer/perioder';
 import { IEøsForBarnFeltTyper, IEøsForSøkerFeltTyper } from '../../../typer/skjema';
-import { barnetsNavnValue } from '../../../utils/barn';
 import JaNeiSpm from '../JaNeiSpm/JaNeiSpm';
 import { LeggTilKnapp } from '../LeggTilKnapp/LeggTilKnapp';
 import useModal from '../SkjemaModal/useModal';
@@ -41,13 +38,12 @@ export const Utbetalingsperiode: React.FC<UtbetalingsperiodeProps> = ({
     mottarEllerMottattUtbetalingFelt,
     registrerteUtbetalingsperioder,
 }) => {
-    const intl = useIntl();
     const { erÅpen: utbetalingermodalErÅpen, toggleModal: toggleUtbetalingsmodal } = useModal();
 
     const gjelderAndreForelder = !!andreForelderData;
     const barn = andreForelderData?.barn;
     const andreForelderErDød = !!andreForelderData?.erDød;
-    const barnetsNavn = barn && barnetsNavnValue(barn, intl);
+    const barnetsNavn = barn && barn.navn;
 
     return (
         <>

--- a/src/frontend/components/Felleskomponenter/UtbetalingerModal/UtbetalingsperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/UtbetalingerModal/UtbetalingsperiodeOppsummering.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
 
-import { useIntl } from 'react-intl';
-
 import { ESvar } from '@navikt/familie-form-elements';
 import { useSprakContext } from '@navikt/familie-sprakvelger';
 
 import { IBarnMedISøknad } from '../../../typer/barn';
 import { IUtbetalingsperiode } from '../../../typer/perioder';
-import { barnetsNavnValue } from '../../../utils/barn';
 import { formaterDato } from '../../../utils/dato';
 import { landkodeTilSpråk } from '../../../utils/språk';
 import { formaterDatoMedUkjent } from '../../../utils/visning';
@@ -23,7 +20,6 @@ export const UtbetalingsperiodeOppsummering: React.FC<{
     andreForelderData?: { erDød: boolean; barn: IBarnMedISøknad };
 }> = ({ utbetalingsperiode, nummer, fjernPeriodeCallback = undefined, andreForelderData }) => {
     const [valgtLocale] = useSprakContext();
-    const intl = useIntl();
     const { fårUtbetalingNå, utbetalingLand, utbetalingFraDato, utbetalingTilDato } =
         utbetalingsperiode;
 
@@ -40,7 +36,7 @@ export const UtbetalingsperiodeOppsummering: React.FC<{
                 ]
             }
             values={{
-                ...(barn && { barn: barnetsNavnValue(barn, intl) }),
+                ...(barn && { barn: barn.navn }),
             }}
         />
     );

--- a/src/frontend/components/Felleskomponenter/UtbetalingerModal/useUtbetalingerSkjema.tsx
+++ b/src/frontend/components/Felleskomponenter/UtbetalingerModal/useUtbetalingerSkjema.tsx
@@ -1,5 +1,3 @@
-import { useIntl } from 'react-intl';
-
 import { ESvar } from '@navikt/familie-form-elements';
 import { useFelt, useSkjema, Valideringsstatus } from '@navikt/familie-skjema';
 
@@ -9,7 +7,6 @@ import useJaNeiSpmFelt from '../../../hooks/useJaNeiSpmFelt';
 import useLanddropdownFelt from '../../../hooks/useLanddropdownFelt';
 import { IBarnMedISøknad } from '../../../typer/barn';
 import { IUtbetalingerFeltTyper } from '../../../typer/skjema';
-import { barnetsNavnValue } from '../../../utils/barn';
 import { dagensDato, erSammeDatoSomDagensDato, gårsdagensDato } from '../../../utils/dato';
 import { minTilDatoForUtbetalingEllerArbeidsperiode } from '../../../utils/perioder';
 import { utbetalingerFeilmelding } from './språkUtils';
@@ -19,8 +16,6 @@ export const useUtbetalingerSkjema = (andreForelderData?: {
     barn: IBarnMedISøknad;
     erDød: boolean;
 }) => {
-    const intl = useIntl();
-
     const gjelderAndreForelder = !!andreForelderData;
     const barn = andreForelderData?.barn;
     const andreForelderErDød = !!andreForelderData?.erDød;
@@ -29,7 +24,7 @@ export const useUtbetalingerSkjema = (andreForelderData?: {
         søknadsfelt: { id: UtbetalingerSpørsmålId.fårUtbetalingNå, svar: null },
         feilmeldingSpråkId: utbetalingerFeilmelding(gjelderAndreForelder),
         skalSkjules: andreForelderErDød,
-        feilmeldingSpråkVerdier: barn ? { barn: barnetsNavnValue(barn, intl) } : undefined,
+        feilmeldingSpråkVerdier: barn ? { barn: barn.navn } : undefined,
     });
 
     const periodenErAvsluttet = fårUtbetalingNå.verdi === ESvar.NEI || andreForelderErDød;
@@ -52,7 +47,7 @@ export const useUtbetalingerSkjema = (andreForelderData?: {
         skalFeltetVises:
             fårUtbetalingNå.valideringsstatus === Valideringsstatus.OK || andreForelderErDød,
         nullstillVedAvhengighetEndring: true,
-        feilmeldingSpråkVerdier: barn ? { barn: barnetsNavnValue(barn, intl) } : undefined,
+        feilmeldingSpråkVerdier: barn ? { barn: barn.navn } : undefined,
     });
 
     const utbetalingFraDato = useDatovelgerFelt({

--- a/src/frontend/components/Felleskomponenter/UtenlandsoppholdModal/UtenlandsoppholdModal.tsx
+++ b/src/frontend/components/Felleskomponenter/UtenlandsoppholdModal/UtenlandsoppholdModal.tsx
@@ -7,7 +7,6 @@ import { ESvar } from '@navikt/familie-form-elements';
 import { IBarnMedISøknad } from '../../../typer/barn';
 import { IUtenlandsperiode } from '../../../typer/perioder';
 import { EUtenlandsoppholdÅrsak } from '../../../typer/utenlandsopphold';
-import { barnetsNavnValue } from '../../../utils/barn';
 import { visFeiloppsummering } from '../../../utils/hjelpefunksjoner';
 import { svarForSpørsmålMedUkjent } from '../../../utils/spørsmål';
 import {
@@ -110,7 +109,7 @@ export const UtenlandsoppholdModal: React.FC<Props> = ({
                         label={
                             <SpråkTekst
                                 id={årsakLabelSpråkId(barn)}
-                                values={{ ...(barn && { barn: barnetsNavnValue(barn, intl) }) }}
+                                values={{ ...(barn && { barn: barn.navn }) }}
                             />
                         }
                         skjema={skjema}
@@ -123,7 +122,7 @@ export const UtenlandsoppholdModal: React.FC<Props> = ({
                                     {
                                         id: årsakSpråkId(årsak as EUtenlandsoppholdÅrsak, barn),
                                     },
-                                    { ...(barn && { barn: barnetsNavnValue(barn, intl) }) }
+                                    { ...(barn && { barn: barn.navn }) }
                                 )}
                             </option>
                         ))}
@@ -139,7 +138,7 @@ export const UtenlandsoppholdModal: React.FC<Props> = ({
                                     skjema.felter.utenlandsoppholdÅrsak.verdi,
                                     barn
                                 )}
-                                values={{ ...(barn && { barn: barnetsNavnValue(barn, intl) }) }}
+                                values={{ ...(barn && { barn: barn.navn }) }}
                             />
                         )
                     }
@@ -156,7 +155,7 @@ export const UtenlandsoppholdModal: React.FC<Props> = ({
                                     skjema.felter.utenlandsoppholdÅrsak.verdi,
                                     barn
                                 )}
-                                values={{ ...(barn && { barn: barnetsNavnValue(barn, intl) }) }}
+                                values={{ ...(barn && { barn: barn.navn }) }}
                             />
                         }
                         skjema={skjema}
@@ -176,7 +175,7 @@ export const UtenlandsoppholdModal: React.FC<Props> = ({
                                         skjema.felter.utenlandsoppholdÅrsak.verdi,
                                         barn
                                     )}
-                                    values={{ ...(barn && { barn: barnetsNavnValue(barn, intl) }) }}
+                                    values={{ ...(barn && { barn: barn.navn }) }}
                                 />
                             }
                             skjema={skjema}

--- a/src/frontend/components/Felleskomponenter/UtenlandsoppholdModal/UtenlandsperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/UtenlandsoppholdModal/UtenlandsperiodeOppsummering.tsx
@@ -11,7 +11,6 @@ import { useFeatureToggles } from '../../../context/FeatureToggleContext';
 import { IBarnMedISøknad } from '../../../typer/barn';
 import { IUtenlandsperiode } from '../../../typer/perioder';
 import { EUtenlandsoppholdÅrsak } from '../../../typer/utenlandsopphold';
-import { barnetsNavnValue } from '../../../utils/barn';
 import { formaterDato } from '../../../utils/dato';
 import { landkodeTilSpråk } from '../../../utils/språk';
 import { formaterDatoMedUkjent } from '../../../utils/visning';
@@ -71,7 +70,7 @@ export const UtenlandsperiodeOppsummering: React.FC<{
                                     årsakTilEøsInfoSpråkIds[periode.utenlandsoppholdÅrsak.svar]
                                 }
                                 språkValues={{
-                                    barn: barn ? barnetsNavnValue(barn, intl) : undefined,
+                                    barn: barn ? barn.navn : undefined,
                                 }}
                             />
                         </EøsNotisWrapper>
@@ -82,14 +81,14 @@ export const UtenlandsperiodeOppsummering: React.FC<{
                     tittel={
                         <SpråkTekst
                             id={årsakLabelSpråkId(barn)}
-                            values={{ barn: barn ? barnetsNavnValue(barn, intl) : undefined }}
+                            values={{ barn: barn ? barn.navn : undefined }}
                         />
                     }
                 >
                     <Normaltekst>
                         <SpråkTekst
                             id={årsakSpråkId(årsak, barn)}
-                            values={{ barn: barn ? barnetsNavnValue(barn, intl) : undefined }}
+                            values={{ barn: barn ? barn.navn : undefined }}
                         />
                     </Normaltekst>
                 </OppsummeringFelt>
@@ -98,7 +97,7 @@ export const UtenlandsperiodeOppsummering: React.FC<{
                     tittel={
                         <SpråkTekst
                             id={landLabelSpråkId(årsak, barn)}
-                            values={{ barn: barn ? barnetsNavnValue(barn, intl) : undefined }}
+                            values={{ barn: barn ? barn.navn : undefined }}
                         />
                     }
                     søknadsvar={landkodeTilSpråk(oppholdsland.svar, valgtLocale)}
@@ -109,7 +108,7 @@ export const UtenlandsperiodeOppsummering: React.FC<{
                         tittel={
                             <SpråkTekst
                                 id={fraDatoLabelSpråkId(årsak, barn)}
-                                values={{ barn: barn ? barnetsNavnValue(barn, intl) : undefined }}
+                                values={{ barn: barn ? barn.navn : undefined }}
                             />
                         }
                         søknadsvar={formaterDato(oppholdslandFraDato.svar)}
@@ -121,7 +120,7 @@ export const UtenlandsperiodeOppsummering: React.FC<{
                         tittel={
                             <SpråkTekst
                                 id={tilDatoLabelSpråkId(årsak, barn)}
-                                values={{ barn: barn ? barnetsNavnValue(barn, intl) : undefined }}
+                                values={{ barn: barn ? barn.navn : undefined }}
                             />
                         }
                         søknadsvar={formaterDatoMedUkjent(

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg.tsx
@@ -10,7 +10,6 @@ import { useApp } from '../../../context/AppContext';
 import { EFiltyper, IDokumentasjon, IVedlegg } from '../../../typer/dokumentasjon';
 import { Dokumentasjonsbehov } from '../../../typer/kontrakt/dokumentasjon';
 import { ESivilstand, ESøknadstype } from '../../../typer/kontrakt/generelle';
-import { barnetsNavnValue } from '../../../utils/barn';
 import EksternLenke from '../../Felleskomponenter/EksternLenke/EksternLenke';
 import SpråkTekst from '../../Felleskomponenter/SpråkTekst/SpråkTekst';
 import Filopplaster from './filopplaster/Filopplaster';
@@ -44,7 +43,7 @@ const LastOppVedlegg: React.FC<Props> = ({ dokumentasjon, vedleggNr, oppdaterDok
         );
 
         return barnDokGjelderFor.map((barn, index) => {
-            const visningsNavn = barnetsNavnValue(barn, intl);
+            const visningsNavn = barn.navn;
             if (index === 0) {
                 return visningsNavn;
             } else {

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Barn/EøsForBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Barn/EøsForBarn.tsx
@@ -7,7 +7,7 @@ import { ESvar } from '@navikt/familie-form-elements';
 import { useApp } from '../../../../context/AppContext';
 import { barnDataKeySpørsmål, IBarnMedISøknad } from '../../../../typer/barn';
 import { BarnetsId } from '../../../../typer/common';
-import { barnetsNavnValue, skalSkjuleAndreForelderFelt } from '../../../../utils/barn';
+import { skalSkjuleAndreForelderFelt } from '../../../../utils/barn';
 import { Arbeidsperiode } from '../../../Felleskomponenter/Arbeidsperiode/Arbeidsperiode';
 import SlektsforholdDropdown from '../../../Felleskomponenter/Dropdowns/SlektsforholdDropdown';
 import JaNeiSpm from '../../../Felleskomponenter/JaNeiSpm/JaNeiSpm';
@@ -55,12 +55,7 @@ const EøsForBarn: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
 
     return (
         <Steg
-            tittel={
-                <SpråkTekst
-                    id={'eøs-om-barn.sidetittel'}
-                    values={{ barn: barnetsNavnValue(barn, intl) }}
-                />
-            }
+            tittel={<SpråkTekst id={'eøs-om-barn.sidetittel'} values={{ barn: barn.navn }} />}
             skjema={{
                 validerFelterOgVisFeilmelding,
                 valideringErOk,
@@ -83,7 +78,7 @@ const EøsForBarn: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
                         label={
                             <SpråkTekst
                                 id={eøsBarnSpørsmålSpråkId[EøsBarnSpørsmålId.søkersSlektsforhold]}
-                                values={{ barn: barnetsNavnValue(barn, intl) }}
+                                values={{ barn: barn.navn }}
                             />
                         }
                         gjelderSøker={true}
@@ -98,7 +93,7 @@ const EøsForBarn: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
                                 ]
                             }
                             språkValues={{
-                                barn: barnetsNavnValue(barn, intl),
+                                barn: barn.navn,
                             }}
                         />
                     )}
@@ -114,7 +109,7 @@ const EøsForBarn: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
                         spørsmålTekstId={
                             eøsBarnSpørsmålSpråkId[EøsBarnSpørsmålId.borMedAndreForelder]
                         }
-                        språkValues={{ barn: barnetsNavnValue(barn, intl) }}
+                        språkValues={{ barn: barn.navn }}
                     />
                     <JaNeiSpm
                         skjema={skjema}
@@ -122,7 +117,7 @@ const EøsForBarn: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
                         spørsmålTekstId={
                             eøsBarnSpørsmålSpråkId[EøsBarnSpørsmålId.borMedOmsorgsperson]
                         }
-                        språkValues={{ barn: barnetsNavnValue(barn, intl) }}
+                        språkValues={{ barn: barn.navn }}
                     />
                 </KomponentGruppe>
             )}
@@ -130,7 +125,7 @@ const EøsForBarn: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
             {skjema.felter.omsorgspersonNavn.erSynlig && (
                 <SkjemaFieldset
                     tittelId={'eøs-om-barn.annenomsorgsperson.gjenlevende'}
-                    språkValues={{ barn: barnetsNavnValue(barn, intl) }}
+                    språkValues={{ barn: barn.navn }}
                 >
                     <SkjemaFeltInput
                         felt={skjema.felter.omsorgspersonNavn}
@@ -153,7 +148,7 @@ const EøsForBarn: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
                                             EøsBarnSpørsmålId.omsorgspersonSlektsforhold
                                         ]
                                     }
-                                    values={{ barn: barnetsNavnValue(barn, intl) }}
+                                    values={{ barn: barn.navn }}
                                 />
                             }
                             gjelderSøker={false}
@@ -169,7 +164,7 @@ const EøsForBarn: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
                                 ]
                             }
                             språkValues={{
-                                barn: barnetsNavnValue(barn, intl),
+                                barn: barn.navn,
                             }}
                         />
                     )}
@@ -216,7 +211,7 @@ const EøsForBarn: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
                         visFeilmeldinger={skjema.visFeilmeldinger}
                         description={<SpråkTekst id={'felles.hjelpetekst.fulladresse'} />}
                         labelSpråkTekstId={eøsBarnSpørsmålSpråkId[EøsBarnSpørsmålId.barnetsAdresse]}
-                        språkValues={{ barn: barnetsNavnValue(barn, intl) }}
+                        språkValues={{ barn: barn.navn }}
                         disabled={skjema.felter.barnetsAdresseVetIkke.verdi === ESvar.JA}
                     />
 
@@ -256,7 +251,7 @@ const EøsForBarn: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
                                             skjema.felter.andreForelderAdresseVetIkke.verdi ===
                                             ESvar.JA
                                         }
-                                        språkValues={{ barn: barnetsNavnValue(barn, intl) }}
+                                        språkValues={{ barn: barn.navn }}
                                     />
 
                                     <SkjemaCheckbox

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Barn/useEøsForBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Barn/useEøsForBarn.tsx
@@ -1,7 +1,6 @@
 import React, { Dispatch, SetStateAction, useState } from 'react';
 
 import { Alpha3Code } from 'i18n-iso-countries';
-import { useIntl } from 'react-intl';
 
 import { ESvar } from '@navikt/familie-form-elements';
 import { feil, Felt, FeltState, ISkjema, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
@@ -22,11 +21,7 @@ import { Slektsforhold } from '../../../../typer/kontrakt/barn';
 import { IArbeidsperiode, IPensjonsperiode, IUtbetalingsperiode } from '../../../../typer/perioder';
 import { IEøsForBarnFeltTyper } from '../../../../typer/skjema';
 import { valideringAdresse } from '../../../../utils/adresse';
-import {
-    barnetsNavnValue,
-    skalSkjuleAndreForelderFelt,
-    skalViseOmsorgspersonHof,
-} from '../../../../utils/barn';
+import { skalSkjuleAndreForelderFelt, skalViseOmsorgspersonHof } from '../../../../utils/barn';
 import { trimWhiteSpace } from '../../../../utils/hjelpefunksjoner';
 import { formaterVerdiForCheckbox } from '../../../../utils/input';
 import { svarForSpørsmålMedUkjent } from '../../../../utils/spørsmål';
@@ -57,7 +52,6 @@ export const useEøsForBarn = (
     settIdNummerFelterForAndreForelder: Dispatch<SetStateAction<Felt<string>[]>>;
 } => {
     const { søknad, settSøknad } = useApp();
-    const intl = useIntl();
 
     const [gjeldendeBarn] = useState<IBarnMedISøknad | undefined>(
         søknad.barnInkludertISøknaden.find(barn => barn.id === barnetsUuid)
@@ -88,7 +82,7 @@ export const useEøsForBarn = (
     const søkersSlektsforholdSpesifisering = useInputFelt({
         søknadsfelt: gjeldendeBarn[barnDataKeySpørsmål.søkersSlektsforholdSpesifisering],
         feilmeldingSpråkId: 'eøs-om-barn.dinrelasjon.feilmelding',
-        feilmeldingSpråkVerdier: { barn: barnetsNavnValue(gjeldendeBarn, intl) },
+        feilmeldingSpråkVerdier: { barn: gjeldendeBarn.navn },
         skalVises: søkersSlektsforhold.verdi === Slektsforhold.ANNEN_RELASJON,
         customValidering: (felt: FeltState<string>) => {
             const verdi = trimWhiteSpace(felt.verdi);
@@ -99,7 +93,7 @@ export const useEøsForBarn = (
                       <SpråkTekst
                           id={'felles.relasjon.format.feilmelding'}
                           values={{
-                              barn: barnetsNavnValue(gjeldendeBarn, intl),
+                              barn: gjeldendeBarn.navn,
                           }}
                       />
                   );
@@ -111,7 +105,7 @@ export const useEøsForBarn = (
     const borMedAndreForelder = useJaNeiSpmFelt({
         søknadsfelt: gjeldendeBarn[barnDataKeySpørsmål.borMedAndreForelder],
         feilmeldingSpråkId: 'eøs-om-barn.borbarnmedandreforelder.feilmelding',
-        feilmeldingSpråkVerdier: { barn: barnetsNavnValue(gjeldendeBarn, intl) },
+        feilmeldingSpråkVerdier: { barn: gjeldendeBarn.navn },
         nullstillVedAvhengighetEndring: true,
         skalSkjules:
             gjeldendeBarn.erFosterbarn.svar === ESvar.JA ||
@@ -122,7 +116,7 @@ export const useEøsForBarn = (
     const borMedOmsorgsperson = useJaNeiSpmFelt({
         søknadsfelt: gjeldendeBarn[barnDataKeySpørsmål.borMedOmsorgsperson],
         feilmeldingSpråkId: 'eøs-om-barn.bormedannenomsorgsperson.feilmelding',
-        feilmeldingSpråkVerdier: { barn: barnetsNavnValue(gjeldendeBarn, intl) },
+        feilmeldingSpråkVerdier: { barn: gjeldendeBarn.navn },
         nullstillVedAvhengighetEndring: true,
         skalSkjules: !(
             gjeldendeBarn.borFastMedSøker.svar === ESvar.JA &&
@@ -152,7 +146,7 @@ export const useEøsForBarn = (
                       <SpråkTekst
                           id={'felles.relasjon.format.feilmelding'}
                           values={{
-                              barn: barnetsNavnValue(gjeldendeBarn, intl),
+                              barn: gjeldendeBarn.navn,
                           }}
                       />
                   );
@@ -178,7 +172,7 @@ export const useEøsForBarn = (
         søknadsfelt: omsorgsperson && omsorgsperson.slektsforholdSpesifisering,
         feilmeldingSpråkId: 'eøs-om-barn.annenomsorgspersonrelasjon.feilmelding',
         feilmeldingSpråkVerdier: {
-            barn: barnetsNavnValue(gjeldendeBarn, intl),
+            barn: gjeldendeBarn.navn,
         },
         skalVises: omsorgspersonSlektsforhold.verdi === Slektsforhold.ANNEN_RELASJON,
         customValidering: (felt: FeltState<string>) => {
@@ -190,7 +184,7 @@ export const useEøsForBarn = (
                       <SpråkTekst
                           id={'felles.relasjon.format.feilmelding'}
                           values={{
-                              barn: barnetsNavnValue(gjeldendeBarn, intl),
+                              barn: gjeldendeBarn.navn,
                           }}
                       />
                   );
@@ -218,7 +212,7 @@ export const useEøsForBarn = (
                       <SpråkTekst
                           id={'felles.idnummer-feilformat.feilmelding'}
                           values={{
-                              barn: barnetsNavnValue(gjeldendeBarn, intl),
+                              barn: gjeldendeBarn.navn,
                           }}
                       />
                   );
@@ -250,7 +244,7 @@ export const useEøsForBarn = (
         avhengighet: barnetsAdresseVetIkke,
         feilmeldingSpråkId: 'eøs.hvorborbarn.feilmelding',
         språkVerdier: {
-            barn: barnetsNavnValue(gjeldendeBarn, intl),
+            barn: gjeldendeBarn.navn,
         },
         skalVises:
             (borMedAndreForelder.verdi === ESvar.JA &&
@@ -272,7 +266,7 @@ export const useEøsForBarn = (
         søknadsfelt: andreForelder && andreForelder[andreForelderDataKeySpørsmål.adresse],
         avhengighet: andreForelderAdresseVetIkke,
         feilmeldingSpråkId: 'eøs-om-barn.andreforelderoppholdssted.feilmelding',
-        språkVerdier: { barn: barnetsNavnValue(gjeldendeBarn, intl) },
+        språkVerdier: { barn: gjeldendeBarn.navn },
         skalVises:
             gjeldendeBarn[barnDataKeySpørsmål.andreForelderErDød].svar !== ESvar.JA &&
             !skalSkjuleAndreForelderFelt(gjeldendeBarn),
@@ -285,7 +279,7 @@ export const useEøsForBarn = (
             gjeldendeBarn.andreForelderErDød.svar === ESvar.JA
                 ? 'enkeenkemann.annenforelderarbeidnorge.feilmelding'
                 : 'eøs-om-barn.annenforelderarbeidsperiodenorge.feilmelding',
-        feilmeldingSpråkVerdier: { barn: barnetsNavnValue(gjeldendeBarn, intl) },
+        feilmeldingSpråkVerdier: { barn: gjeldendeBarn.navn },
         skalSkjules: skalSkjuleAndreForelderFelt(gjeldendeBarn),
     });
 
@@ -311,7 +305,7 @@ export const useEøsForBarn = (
             gjeldendeBarn.andreForelderErDød.svar === ESvar.JA
                 ? 'enkeenkemann.andreforelderpensjon.feilmelding'
                 : 'eøs-om-barn.andreforelderpensjon.feilmelding',
-        feilmeldingSpråkVerdier: { barn: barnetsNavnValue(gjeldendeBarn, intl) },
+        feilmeldingSpråkVerdier: { barn: gjeldendeBarn.navn },
         skalSkjules: skalSkjuleAndreForelderFelt(gjeldendeBarn),
     });
 
@@ -337,7 +331,7 @@ export const useEøsForBarn = (
             gjeldendeBarn.andreForelderErDød.svar === ESvar.JA
                 ? 'enkeenkemann.annenforelderytelser.feilmelding'
                 : 'eøs-om-barn.andreforelderutbetalinger.feilmelding',
-        feilmeldingSpråkVerdier: { barn: barnetsNavnValue(gjeldendeBarn, intl) },
+        feilmeldingSpråkVerdier: { barn: gjeldendeBarn.navn },
         skalSkjules: skalSkjuleAndreForelderFelt(gjeldendeBarn),
     });
 

--- a/src/frontend/components/SøknadsSteg/EøsSteg/IdNummer.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/IdNummer.tsx
@@ -14,7 +14,6 @@ import useInputFeltMedUkjent from '../../../hooks/useInputFeltMedUkjent';
 import { IBarnMedISøknad } from '../../../typer/barn';
 import { AlternativtSvarForInput } from '../../../typer/common';
 import { IEøsForBarnFeltTyper, IEøsForSøkerFeltTyper } from '../../../typer/skjema';
-import { barnetsNavnValue } from '../../../utils/barn';
 import { trimWhiteSpace } from '../../../utils/hjelpefunksjoner';
 import { SkjemaCheckbox } from '../../Felleskomponenter/SkjemaCheckbox/SkjemaCheckbox';
 import { SkjemaFeltInput } from '../../Felleskomponenter/SkjemaFeltInput/SkjemaFeltInput';
@@ -84,7 +83,7 @@ export const IdNummer: React.FC<{
                 return feil(felt, <SpråkTekst id={'felles.idnummer-feilformat.feilmelding'} />);
             }
         },
-        ...(barn && { språkVerdier: { barn: barnetsNavnValue(barn, intl) } }),
+        ...(barn && { språkVerdier: { barn: barn.navn } }),
     });
 
     useEffect(() => {
@@ -102,7 +101,7 @@ export const IdNummer: React.FC<{
                             id={spørsmålSpråkId}
                             values={{
                                 land: getName(landAlphaCode, valgtLocale),
-                                ...(barn && { barn: barnetsNavnValue(barn, intl) }),
+                                ...(barn && { barn: barn.navn }),
                             }}
                         />
                     }
@@ -125,7 +124,7 @@ export const IdNummer: React.FC<{
                         labelSpråkTekstId={spørsmålSpråkId}
                         språkValues={{
                             land: getName(landAlphaCode, valgtLocale),
-                            ...(barn && { barn: barnetsNavnValue(barn, intl) }),
+                            ...(barn && { barn: barn.navn }),
                         }}
                         disabled={idNummerUkjent.verdi === ESvar.JA}
                     />

--- a/src/frontend/components/SøknadsSteg/OmBarnaDine/HvilkeBarnCheckboxGruppe.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnaDine/HvilkeBarnCheckboxGruppe.tsx
@@ -1,7 +1,5 @@
 import React, { ChangeEvent, useEffect, useState } from 'react';
 
-import { useIntl } from 'react-intl';
-
 import { Checkbox, CheckboxGruppe } from 'nav-frontend-skjema';
 import { Element } from 'nav-frontend-typografi';
 
@@ -11,7 +9,6 @@ import { Felt } from '@navikt/familie-skjema';
 import { useApp } from '../../../context/AppContext';
 import { barnDataKeySpørsmål } from '../../../typer/barn';
 import { BarnetsId } from '../../../typer/common';
-import { barnetsNavnValue } from '../../../utils/barn';
 import SpråkTekst from '../../Felleskomponenter/SpråkTekst/SpråkTekst';
 
 interface Props {
@@ -36,7 +33,6 @@ const HvilkeBarnCheckboxGruppe: React.FC<Props> = ({
             .filter(barn => barn[søknadsdatafelt].svar === ESvar.JA)
             .map(barn => barn.id)
     );
-    const intl = useIntl();
 
     useEffect(() => {
         skjemafelt.hentNavInputProps(false).onChange(valgteBarn);
@@ -77,7 +73,7 @@ const HvilkeBarnCheckboxGruppe: React.FC<Props> = ({
                     return (
                         <Checkbox
                             key={index}
-                            label={barnetsNavnValue(barnISøknad, intl)}
+                            label={barnISøknad.navn}
                             defaultChecked={!!valgteBarn.find(barnId => barnId === barnISøknad.id)}
                             id={`${skjemafelt.id}${barnISøknad.id}`}
                             onChange={event => oppdaterListeMedBarn(event, barnISøknad.id)}

--- a/src/frontend/components/SøknadsSteg/OmBarnet/AndreForelder.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/AndreForelder.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { useIntl } from 'react-intl';
-
 import { ESvar } from '@navikt/familie-form-elements';
 import { ISkjema } from '@navikt/familie-skjema';
 
@@ -11,7 +9,6 @@ import { andreForelderDataKeySpørsmål, IAndreForelder, IBarnMedISøknad } from
 import { AlternativtSvarForInput } from '../../../typer/common';
 import { IArbeidsperiode, IPensjonsperiode } from '../../../typer/perioder';
 import { IOmBarnetUtvidetFeltTyper } from '../../../typer/skjema';
-import { barnetsNavnValue } from '../../../utils/barn';
 import { dagensDato } from '../../../utils/dato';
 import { Arbeidsperiode } from '../../Felleskomponenter/Arbeidsperiode/Arbeidsperiode';
 import Datovelger from '../../Felleskomponenter/Datovelger/Datovelger';
@@ -48,8 +45,6 @@ const AndreForelder: React.FC<{
     fjernPensjonsperiode,
 }) => {
     const { erEøsLand } = useEøs();
-    const intl = useIntl();
-    const barnetsNavn = barnetsNavnValue(barn, intl);
     const barnMedSammeForelder: IBarnMedISøknad | undefined = andreBarnSomErFyltUt.find(
         annetBarn => annetBarn.id === skjema.felter.sammeForelderSomAnnetBarn.verdi
     );
@@ -62,7 +57,7 @@ const AndreForelder: React.FC<{
                     <SammeSomAnnetBarnRadio
                         andreBarnSomErFyltUt={andreBarnSomErFyltUt}
                         skjema={skjema}
-                        barnetsNavn={barnetsNavn}
+                        barnetsNavn={barn.navn}
                     />
                 )}
                 {!skjema.felter.sammeForelderSomAnnetBarn.erSynlig ||
@@ -205,7 +200,7 @@ const AndreForelder: React.FC<{
                                                 ]
                                             }
                                             inkluderVetIkke={true}
-                                            språkValues={{ navn: barnetsNavn }}
+                                            språkValues={{ navn: barn.navn }}
                                         />
                                         <LandDropdown
                                             felt={
@@ -237,7 +232,7 @@ const AndreForelder: React.FC<{
                                                         ? 'enkeenkemann.arbeid-utland.eøs-info'
                                                         : 'ombarnet.andre-forelder.arbeid-utland.eøs-info'
                                                 }
-                                                språkValues={{ navn: barnetsNavn }}
+                                                språkValues={{ navn: barn.navn }}
                                                 dynamisk
                                             />
                                         )}
@@ -253,7 +248,7 @@ const AndreForelder: React.FC<{
                                                 ]
                                             }
                                             inkluderVetIkke={true}
-                                            språkValues={{ navn: barnetsNavn }}
+                                            språkValues={{ navn: barn.navn }}
                                         />
                                         <LandDropdown
                                             felt={skjema.felter.andreForelderPensjonHvilketLand}
@@ -270,7 +265,7 @@ const AndreForelder: React.FC<{
                                                             ].id
                                                         ]
                                                     }
-                                                    values={{ barn: barnetsNavn }}
+                                                    values={{ barn: barn.navn }}
                                                 />
                                             }
                                         />
@@ -283,7 +278,7 @@ const AndreForelder: React.FC<{
                                                         ? 'enkeenkemann.utenlandspensjon.eøs-info'
                                                         : 'ombarnet.andre-forelder.utenlandspensjon.eøs-info'
                                                 }
-                                                språkValues={{ navn: barnetsNavn }}
+                                                språkValues={{ navn: barn.navn }}
                                                 dynamisk
                                             />
                                         )}

--- a/src/frontend/components/SøknadsSteg/OmBarnet/OmBarnet.test.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/OmBarnet.test.tsx
@@ -283,7 +283,7 @@ describe('OmBarnet', () => {
 
         expect(mockedHistoryArray[mockedHistoryArray.length - 1]).toEqual('/om-barnet/barn-1');
 
-        const jensTittel = await findByText('Om JENS');
+        const jensTittel = await findByText('Om Jens');
         expect(jensTittel).toBeInTheDocument();
 
         const gåVidere = await findByText(/felles.navigasjon.gå-videre/);
@@ -310,7 +310,7 @@ describe('OmBarnet', () => {
 
         expect(mockedHistoryArray[mockedHistoryArray.length - 1]).toEqual('/om-barnet/barn-1');
 
-        const jensTittel = await findByText('Om JENS');
+        const jensTittel = await findByText('Om Jens');
         expect(jensTittel).toBeInTheDocument();
 
         const gåVidere = await findByText(/felles.navigasjon.gå-videre/);

--- a/src/frontend/components/SøknadsSteg/OmBarnet/OmBarnet.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/OmBarnet.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { useIntl } from 'react-intl';
 import styled from 'styled-components';
 
 import { Normaltekst } from 'nav-frontend-typografi';
@@ -11,7 +10,6 @@ import { useApp } from '../../../context/AppContext';
 import { BarnetsId } from '../../../typer/common';
 import { ESivilstand } from '../../../typer/kontrakt/generelle';
 import { Årsak } from '../../../typer/utvidet';
-import { barnetsNavnValue } from '../../../utils/barn';
 import { dagensDato } from '../../../utils/dato';
 import AlertStripe from '../../Felleskomponenter/AlertStripe/AlertStripe';
 import Datovelger from '../../Felleskomponenter/Datovelger/Datovelger';
@@ -52,16 +50,10 @@ const OmBarnet: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
         leggTilBarnetrygdsperiode,
         fjernBarnetrygdsperiode,
     } = useOmBarnet(barnetsId);
-    const intl = useIntl();
 
     return barn ? (
         <Steg
-            tittel={
-                <SpråkTekst
-                    id={'ombarnet.sidetittel'}
-                    values={{ navn: barnetsNavnValue(barn, intl) }}
-                />
-            }
+            tittel={<SpråkTekst id={'ombarnet.sidetittel'} values={{ navn: barn.navn }} />}
             skjema={{
                 validerFelterOgVisFeilmelding,
                 valideringErOk,
@@ -117,7 +109,7 @@ const OmBarnet: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
                         spørsmålTekstId={
                             omBarnetSpørsmålSpråkId[OmBarnetSpørsmålsId.borFastMedSøker]
                         }
-                        språkValues={{ navn: barnetsNavnValue(barn, intl) }}
+                        språkValues={{ navn: barn.navn }}
                     />
                     {skjema.felter.borFastMedSøker.verdi === ESvar.JA && !barn.borMedSøker && (
                         <VedleggNotis språkTekstId={'ombarnet.bor-fast.vedleggsinfo'} dynamisk />
@@ -133,7 +125,7 @@ const OmBarnet: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
                                         OmBarnetSpørsmålsId.skriftligAvtaleOmDeltBosted
                                     ]
                                 }
-                                språkValues={{ navn: barnetsNavnValue(barn, intl) }}
+                                språkValues={{ navn: barn.navn }}
                             />
                             {skjema.felter.skriftligAvtaleOmDeltBosted.verdi === ESvar.JA && (
                                 <VedleggNotis
@@ -151,7 +143,7 @@ const OmBarnet: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
                         skjema={skjema}
                         felt={skjema.felter.søkerForTidsrom}
                         spørsmålTekstId={'ombarnet.søker-for-periode.spm'}
-                        språkValues={{ navn: barnetsNavnValue(barn, intl) }}
+                        språkValues={{ navn: barn.navn }}
                         tilleggsinfo={
                             <AlertStripe>
                                 <SpråkTekst id={'ombarnet.søker-for-periode.alert'} />
@@ -227,7 +219,7 @@ const OmBarnet: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
                                 OmBarnetSpørsmålsId.søkerHarBoddMedAndreForelder
                             ]
                         }
-                        språkValues={{ navn: barnetsNavnValue(barn, intl) }}
+                        språkValues={{ navn: barn.navn }}
                     />
                     {skjema.felter.søkerFlyttetFraAndreForelderDato.erSynlig && (
                         <KomponentGruppe inline dynamisk>

--- a/src/frontend/components/SøknadsSteg/OmBarnet/Oppfølgningsspørsmål.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/Oppfølgningsspørsmål.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { useIntl } from 'react-intl';
-
 import { Element } from 'nav-frontend-typografi';
 
 import { ESvar } from '@navikt/familie-form-elements';
@@ -12,7 +10,6 @@ import { useFeatureToggles } from '../../../context/FeatureToggleContext';
 import { barnDataKeySpørsmål, IBarnMedISøknad } from '../../../typer/barn';
 import { IEøsBarnetrygdsperiode, IUtenlandsperiode } from '../../../typer/perioder';
 import { IOmBarnetUtvidetFeltTyper } from '../../../typer/skjema';
-import { barnetsNavnValue } from '../../../utils/barn';
 import { dagensDato, erSammeDatoSomDagensDato, morgendagensDato } from '../../../utils/dato';
 import AlertStripe from '../../Felleskomponenter/AlertStripe/AlertStripe';
 import { Barnetrygdperiode } from '../../Felleskomponenter/Barnetrygdperiode/Barnetrygdperiode';
@@ -52,7 +49,6 @@ const Oppfølgningsspørsmål: React.FC<{
     fjernBarnetrygdsperiode,
     registrerteEøsBarnetrygdsperioder,
 }) => {
-    const intl = useIntl();
     const { erÅpen: utenlandsmodalErÅpen, toggleModal: toggleUtenlandsmodal } = useModal();
     const { erEøsLand } = useEøs();
     const { toggles } = useFeatureToggles();
@@ -67,7 +63,7 @@ const Oppfølgningsspørsmål: React.FC<{
                 <KomponentGruppe>
                     <Informasjonsbolk
                         tittelId={'ombarnet.fosterbarn'}
-                        språkValues={{ navn: barnetsNavnValue(barn, intl) }}
+                        språkValues={{ navn: barn.navn }}
                     >
                         <VedleggNotis språkTekstId={'ombarnet.fosterbarn.vedleggsinfo'} />
                     </Informasjonsbolk>
@@ -75,10 +71,7 @@ const Oppfølgningsspørsmål: React.FC<{
             )}
 
             {barn[barnDataKeySpørsmål.oppholderSegIInstitusjon].svar === ESvar.JA && (
-                <SkjemaFieldset
-                    tittelId={'ombarnet.institusjon'}
-                    språkValues={{ navn: barnetsNavnValue(barn, intl) }}
-                >
+                <SkjemaFieldset tittelId={'ombarnet.institusjon'} språkValues={{ navn: barn.navn }}>
                     <SkjemaCheckbox
                         labelSpråkTekstId={
                             omBarnetSpørsmålSpråkId[OmBarnetSpørsmålsId.institusjonIUtland]
@@ -159,7 +152,7 @@ const Oppfølgningsspørsmål: React.FC<{
             {barn[barnDataKeySpørsmål.boddMindreEnn12MndINorge].svar === ESvar.JA && (
                 <SkjemaFieldset
                     tittelId={'ombarnet.opplystatbarnutlandopphold.info'}
-                    språkValues={{ navn: barnetsNavnValue(barn, intl) }}
+                    språkValues={{ navn: barn.navn }}
                 >
                     {utenlandsperioder.map((periode, index) => (
                         <UtenlandsperiodeOppsummering
@@ -175,7 +168,7 @@ const Oppfølgningsspørsmål: React.FC<{
                         <Element>
                             <SpråkTekst
                                 id={'ombarnet.flereopphold.spm'}
-                                values={{ barn: barnetsNavnValue(barn, intl) }}
+                                values={{ barn: barn.navn }}
                             />
                         </Element>
                     )}
@@ -201,7 +194,7 @@ const Oppfølgningsspørsmål: React.FC<{
                                         OmBarnetSpørsmålsId.planleggerÅBoINorge12Mnd
                                     ]
                                 }
-                                språkValues={{ barn: barnetsNavnValue(barn, intl) }}
+                                språkValues={{ barn: barn.navn }}
                             />
                             {skjema.felter.planleggerÅBoINorge12Mnd.verdi === ESvar.NEI && (
                                 <AlertStripe type={'advarsel'} dynamisk>
@@ -217,7 +210,7 @@ const Oppfølgningsspørsmål: React.FC<{
             {barn[barnDataKeySpørsmål.barnetrygdFraAnnetEøsland].svar === ESvar.JA && (
                 <SkjemaFieldset
                     tittelId={'ombarnet.barnetrygd-eøs'}
-                    språkValues={{ navn: barnetsNavnValue(barn, intl) }}
+                    språkValues={{ navn: barn.navn }}
                 >
                     {toggles.EØS_KOMPLETT ? (
                         <KomponentGruppe>

--- a/src/frontend/components/SøknadsSteg/OmBarnet/SammeSomAnnetBarnRadio.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/SammeSomAnnetBarnRadio.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { useIntl } from 'react-intl';
 import styled from 'styled-components';
 
 import { RadioPanelGruppe } from 'nav-frontend-skjema';
@@ -11,7 +10,6 @@ import { ISkjema } from '@navikt/familie-skjema';
 import { IBarnMedISøknad } from '../../../typer/barn';
 import { AlternativtSvarForInput } from '../../../typer/common';
 import { IOmBarnetUtvidetFeltTyper } from '../../../typer/skjema';
-import { barnetsNavnValue } from '../../../utils/barn';
 import SpråkTekst from '../../Felleskomponenter/SpråkTekst/SpråkTekst';
 import { OmBarnetSpørsmålsId, omBarnetSpørsmålSpråkId } from './spørsmål';
 
@@ -28,14 +26,12 @@ const SammeSomAnnetBarnRadio: React.FC<{
 }> = ({ andreBarnSomErFyltUt, skjema, barnetsNavn }) => {
     const felt = skjema.felter.sammeForelderSomAnnetBarn;
 
-    const intl = useIntl();
-
     const radios = andreBarnSomErFyltUt
         .map(barn => ({
             label: (
                 <SpråkTekst
                     id={'ombarnet.svaralternativ.samme-som-barn'}
-                    values={{ navn: barnetsNavnValue(barn, intl) }}
+                    values={{ navn: barn.navn }}
                 />
             ),
             value: barn.id,

--- a/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.tsx
@@ -1,7 +1,5 @@
 import React, { useEffect, useState } from 'react';
 
-import { useIntl } from 'react-intl';
-
 import { ESvar } from '@navikt/familie-form-elements';
 import { feil, FeltState, ISkjema, ok, useFelt, useSkjema } from '@navikt/familie-skjema';
 
@@ -38,7 +36,6 @@ import { IOmBarnetUtvidetFeltTyper } from '../../../typer/skjema';
 import { Årsak } from '../../../typer/utvidet';
 import { erNorskPostnummer, valideringAdresse } from '../../../utils/adresse';
 import {
-    barnetsNavnValue,
     filtrerteRelevanteIdNummerForBarn,
     genererInitiellAndreForelder,
     nullstilteEøsFelterForBarn,
@@ -83,7 +80,6 @@ export const useOmBarnet = (
     fjernBarnetrygdsperiode: (periode: IEøsBarnetrygdsperiode) => void;
 } => {
     const { søknad, settSøknad, erUtvidet } = useApp();
-    const intl = useIntl();
     const { skalTriggeEøsForBarn, barnSomTriggerEøs, settBarnSomTriggerEøs, erEøsLand } = useEøs();
 
     const { toggles } = useFeatureToggles();
@@ -217,7 +213,7 @@ export const useOmBarnet = (
     const planleggerÅBoINorge12Mnd = useJaNeiSpmFelt({
         søknadsfelt: gjeldendeBarn[barnDataKeySpørsmål.planleggerÅBoINorge12Mnd],
         feilmeldingSpråkId: 'ombarnet.oppholdtsammenhengende.feilmelding',
-        feilmeldingSpråkVerdier: { barn: barnetsNavnValue(gjeldendeBarn, intl) },
+        feilmeldingSpråkVerdier: { barn: gjeldendeBarn.navn },
         skalSkjules:
             !skalFeltetVises(barnDataKeySpørsmål.boddMindreEnn12MndINorge) ||
             flyttetPermanentFraNorge(utenlandsperioder) ||
@@ -304,7 +300,7 @@ export const useOmBarnet = (
                       felt,
                       <SpråkTekst
                           id={'ombarnet.hvemerandreforelder.feilmelding'}
-                          values={{ barn: barnetsNavnValue(gjeldendeBarn, intl) }}
+                          values={{ barn: gjeldendeBarn.navn }}
                       />
                   );
         },
@@ -418,7 +414,7 @@ export const useOmBarnet = (
                     : undefined,
         },
         skalSkjules: andreForelderNavnUkjent.verdi === ESvar.JA,
-        feilmeldingSpråkVerdier: { navn: barnetsNavnValue(gjeldendeBarn, intl) },
+        feilmeldingSpråkVerdier: { navn: gjeldendeBarn.navn },
     });
 
     const andreForelderArbeidUtlandetHvilketLand = useLanddropdownFeltMedJaNeiAvhengighet({
@@ -471,7 +467,7 @@ export const useOmBarnet = (
                     : undefined,
         },
         skalSkjules: andreForelderNavnUkjent.verdi === ESvar.JA,
-        feilmeldingSpråkVerdier: { navn: barnetsNavnValue(gjeldendeBarn, intl) },
+        feilmeldingSpråkVerdier: { navn: gjeldendeBarn.navn },
     });
 
     const andreForelderPensjonHvilketLand = useLanddropdownFeltMedJaNeiAvhengighet({
@@ -510,7 +506,7 @@ export const useOmBarnet = (
     const borFastMedSøker = useJaNeiSpmFelt({
         søknadsfelt: gjeldendeBarn[barnDataKeySpørsmål.borFastMedSøker],
         feilmeldingSpråkId: 'ombarnet.bor-fast.feilmelding',
-        feilmeldingSpråkVerdier: { navn: barnetsNavnValue(gjeldendeBarn, intl) },
+        feilmeldingSpråkVerdier: { navn: gjeldendeBarn.navn },
     });
 
     const skriftligAvtaleOmDeltBosted = useJaNeiSpmFelt({
@@ -519,7 +515,7 @@ export const useOmBarnet = (
         skalSkjules:
             !andreForelder ||
             gjeldendeBarn[barnDataKeySpørsmål.andreForelderErDød].svar === ESvar.JA,
-        feilmeldingSpråkVerdier: { navn: barnetsNavnValue(gjeldendeBarn, intl) },
+        feilmeldingSpråkVerdier: { navn: gjeldendeBarn.navn },
     });
 
     /*--- SØKER FOR PERIODE ---*/
@@ -534,7 +530,7 @@ export const useOmBarnet = (
                   }
                 : undefined,
         },
-        feilmeldingSpråkVerdier: { navn: barnetsNavnValue(gjeldendeBarn, intl) },
+        feilmeldingSpråkVerdier: { navn: gjeldendeBarn.navn },
     });
 
     const søkerForTidsromStartdato = useDatovelgerFeltMedJaNeiAvhengighet({
@@ -594,7 +590,7 @@ export const useOmBarnet = (
                 : undefined,
         },
         skalSkjules: !erUtvidet || !andreForelder,
-        feilmeldingSpråkVerdier: { navn: barnetsNavnValue(gjeldendeBarn, intl) },
+        feilmeldingSpråkVerdier: { navn: gjeldendeBarn.navn },
     });
 
     const borMedAndreForelderCheckbox = useFelt<ESvar>({

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsAndreForelderOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsAndreForelderOppsummering.tsx
@@ -13,7 +13,6 @@ import {
 } from '../../../../../typer/barn';
 import { AlternativtSvarForInput } from '../../../../../typer/common';
 import { IEøsForBarnFeltTyper } from '../../../../../typer/skjema';
-import { barnetsNavnValue } from '../../../../../utils/barn';
 import { ArbeidsperiodeOppsummering } from '../../../../Felleskomponenter/Arbeidsperiode/ArbeidsperiodeOppsummering';
 import { PensjonsperiodeOppsummering } from '../../../../Felleskomponenter/Pensjonsmodal/PensjonsperiodeOppsummering';
 import SpråkTekst from '../../../../Felleskomponenter/SpråkTekst/SpråkTekst';
@@ -31,7 +30,6 @@ const EøsAndreForelderOppsummering: React.FC<{
 }> = ({ barn, andreForelder, skjema, settIdNummerFelter }) => {
     const intl = useIntl();
     const { formatMessage } = intl;
-    const barnetsNavn = barnetsNavnValue(barn, intl);
     const andreForelderErDød = barn[barnDataKeySpørsmål.andreForelderErDød].svar === ESvar.JA;
 
     const jaNeiSpmOppsummering = (andreForelderDataKeySpm: andreForelderDataKeySpørsmål) =>
@@ -40,7 +38,7 @@ const EøsAndreForelderOppsummering: React.FC<{
                 tittel={
                     <SpråkTekst
                         id={eøsBarnSpørsmålSpråkId[barn.andreForelder[andreForelderDataKeySpm].id]}
-                        values={{ barn: barnetsNavn }}
+                        values={{ barn: barn.navn }}
                     />
                 }
                 søknadsvar={barn.andreForelder[andreForelderDataKeySpm].svar}
@@ -61,7 +59,7 @@ const EøsAndreForelderOppsummering: React.FC<{
                         tittel={
                             <SpråkTekst
                                 id={eøsBarnSpørsmålSpråkId[andreForelder.adresse.id]}
-                                values={{ barn: barnetsNavn }}
+                                values={{ barn: barn.navn }}
                             />
                         }
                         søknadsvar={

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsBarnOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsBarnOppsummering.tsx
@@ -5,7 +5,6 @@ import { useIntl } from 'react-intl';
 import { useSteg } from '../../../../../context/StegContext';
 import { IBarnMedISøknad } from '../../../../../typer/barn';
 import { AlternativtSvarForInput } from '../../../../../typer/common';
-import { barnetsNavnValue } from '../../../../../utils/barn';
 import { toSlektsforholdSpråkId } from '../../../../../utils/språk';
 import SpråkTekst from '../../../../Felleskomponenter/SpråkTekst/SpråkTekst';
 import SamletIdNummerForBarn from '../../../EøsSteg/Barn/SamletIdNummerForBarn';
@@ -28,16 +27,14 @@ const EøsBarnOppsummering: React.FC<Props> = ({ settFeilAnchors, nummer, barn }
     const eøsForBarnHook = useEøsForBarn(barn.id);
 
     const { formatMessage } = useIntl();
-    const intl = useIntl();
-    const barnetsNavn = barnetsNavnValue(barn, intl);
 
     const tittelSpm = (spørsmålId: string) => (
-        <SpråkTekst id={eøsBarnSpørsmålSpråkId[spørsmålId]} values={{ barn: barnetsNavn }} />
+        <SpråkTekst id={eøsBarnSpørsmålSpråkId[spørsmålId]} values={{ barn: barn.navn }} />
     );
     return (
         <Oppsummeringsbolk
             tittel={'eøs-om-barn.oppsummering.tittel'}
-            språkValues={{ nummer, barn: barnetsNavn }}
+            språkValues={{ nummer, barn: barn.navn }}
             steg={hentStegObjektForBarnEøs(barn)}
             skjemaHook={eøsForBarnHook}
             settFeilAnchors={settFeilAnchors}

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnaOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnaOppsummering.tsx
@@ -1,14 +1,11 @@
 import React from 'react';
 
-import { useIntl } from 'react-intl';
-
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { useApp } from '../../../../context/AppContext';
 import { useRoutes } from '../../../../context/RoutesContext';
 import { barnDataKeySpørsmål } from '../../../../typer/barn';
 import { RouteEnum } from '../../../../typer/routes';
-import { barnetsNavnValue } from '../../../../utils/barn';
 import SpråkTekst from '../../../Felleskomponenter/SpråkTekst/SpråkTekst';
 import { OmBarnaDineSpørsmålId, omBarnaDineSpørsmålSpråkId } from '../../OmBarnaDine/spørsmål';
 import { useOmBarnaDine } from '../../OmBarnaDine/useOmBarnaDine';
@@ -21,7 +18,6 @@ interface Props {
 }
 
 const OmBarnaOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
-    const intl = useIntl();
     const { søknad } = useApp();
     const { hentRouteObjektForRouteEnum } = useRoutes();
     const omBarnaDineHook = useOmBarnaDine();
@@ -29,7 +25,7 @@ const OmBarnaOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
     const genererListeMedBarn = (søknadDatafelt: barnDataKeySpørsmål) =>
         søknad.barnInkludertISøknaden
             .filter(barn => barn[søknadDatafelt].svar === ESvar.JA)
-            .map(filtrertBarn => barnetsNavnValue(filtrertBarn, intl))
+            .map(filtrertBarn => filtrertBarn.navn)
             .join(', ');
 
     return (

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnet/AndreForelderOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnet/AndreForelderOppsummering.tsx
@@ -13,7 +13,6 @@ import {
     IBarnMedISøknad,
 } from '../../../../../typer/barn';
 import { AlternativtSvarForInput } from '../../../../../typer/common';
-import { barnetsNavnValue } from '../../../../../utils/barn';
 import { formaterDato } from '../../../../../utils/dato';
 import { landkodeTilSpråk } from '../../../../../utils/språk';
 import { formaterDatoMedUkjent } from '../../../../../utils/visning';
@@ -32,7 +31,6 @@ const AndreForelderOppsummering: React.FC<{
     const { formatMessage } = intl;
     const [valgtLocale] = useSprakContext();
     const { toggles } = useFeatureToggles();
-    const barnetsNavn = barnetsNavnValue(barn, intl);
 
     return (
         <>
@@ -102,7 +100,7 @@ const AndreForelderOppsummering: React.FC<{
                                             .id
                                     ]
                                 }
-                                values={{ navn: barnetsNavn }}
+                                values={{ navn: barn.navn }}
                             />
                         }
                         søknadsvar={andreForelder[andreForelderDataKeySpørsmål.arbeidUtlandet].svar}
@@ -160,7 +158,7 @@ const AndreForelderOppsummering: React.FC<{
                                         andreForelder[andreForelderDataKeySpørsmål.pensjonUtland].id
                                     ]
                                 }
-                                values={{ navn: barnetsNavn }}
+                                values={{ navn: barn.navn }}
                             />
                         }
                         søknadsvar={andreForelder[andreForelderDataKeySpørsmål.pensjonUtland].svar}
@@ -198,8 +196,8 @@ const AndreForelderOppsummering: React.FC<{
                                             ]
                                         }
                                         values={{
-                                            navn: barnetsNavn,
-                                            barn: barnetsNavn,
+                                            navn: barn.navn,
+                                            barn: barn.navn,
                                         }}
                                     />
                                 }
@@ -222,7 +220,7 @@ const AndreForelderOppsummering: React.FC<{
                                         OmBarnetSpørsmålsId.søkerHarBoddMedAndreForelder
                                     ]
                                 }
-                                values={{ navn: barnetsNavn }}
+                                values={{ navn: barn.navn }}
                             />
                         }
                         søknadsvar={

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnet/OmBarnetOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnet/OmBarnetOppsummering.tsx
@@ -13,7 +13,6 @@ import {
     IBarnMedISøknad,
 } from '../../../../../typer/barn';
 import { AlternativtSvarForInput } from '../../../../../typer/common';
-import { barnetsNavnValue } from '../../../../../utils/barn';
 import { formaterDato } from '../../../../../utils/dato';
 import { landkodeTilSpråk } from '../../../../../utils/språk';
 import { formaterDatoMedUkjent } from '../../../../../utils/visning';
@@ -45,7 +44,7 @@ const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, nummer, barn, 
     return (
         <Oppsummeringsbolk
             tittel={'oppsummering.deltittel.ombarnet'}
-            språkValues={{ nummer, navn: barnetsNavnValue(barn, intl) }}
+            språkValues={{ nummer, navn: barn.navn }}
             key={index}
             steg={hentStegObjektForBarn(barn)}
             skjemaHook={omBarnetHook}
@@ -53,22 +52,14 @@ const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, nummer, barn, 
         >
             {barn[barnDataKeySpørsmål.erFosterbarn].svar === ESvar.JA && (
                 <OppsummeringFelt
-                    tittel={
-                        <SpråkTekst
-                            id={'ombarnet.fosterbarn'}
-                            values={{ navn: barnetsNavnValue(barn, intl) }}
-                        />
-                    }
+                    tittel={<SpråkTekst id={'ombarnet.fosterbarn'} values={{ navn: barn.navn }} />}
                 />
             )}
             {barn[barnDataKeySpørsmål.oppholderSegIInstitusjon].svar === ESvar.JA && (
                 <StyledOppsummeringsFeltGruppe>
                     <OppsummeringFelt
                         tittel={
-                            <SpråkTekst
-                                id={'ombarnet.institusjon'}
-                                values={{ navn: barnetsNavnValue(barn, intl) }}
-                            />
+                            <SpråkTekst id={'ombarnet.institusjon'} values={{ navn: barn.navn }} />
                         }
                     />
 
@@ -169,7 +160,7 @@ const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, nummer, barn, 
                         tittel={
                             <SpråkTekst
                                 id={'ombarnet.opplystatbarnutlandopphold.info'}
-                                values={{ navn: barnetsNavnValue(barn, intl) }}
+                                values={{ navn: barn.navn }}
                             />
                         }
                     />
@@ -190,7 +181,7 @@ const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, nummer, barn, 
                                             OmBarnetSpørsmålsId.planleggerÅBoINorge12Mnd
                                         ]
                                     }
-                                    values={{ barn: barnetsNavnValue(barn, intl) }}
+                                    values={{ barn: barn.navn }}
                                 />
                             }
                             søknadsvar={barn[barnDataKeySpørsmål.planleggerÅBoINorge12Mnd].svar}
@@ -205,7 +196,7 @@ const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, nummer, barn, 
                         tittel={
                             <SpråkTekst
                                 id={'ombarnet.barnetrygd-eøs'}
-                                values={{ navn: barnetsNavnValue(barn, intl) }}
+                                values={{ navn: barn.navn }}
                             />
                         }
                     />
@@ -269,7 +260,7 @@ const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, nummer, barn, 
                                     key={`barnetrygdperiode-${index}`}
                                     nummer={index + 1}
                                     barnetrygdsperiode={periode}
-                                    barnetsNavn={barnetsNavnValue(barn, intl)}
+                                    barnetsNavn={barn.navn}
                                 />
                             ))}
                         </>
@@ -303,7 +294,7 @@ const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, nummer, barn, 
                     tittel={
                         <SpråkTekst
                             id={omBarnetSpørsmålSpråkId[OmBarnetSpørsmålsId.borFastMedSøker]}
-                            values={{ navn: barnetsNavnValue(barn, intl) }}
+                            values={{ navn: barn.navn }}
                         />
                     }
                     søknadsvar={barn[barnDataKeySpørsmål.borFastMedSøker].svar}
@@ -318,7 +309,7 @@ const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, nummer, barn, 
                                         OmBarnetSpørsmålsId.skriftligAvtaleOmDeltBosted
                                     ]
                                 }
-                                values={{ navn: barnetsNavnValue(barn, intl) }}
+                                values={{ navn: barn.navn }}
                             />
                         }
                         søknadsvar={
@@ -334,7 +325,7 @@ const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, nummer, barn, 
                     tittel={
                         <SpråkTekst
                             id={omBarnetSpørsmålSpråkId[OmBarnetSpørsmålsId.søkerForTidsrom]}
-                            values={{ navn: barnetsNavnValue(barn, intl) }}
+                            values={{ navn: barn.navn }}
                         />
                     }
                     søknadsvar={barn[barnDataKeySpørsmål.søkerForTidsrom].svar}

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/VelgBarnOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/VelgBarnOppsummering.tsx
@@ -5,7 +5,6 @@ import { useIntl } from 'react-intl';
 import { useApp } from '../../../../context/AppContext';
 import { useRoutes } from '../../../../context/RoutesContext';
 import { RouteEnum } from '../../../../typer/routes';
-import { barnetsNavnValue } from '../../../../utils/barn';
 import { hentBostedSpråkId } from '../../../../utils/språk';
 import SpråkTekst from '../../../Felleskomponenter/SpråkTekst/SpråkTekst';
 import { VelgBarnSpørsmålId, velgBarnSpørsmålSpråkId } from '../../VelgBarn/spørsmål';
@@ -21,7 +20,6 @@ interface Props {
 const VelgBarnOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
     const { formatMessage } = useIntl();
     const { søknad } = useApp();
-    const intl = useIntl();
     const { hentRouteObjektForRouteEnum } = useRoutes();
     const velgBarnHook = useVelgBarn();
 
@@ -45,7 +43,7 @@ const VelgBarnOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
                                 ? formatMessage({
                                       id: 'hvilkebarn.barn.bosted.adressesperre',
                                   })
-                                : barnetsNavnValue(barn, intl)
+                                : barn.navn
                         }
                     />
 

--- a/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/Barnekort.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/Barnekort.tsx
@@ -126,15 +126,11 @@ const Barnekort: React.FC<IBarnekortProps> = ({
                 )}
                 <StyledCheckbox
                     checked={erMedISøknad}
-                    label={
-                        <SpråkTekst
-                            id={
-                                erUtvidet
-                                    ? 'hvilkebarn-utvidet.barn.søk-om.spm'
-                                    : 'hvilkebarn.barn.søk-om.spm'
-                            }
-                        />
-                    }
+                    label={formatMessage({
+                        id: erUtvidet
+                            ? 'hvilkebarn-utvidet.barn.søk-om.spm'
+                            : 'hvilkebarn.barn.søk-om.spm',
+                    })}
                     aria-label={
                         formatMessage({
                             id: erUtvidet

--- a/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.test.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.test.tsx
@@ -51,6 +51,7 @@ const fraPdl: Partial<IBarnRespons> = {
 
 const fraPdlSomIBarnMedISøknad: Partial<IBarnMedISøknad> = {
     ...fraPdl,
+    navn: fraPdl.navn ?? 'ukjent',
     id: 'random-id-2',
     barnetrygdFraEøslandHvilketLand: {
         id: OmBarnetSpørsmålsId.barnetrygdFraEøslandHvilketLand,

--- a/src/frontend/context/AppContext.ts
+++ b/src/frontend/context/AppContext.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 import createUseContext from 'constate';
 import { Alpha3Code } from 'i18n-iso-countries';
+import { useIntl } from 'react-intl';
 
 import { useSprakContext } from '@navikt/familie-sprakvelger';
 import {
@@ -29,6 +30,7 @@ import { hentSluttbrukerFraPdl } from './pdl';
 
 const [AppProvider, useApp] = createUseContext(() => {
     const [valgtLocale] = useSprakContext();
+    const intl = useIntl();
     const { axiosRequest, lasterRessurser } = useLastRessurserContext();
     const { innloggetStatus } = useInnloggetContext();
     const [sluttbruker, settSluttbruker] = useState(byggTomRessurs<ISøkerRespons>());
@@ -86,7 +88,7 @@ const [AppProvider, useApp] = createUseContext(() => {
                             ...søknad.søker,
                             navn: ressurs.data.navn,
                             statsborgerskap: ressurs.data.statsborgerskap,
-                            barn: mapBarnResponsTilBarn(ressurs.data.barn),
+                            barn: mapBarnResponsTilBarn(ressurs.data.barn, intl),
                             ident: ressurs.data.ident,
                             adresse: ressurs.data.adresse,
                             sivilstand: ressurs.data.sivilstand,

--- a/src/frontend/hooks/useSendInnSkjema.tsx
+++ b/src/frontend/hooks/useSendInnSkjema.tsx
@@ -1,5 +1,3 @@
-import { IntlShape, useIntl } from 'react-intl';
-
 import { useSprakContext } from '@navikt/familie-sprakvelger';
 import { RessursStatus } from '@navikt/familie-typer';
 
@@ -24,11 +22,10 @@ export const useSendInnSkjema = (): {
     const { axiosRequest, søknad, settInnsendingStatus, settSisteModellVersjon } = useApp();
     const { soknadApi } = Miljø();
     const [valgtSpråk] = useSprakContext();
-    const intl: IntlShape = useIntl();
 
     const sendInnSkjema = async (): Promise<[boolean, ISøknadKontrakt]> => {
         settInnsendingStatus({ status: RessursStatus.HENTER });
-        const formatert = dataISøknadKontraktFormat(intl, valgtSpråk, søknad);
+        const formatert = dataISøknadKontraktFormat(valgtSpråk, søknad);
 
         const res = await axiosRequest<IKvittering, ISøknadKontrakt>({
             url: `${soknadApi}/soknad/v6`,
@@ -53,7 +50,7 @@ export const useSendInnSkjema = (): {
     const sendInnSkjemaV7 = async (): Promise<[boolean, ISøknadKontraktV7]> => {
         settInnsendingStatus({ status: RessursStatus.HENTER });
 
-        const formatert: ISøknadKontraktV7 = dataISøknadKontraktFormatV7(intl, valgtSpråk, søknad);
+        const formatert: ISøknadKontraktV7 = dataISøknadKontraktFormatV7(valgtSpråk, søknad);
 
         const res = await sendInn<ISøknadKontraktV7>(
             formatert,

--- a/src/frontend/hooks/useSendInnSkjemaTest/test-data/testdata1.ts
+++ b/src/frontend/hooks/useSendInnSkjemaTest/test-data/testdata1.ts
@@ -7,7 +7,7 @@ export const testdata1: TilKontraktTestData = {
         barnInkludertISøknaden: [
             {
                 id: '136f8dd4-e4f0-42b6-aa77-403de54a1650',
-                navn: null,
+                navn: 'Barn 234567 89876',
                 ident: '23456789876',
                 alder: '13',
                 borMedSøker: false,
@@ -236,7 +236,7 @@ export const testdata1: TilKontraktTestData = {
             barn: [
                 {
                     id: '136f8dd4-e4f0-42b6-aa77-403de54a1650',
-                    navn: null,
+                    navn: 'Barn 234567 89876',
                     ident: '23456789876',
                     alder: '13',
                     borMedSøker: false,
@@ -625,9 +625,9 @@ export const testdata1: TilKontraktTestData = {
                     },
                     pensjonUtland: {
                         label: {
-                            en: "Does BARN 234567 89876's other parent receive, or have they received a pension from abroad?",
-                            nb: 'Får eller har den andre forelderen til BARN 234567 89876 fått pensjon fra utlandet?',
-                            nn: 'Får eller har den andre forelderen til BARN 234567 89876 fått pensjon frå utlandet?',
+                            en: "Does Barn 234567 89876's other parent receive, or have they received a pension from abroad?",
+                            nb: 'Får eller har den andre forelderen til Barn 234567 89876 fått pensjon fra utlandet?',
+                            nn: 'Får eller har den andre forelderen til Barn 234567 89876 fått pensjon frå utlandet?',
                         },
                         verdi: {
                             nb: null,
@@ -637,9 +637,9 @@ export const testdata1: TilKontraktTestData = {
                     },
                     pensjonHvilketLand: {
                         label: {
-                            en: "What country does BARN 234567 89876's other parent receive a pension from?",
-                            nb: 'Hvilket land får den andre forelderen til BARN 234567 89876 pensjon fra?',
-                            nn: 'Kva land får den andre forelderen til BARN 234567 89876 pensjon frå?',
+                            en: "What country does Barn 234567 89876's other parent receive a pension from?",
+                            nb: 'Hvilket land får den andre forelderen til Barn 234567 89876 pensjon fra?',
+                            nn: 'Kva land får den andre forelderen til Barn 234567 89876 pensjon frå?',
                         },
                         verdi: {
                             nb: 'UKJENT',
@@ -649,9 +649,9 @@ export const testdata1: TilKontraktTestData = {
                     },
                     arbeidUtlandet: {
                         label: {
-                            en: "Does BARN 234567 89876's other parent work, or have they worked outside of Norway, on a foreign ship or on a foreign continental shelf?",
-                            nb: 'Arbeider eller har den andre forelderen til BARN 234567 89876 arbeidet utenfor Norge, på utenlandsk skip eller på utenlandsk kontinentalsokkel?',
-                            nn: 'Arbeidar eller har den andre forelderen til BARN 234567 89876 arbeida utanfor Noreg, på utanlandsk skip eller på utanlandsk kontinentalsokkel?',
+                            en: "Does Barn 234567 89876's other parent work, or have they worked outside of Norway, on a foreign ship or on a foreign continental shelf?",
+                            nb: 'Arbeider eller har den andre forelderen til Barn 234567 89876 arbeidet utenfor Norge, på utenlandsk skip eller på utenlandsk kontinentalsokkel?',
+                            nn: 'Arbeidar eller har den andre forelderen til Barn 234567 89876 arbeida utanfor Noreg, på utanlandsk skip eller på utanlandsk kontinentalsokkel?',
                         },
                         verdi: {
                             nb: null,
@@ -673,9 +673,9 @@ export const testdata1: TilKontraktTestData = {
                     },
                     skriftligAvtaleOmDeltBosted: {
                         label: {
-                            en: 'Do you and the other parent have a written agreement on dual residence for BARN 234567 89876?',
-                            nb: 'Har du og den andre forelderen skriftlig avtale om delt bosted for BARN 234567 89876?',
-                            nn: 'Har du og den andre forelderen skriftleg avtale om delt bustad for BARN 234567 89876?',
+                            en: 'Do you and the other parent have a written agreement on dual residence for Barn 234567 89876?',
+                            nb: 'Har du og den andre forelderen skriftlig avtale om delt bosted for Barn 234567 89876?',
+                            nn: 'Har du og den andre forelderen skriftleg avtale om delt bustad for Barn 234567 89876?',
                         },
                         verdi: {
                             nb: 'NEI',
@@ -686,9 +686,9 @@ export const testdata1: TilKontraktTestData = {
                     utvidet: {
                         søkerHarBoddMedAndreForelder: {
                             label: {
-                                en: "Have you ever lived with BARN 234567 89876's other parent?",
-                                nb: 'Har du bodd sammen med BARN 234567 89876 sin andre forelder?',
-                                nn: 'Har du budd saman med BARN 234567 89876 sin andre forelder?',
+                                en: "Have you ever lived with Barn 234567 89876's other parent?",
+                                nb: 'Har du bodd sammen med Barn 234567 89876 sin andre forelder?',
+                                nn: 'Har du budd saman med Barn 234567 89876 sin andre forelder?',
                             },
                             verdi: {
                                 nb: null,
@@ -809,9 +809,9 @@ export const testdata1: TilKontraktTestData = {
                     },
                     borFastMedSøker: {
                         label: {
-                            en: 'Does BARN 234567 89876 live with you on a permanent basis?',
-                            nb: 'Bor BARN 234567 89876 fast sammen med deg?',
-                            nn: 'Bur BARN 234567 89876 fast saman med deg?',
+                            en: 'Does Barn 234567 89876 live with you on a permanent basis?',
+                            nb: 'Bor Barn 234567 89876 fast sammen med deg?',
+                            nn: 'Bur Barn 234567 89876 fast saman med deg?',
                         },
                         verdi: {
                             nb: 'NEI',
@@ -821,9 +821,9 @@ export const testdata1: TilKontraktTestData = {
                     },
                     søkerForTidsrom: {
                         label: {
-                            en: 'Are you applying for child benefit for a particular period of time for BARN 234567 89876?',
-                            nb: 'Søker du barnetrygd for et spesielt tidsrom for BARN 234567 89876?',
-                            nn: 'Søker du barnetrygd for eit spesielt tidsrom for BARN 234567 89876?',
+                            en: 'Are you applying for child benefit for a particular period of time for Barn 234567 89876?',
+                            nb: 'Søker du barnetrygd for et spesielt tidsrom for Barn 234567 89876?',
+                            nn: 'Søker du barnetrygd for eit spesielt tidsrom for Barn 234567 89876?',
                         },
                         verdi: {
                             nb: 'NEI',

--- a/src/frontend/hooks/useSendInnSkjemaTest/test-data/testdata2.ts
+++ b/src/frontend/hooks/useSendInnSkjemaTest/test-data/testdata2.ts
@@ -1337,8 +1337,8 @@ export const testdata2: TilKontraktTestData = {
                                 oppholdsland: {
                                     label: {
                                         en: 'Which country was Barn 234567 89876 staying in?',
-                                        nb: 'Hvilket land oppholdt BARN 234567 89876 seg i?',
-                                        nn: 'Kva land oppheldt BARN 234567 89876 seg i?',
+                                        nb: 'Hvilket land oppholdt Barn 234567 89876 seg i?',
+                                        nn: 'Kva land oppheldt Barn 234567 89876 seg i?',
                                     },
                                     verdi: {
                                         nb: 'Belgia',
@@ -1383,9 +1383,9 @@ export const testdata2: TilKontraktTestData = {
                             nb: {
                                 utenlandsoppholdÅrsak: {
                                     label: {
-                                        en: 'What best describes the period BARN 234567 89876 stayed outside of Norway?',
-                                        nb: 'Hva beskriver perioden BARN 234567 89876 oppholdt seg utenfor Norge best?',
-                                        nn: 'Kva beskriv perioden BARN 234567 89876 har opphalde seg utanfor Noreg best',
+                                        en: 'What best describes the period Barn 234567 89876 stayed outside of Norway?',
+                                        nb: 'Hva beskriver perioden Barn 234567 89876 oppholdt seg utenfor Norge best?',
+                                        nn: 'Kva beskriv perioden Barn 234567 89876 har opphalde seg utanfor Noreg best',
                                     },
                                     verdi: {
                                         en: 'The child has moved permanently from Norway',
@@ -1395,9 +1395,9 @@ export const testdata2: TilKontraktTestData = {
                                 },
                                 oppholdsland: {
                                     label: {
-                                        en: 'Which country has BARN 234567 89876 moved to?',
-                                        nb: 'Hvilket land har BARN 234567 89876 flyttet til?',
-                                        nn: 'Kva land har BARN 234567 89876 flytta til?',
+                                        en: 'Which country has Barn 234567 89876 moved to?',
+                                        nb: 'Hvilket land har Barn 234567 89876 flyttet til?',
+                                        nn: 'Kva land har Barn 234567 89876 flytta til?',
                                     },
                                     verdi: {
                                         nb: 'Afghanistan',
@@ -1407,9 +1407,9 @@ export const testdata2: TilKontraktTestData = {
                                 },
                                 oppholdslandFraDato: {
                                     label: {
-                                        en: 'When did BARN 234567 89876 move from Norway?',
-                                        nb: 'Når flyttet BARN 234567 89876 fra Norge?',
-                                        nn: 'Når flytta BARN 234567 89876 frå Noreg?',
+                                        en: 'When did Barn 234567 89876 move from Norway?',
+                                        nb: 'Når flyttet Barn 234567 89876 fra Norge?',
+                                        nn: 'Når flytta Barn 234567 89876 frå Noreg?',
                                     },
                                     verdi: {
                                         nb: '2022-01-12',
@@ -1429,9 +1429,9 @@ export const testdata2: TilKontraktTestData = {
                             nn: {
                                 utenlandsoppholdÅrsak: {
                                     label: {
-                                        en: 'What best describes the period BARN 234567 89876 stayed outside of Norway?',
-                                        nb: 'Hva beskriver perioden BARN 234567 89876 oppholdt seg utenfor Norge best?',
-                                        nn: 'Kva beskriv perioden BARN 234567 89876 har opphalde seg utanfor Noreg best',
+                                        en: 'What best describes the period Barn 234567 89876 stayed outside of Norway?',
+                                        nb: 'Hva beskriver perioden Barn 234567 89876 oppholdt seg utenfor Norge best?',
+                                        nn: 'Kva beskriv perioden Barn 234567 89876 har opphalde seg utanfor Noreg best',
                                     },
                                     verdi: {
                                         en: 'The child has moved permanently from Norway',
@@ -1441,9 +1441,9 @@ export const testdata2: TilKontraktTestData = {
                                 },
                                 oppholdsland: {
                                     label: {
-                                        en: 'Which country has BARN 234567 89876 moved to?',
-                                        nb: 'Hvilket land har BARN 234567 89876 flyttet til?',
-                                        nn: 'Kva land har BARN 234567 89876 flytta til?',
+                                        en: 'Which country has Barn 234567 89876 moved to?',
+                                        nb: 'Hvilket land har Barn 234567 89876 flyttet til?',
+                                        nn: 'Kva land har Barn 234567 89876 flytta til?',
                                     },
                                     verdi: {
                                         nb: 'Afghanistan',
@@ -1453,9 +1453,9 @@ export const testdata2: TilKontraktTestData = {
                                 },
                                 oppholdslandFraDato: {
                                     label: {
-                                        en: 'When did BARN 234567 89876 move from Norway?',
-                                        nb: 'Når flyttet BARN 234567 89876 fra Norge?',
-                                        nn: 'Når flytta BARN 234567 89876 frå Noreg?',
+                                        en: 'When did Barn 234567 89876 move from Norway?',
+                                        nb: 'Når flyttet Barn 234567 89876 fra Norge?',
+                                        nn: 'Når flytta Barn 234567 89876 frå Noreg?',
                                     },
                                     verdi: {
                                         nb: '2022-01-12',
@@ -1475,9 +1475,9 @@ export const testdata2: TilKontraktTestData = {
                             en: {
                                 utenlandsoppholdÅrsak: {
                                     label: {
-                                        en: 'What best describes the period BARN 234567 89876 stayed outside of Norway?',
-                                        nb: 'Hva beskriver perioden BARN 234567 89876 oppholdt seg utenfor Norge best?',
-                                        nn: 'Kva beskriv perioden BARN 234567 89876 har opphalde seg utanfor Noreg best',
+                                        en: 'What best describes the period Barn 234567 89876 stayed outside of Norway?',
+                                        nb: 'Hva beskriver perioden Barn 234567 89876 oppholdt seg utenfor Norge best?',
+                                        nn: 'Kva beskriv perioden Barn 234567 89876 har opphalde seg utanfor Noreg best',
                                     },
                                     verdi: {
                                         en: 'The child has moved permanently from Norway',
@@ -1487,9 +1487,9 @@ export const testdata2: TilKontraktTestData = {
                                 },
                                 oppholdsland: {
                                     label: {
-                                        en: 'Which country has BARN 234567 89876 moved to?',
-                                        nb: 'Hvilket land har BARN 234567 89876 flyttet til?',
-                                        nn: 'Kva land har BARN 234567 89876 flytta til?',
+                                        en: 'Which country has Barn 234567 89876 moved to?',
+                                        nb: 'Hvilket land har Barn 234567 89876 flyttet til?',
+                                        nn: 'Kva land har Barn 234567 89876 flytta til?',
                                     },
                                     verdi: {
                                         nb: 'Afghanistan',
@@ -1499,9 +1499,9 @@ export const testdata2: TilKontraktTestData = {
                                 },
                                 oppholdslandFraDato: {
                                     label: {
-                                        en: 'When did BARN 234567 89876 move from Norway?',
-                                        nb: 'Når flyttet BARN 234567 89876 fra Norge?',
-                                        nn: 'Når flytta BARN 234567 89876 frå Noreg?',
+                                        en: 'When did Barn 234567 89876 move from Norway?',
+                                        nb: 'Når flyttet Barn 234567 89876 fra Norge?',
+                                        nn: 'Når flytta Barn 234567 89876 frå Noreg?',
                                     },
                                     verdi: {
                                         nb: '2022-01-12',
@@ -1645,9 +1645,9 @@ export const testdata2: TilKontraktTestData = {
                     },
                     borFastMedSøker: {
                         label: {
-                            en: 'Does BARN 234567 89876 live with you on a permanent basis?',
-                            nb: 'Bor BARN 234567 89876 fast sammen med deg?',
-                            nn: 'Bur BARN 234567 89876 fast saman med deg?',
+                            en: 'Does Barn 234567 89876 live with you on a permanent basis?',
+                            nb: 'Bor Barn 234567 89876 fast sammen med deg?',
+                            nn: 'Bur Barn 234567 89876 fast saman med deg?',
                         },
                         verdi: {
                             nb: 'NEI',
@@ -1657,9 +1657,9 @@ export const testdata2: TilKontraktTestData = {
                     },
                     søkerForTidsrom: {
                         label: {
-                            en: 'Are you applying for child benefit for a particular period of time for BARN 234567 89876?',
-                            nb: 'Søker du barnetrygd for et spesielt tidsrom for BARN 234567 89876?',
-                            nn: 'Søker du barnetrygd for eit spesielt tidsrom for BARN 234567 89876?',
+                            en: 'Are you applying for child benefit for a particular period of time for Barn 234567 89876?',
+                            nb: 'Søker du barnetrygd for et spesielt tidsrom for Barn 234567 89876?',
+                            nn: 'Søker du barnetrygd for eit spesielt tidsrom for Barn 234567 89876?',
                         },
                         verdi: {
                             nb: 'JA',

--- a/src/frontend/hooks/useSendInnSkjemaTest/test-data/testdata2.ts
+++ b/src/frontend/hooks/useSendInnSkjemaTest/test-data/testdata2.ts
@@ -7,7 +7,7 @@ export const testdata2: TilKontraktTestData = {
         barnInkludertISøknaden: [
             {
                 id: 'db2afce7-2607-461e-a056-682eab5546e4',
-                navn: null,
+                navn: 'Barn 234567 89876',
                 ident: '23456789876',
                 alder: '13',
                 borMedSøker: false,
@@ -341,7 +341,7 @@ export const testdata2: TilKontraktTestData = {
             barn: [
                 {
                     id: 'db2afce7-2607-461e-a056-682eab5546e4',
-                    navn: null,
+                    navn: 'Barn 234567 89876',
                     ident: '23456789876',
                     alder: '13',
                     borMedSøker: false,
@@ -1224,9 +1224,9 @@ export const testdata2: TilKontraktTestData = {
                             nb: {
                                 utenlandsoppholdÅrsak: {
                                     label: {
-                                        en: 'What best describes the period BARN 234567 89876 stayed outside of Norway?',
-                                        nb: 'Hva beskriver perioden BARN 234567 89876 oppholdt seg utenfor Norge best?',
-                                        nn: 'Kva beskriv perioden BARN 234567 89876 har opphalde seg utanfor Noreg best',
+                                        en: 'What best describes the period Barn 234567 89876 stayed outside of Norway?',
+                                        nb: 'Hva beskriver perioden Barn 234567 89876 oppholdt seg utenfor Norge best?',
+                                        nn: 'Kva beskriv perioden Barn 234567 89876 har opphalde seg utanfor Noreg best',
                                     },
                                     verdi: {
                                         en: 'The child has stayed outside of Norway earlier',
@@ -1236,9 +1236,9 @@ export const testdata2: TilKontraktTestData = {
                                 },
                                 oppholdsland: {
                                     label: {
-                                        en: 'Which country was BARN 234567 89876 staying in?',
-                                        nb: 'Hvilket land oppholdt BARN 234567 89876 seg i?',
-                                        nn: 'Kva land oppheldt BARN 234567 89876 seg i?',
+                                        en: 'Which country was Barn 234567 89876 staying in?',
+                                        nb: 'Hvilket land oppholdt Barn 234567 89876 seg i?',
+                                        nn: 'Kva land oppheldt Barn 234567 89876 seg i?',
                                     },
                                     verdi: {
                                         nb: 'Belgia',
@@ -1274,9 +1274,9 @@ export const testdata2: TilKontraktTestData = {
                             nn: {
                                 utenlandsoppholdÅrsak: {
                                     label: {
-                                        en: 'What best describes the period BARN 234567 89876 stayed outside of Norway?',
-                                        nb: 'Hva beskriver perioden BARN 234567 89876 oppholdt seg utenfor Norge best?',
-                                        nn: 'Kva beskriv perioden BARN 234567 89876 har opphalde seg utanfor Noreg best',
+                                        en: 'What best describes the period Barn 234567 89876 stayed outside of Norway?',
+                                        nb: 'Hva beskriver perioden Barn 234567 89876 oppholdt seg utenfor Norge best?',
+                                        nn: 'Kva beskriv perioden Barn 234567 89876 har opphalde seg utanfor Noreg best',
                                     },
                                     verdi: {
                                         en: 'The child has stayed outside of Norway earlier',
@@ -1286,9 +1286,9 @@ export const testdata2: TilKontraktTestData = {
                                 },
                                 oppholdsland: {
                                     label: {
-                                        en: 'Which country was BARN 234567 89876 staying in?',
-                                        nb: 'Hvilket land oppholdt BARN 234567 89876 seg i?',
-                                        nn: 'Kva land oppheldt BARN 234567 89876 seg i?',
+                                        en: 'Which country was Barn 234567 89876 staying in?',
+                                        nb: 'Hvilket land oppholdt Barn 234567 89876 seg i?',
+                                        nn: 'Kva land oppheldt Barn 234567 89876 seg i?',
                                     },
                                     verdi: {
                                         nb: 'Belgia',
@@ -1324,9 +1324,9 @@ export const testdata2: TilKontraktTestData = {
                             en: {
                                 utenlandsoppholdÅrsak: {
                                     label: {
-                                        en: 'What best describes the period BARN 234567 89876 stayed outside of Norway?',
-                                        nb: 'Hva beskriver perioden BARN 234567 89876 oppholdt seg utenfor Norge best?',
-                                        nn: 'Kva beskriv perioden BARN 234567 89876 har opphalde seg utanfor Noreg best',
+                                        en: 'What best describes the period Barn 234567 89876 stayed outside of Norway?',
+                                        nb: 'Hva beskriver perioden Barn 234567 89876 oppholdt seg utenfor Norge best?',
+                                        nn: 'Kva beskriv perioden Barn 234567 89876 har opphalde seg utanfor Noreg best',
                                     },
                                     verdi: {
                                         en: 'The child has stayed outside of Norway earlier',
@@ -1336,7 +1336,7 @@ export const testdata2: TilKontraktTestData = {
                                 },
                                 oppholdsland: {
                                     label: {
-                                        en: 'Which country was BARN 234567 89876 staying in?',
+                                        en: 'Which country was Barn 234567 89876 staying in?',
                                         nb: 'Hvilket land oppholdt BARN 234567 89876 seg i?',
                                         nn: 'Kva land oppheldt BARN 234567 89876 seg i?',
                                     },
@@ -1765,9 +1765,9 @@ export const testdata2: TilKontraktTestData = {
                             nb: {
                                 utenlandsoppholdÅrsak: {
                                     label: {
-                                        en: 'What best describes the period BARN BARNESSEN III stayed outside of Norway?',
-                                        nb: 'Hva beskriver perioden BARN BARNESSEN III oppholdt seg utenfor Norge best?',
-                                        nn: 'Kva beskriv perioden BARN BARNESSEN III har opphalde seg utanfor Noreg best',
+                                        en: 'What best describes the period Barn Barnessen III stayed outside of Norway?',
+                                        nb: 'Hva beskriver perioden Barn Barnessen III oppholdt seg utenfor Norge best?',
+                                        nn: 'Kva beskriv perioden Barn Barnessen III har opphalde seg utanfor Noreg best',
                                     },
                                     verdi: {
                                         en: 'The child is currently staying outside of Norway',
@@ -1777,9 +1777,9 @@ export const testdata2: TilKontraktTestData = {
                                 },
                                 oppholdsland: {
                                     label: {
-                                        en: 'Which country is BARN BARNESSEN III currently in?',
-                                        nb: 'Hvilket land oppholder BARN BARNESSEN III seg i?',
-                                        nn: 'Kva land oppheld BARN BARNESSEN III seg i?',
+                                        en: 'Which country is Barn Barnessen III currently in?',
+                                        nb: 'Hvilket land oppholder Barn Barnessen III seg i?',
+                                        nn: 'Kva land oppheld Barn Barnessen III seg i?',
                                     },
                                     verdi: {
                                         nb: 'Hellas',
@@ -1815,9 +1815,9 @@ export const testdata2: TilKontraktTestData = {
                             nn: {
                                 utenlandsoppholdÅrsak: {
                                     label: {
-                                        en: 'What best describes the period BARN BARNESSEN III stayed outside of Norway?',
-                                        nb: 'Hva beskriver perioden BARN BARNESSEN III oppholdt seg utenfor Norge best?',
-                                        nn: 'Kva beskriv perioden BARN BARNESSEN III har opphalde seg utanfor Noreg best',
+                                        en: 'What best describes the period Barn Barnessen III stayed outside of Norway?',
+                                        nb: 'Hva beskriver perioden Barn Barnessen III oppholdt seg utenfor Norge best?',
+                                        nn: 'Kva beskriv perioden Barn Barnessen III har opphalde seg utanfor Noreg best',
                                     },
                                     verdi: {
                                         en: 'The child is currently staying outside of Norway',
@@ -1827,9 +1827,9 @@ export const testdata2: TilKontraktTestData = {
                                 },
                                 oppholdsland: {
                                     label: {
-                                        en: 'Which country is BARN BARNESSEN III currently in?',
-                                        nb: 'Hvilket land oppholder BARN BARNESSEN III seg i?',
-                                        nn: 'Kva land oppheld BARN BARNESSEN III seg i?',
+                                        en: 'Which country is Barn Barnessen III currently in?',
+                                        nb: 'Hvilket land oppholder Barn Barnessen III seg i?',
+                                        nn: 'Kva land oppheld Barn Barnessen III seg i?',
                                     },
                                     verdi: {
                                         nb: 'Hellas',
@@ -1865,9 +1865,9 @@ export const testdata2: TilKontraktTestData = {
                             en: {
                                 utenlandsoppholdÅrsak: {
                                     label: {
-                                        en: 'What best describes the period BARN BARNESSEN III stayed outside of Norway?',
-                                        nb: 'Hva beskriver perioden BARN BARNESSEN III oppholdt seg utenfor Norge best?',
-                                        nn: 'Kva beskriv perioden BARN BARNESSEN III har opphalde seg utanfor Noreg best',
+                                        en: 'What best describes the period Barn Barnessen III stayed outside of Norway?',
+                                        nb: 'Hva beskriver perioden Barn Barnessen III oppholdt seg utenfor Norge best?',
+                                        nn: 'Kva beskriv perioden Barn Barnessen III har opphalde seg utanfor Noreg best',
                                     },
                                     verdi: {
                                         en: 'The child is currently staying outside of Norway',
@@ -1877,9 +1877,9 @@ export const testdata2: TilKontraktTestData = {
                                 },
                                 oppholdsland: {
                                     label: {
-                                        en: 'Which country is BARN BARNESSEN III currently in?',
-                                        nb: 'Hvilket land oppholder BARN BARNESSEN III seg i?',
-                                        nn: 'Kva land oppheld BARN BARNESSEN III seg i?',
+                                        en: 'Which country is Barn Barnessen III currently in?',
+                                        nb: 'Hvilket land oppholder Barn Barnessen III seg i?',
+                                        nn: 'Kva land oppheld Barn Barnessen III seg i?',
                                     },
                                     verdi: {
                                         nb: 'Hellas',
@@ -2063,9 +2063,9 @@ export const testdata2: TilKontraktTestData = {
                     },
                     planleggerÅBoINorge12Mnd: {
                         label: {
-                            en: 'Is it planned that BARN BARNESSEN III will live in Norway continuously for more than 12 months?',
-                            nb: 'Er det planlagt at BARN BARNESSEN III skal bo sammenhengende i Norge i mer enn tolv måneder?',
-                            nn: 'Er det planlagd at BARN BARNESSEN III skal bu i Noreg samanhengande i meir enn tolv månadar?',
+                            en: 'Is it planned that Barn Barnessen III will live in Norway continuously for more than 12 months?',
+                            nb: 'Er det planlagt at Barn Barnessen III skal bo sammenhengende i Norge i mer enn tolv måneder?',
+                            nn: 'Er det planlagd at Barn Barnessen III skal bu i Noreg samanhengande i meir enn tolv månadar?',
                         },
                         verdi: {
                             nb: 'NEI',
@@ -2087,9 +2087,9 @@ export const testdata2: TilKontraktTestData = {
                     },
                     borFastMedSøker: {
                         label: {
-                            en: 'Does BARN BARNESSEN III live with you on a permanent basis?',
-                            nb: 'Bor BARN BARNESSEN III fast sammen med deg?',
-                            nn: 'Bur BARN BARNESSEN III fast saman med deg?',
+                            en: 'Does Barn Barnessen III live with you on a permanent basis?',
+                            nb: 'Bor Barn Barnessen III fast sammen med deg?',
+                            nn: 'Bur Barn Barnessen III fast saman med deg?',
                         },
                         verdi: {
                             nb: 'NEI',
@@ -2099,9 +2099,9 @@ export const testdata2: TilKontraktTestData = {
                     },
                     søkerForTidsrom: {
                         label: {
-                            en: 'Are you applying for child benefit for a particular period of time for BARN BARNESSEN III?',
-                            nb: 'Søker du barnetrygd for et spesielt tidsrom for BARN BARNESSEN III?',
-                            nn: 'Søker du barnetrygd for eit spesielt tidsrom for BARN BARNESSEN III?',
+                            en: 'Are you applying for child benefit for a particular period of time for Barn Barnessen III?',
+                            nb: 'Søker du barnetrygd for et spesielt tidsrom for Barn Barnessen III?',
+                            nn: 'Søker du barnetrygd for eit spesielt tidsrom for Barn Barnessen III?',
                         },
                         verdi: {
                             nb: 'JA',

--- a/src/frontend/hooks/useSendInnSkjemaTest/test-data/testdata3.ts
+++ b/src/frontend/hooks/useSendInnSkjemaTest/test-data/testdata3.ts
@@ -7,7 +7,7 @@ export const testdata3: TilKontraktTestData = {
         barnInkludertISøknaden: [
             {
                 id: 'db2afce7-2607-461e-a056-682eab5546e4',
-                navn: null,
+                navn: 'Barn 234567 89876',
                 ident: '23456789876',
                 alder: '13',
                 borMedSøker: false,
@@ -393,7 +393,7 @@ export const testdata3: TilKontraktTestData = {
             barn: [
                 {
                     id: 'db2afce7-2607-461e-a056-682eab5546e4',
-                    navn: null,
+                    navn: 'Barn 234567 89876',
                     ident: '23456789876',
                     alder: '13',
                     borMedSøker: false,
@@ -1305,9 +1305,9 @@ export const testdata3: TilKontraktTestData = {
                     },
                     pensjonUtland: {
                         label: {
-                            en: "Does BARN 234567 89876's other parent receive, or have they received a pension from abroad?",
-                            nb: 'Får eller har den andre forelderen til BARN 234567 89876 fått pensjon fra utlandet?',
-                            nn: 'Får eller har den andre forelderen til BARN 234567 89876 fått pensjon frå utlandet?',
+                            en: "Does Barn 234567 89876's other parent receive, or have they received a pension from abroad?",
+                            nb: 'Får eller har den andre forelderen til Barn 234567 89876 fått pensjon fra utlandet?',
+                            nn: 'Får eller har den andre forelderen til Barn 234567 89876 fått pensjon frå utlandet?',
                         },
                         verdi: {
                             nb: 'VET_IKKE',
@@ -1317,9 +1317,9 @@ export const testdata3: TilKontraktTestData = {
                     },
                     pensjonHvilketLand: {
                         label: {
-                            en: "What country does BARN 234567 89876's other parent receive a pension from?",
-                            nb: 'Hvilket land får den andre forelderen til BARN 234567 89876 pensjon fra?',
-                            nn: 'Kva land får den andre forelderen til BARN 234567 89876 pensjon frå?',
+                            en: "What country does Barn 234567 89876's other parent receive a pension from?",
+                            nb: 'Hvilket land får den andre forelderen til Barn 234567 89876 pensjon fra?',
+                            nn: 'Kva land får den andre forelderen til Barn 234567 89876 pensjon frå?',
                         },
                         verdi: {
                             nb: 'UKJENT',
@@ -1329,9 +1329,9 @@ export const testdata3: TilKontraktTestData = {
                     },
                     arbeidUtlandet: {
                         label: {
-                            en: "Does BARN 234567 89876's other parent work, or have they worked outside of Norway, on a foreign ship or on a foreign continental shelf?",
-                            nb: 'Arbeider eller har den andre forelderen til BARN 234567 89876 arbeidet utenfor Norge, på utenlandsk skip eller på utenlandsk kontinentalsokkel?',
-                            nn: 'Arbeidar eller har den andre forelderen til BARN 234567 89876 arbeida utanfor Noreg, på utanlandsk skip eller på utanlandsk kontinentalsokkel?',
+                            en: "Does Barn 234567 89876's other parent work, or have they worked outside of Norway, on a foreign ship or on a foreign continental shelf?",
+                            nb: 'Arbeider eller har den andre forelderen til Barn 234567 89876 arbeidet utenfor Norge, på utenlandsk skip eller på utenlandsk kontinentalsokkel?',
+                            nn: 'Arbeidar eller har den andre forelderen til Barn 234567 89876 arbeida utanfor Noreg, på utanlandsk skip eller på utanlandsk kontinentalsokkel?',
                         },
                         verdi: {
                             nb: 'VET_IKKE',
@@ -1353,9 +1353,9 @@ export const testdata3: TilKontraktTestData = {
                     },
                     skriftligAvtaleOmDeltBosted: {
                         label: {
-                            en: 'Do you and the other parent have a written agreement on dual residence for BARN 234567 89876?',
-                            nb: 'Har du og den andre forelderen skriftlig avtale om delt bosted for BARN 234567 89876?',
-                            nn: 'Har du og den andre forelderen skriftleg avtale om delt bustad for BARN 234567 89876?',
+                            en: 'Do you and the other parent have a written agreement on dual residence for Barn 234567 89876?',
+                            nb: 'Har du og den andre forelderen skriftlig avtale om delt bosted for Barn 234567 89876?',
+                            nn: 'Har du og den andre forelderen skriftleg avtale om delt bustad for Barn 234567 89876?',
                         },
                         verdi: {
                             nb: 'JA',
@@ -1366,9 +1366,9 @@ export const testdata3: TilKontraktTestData = {
                     utvidet: {
                         søkerHarBoddMedAndreForelder: {
                             label: {
-                                en: "Have you ever lived with BARN 234567 89876's other parent?",
-                                nb: 'Har du bodd sammen med BARN 234567 89876 sin andre forelder?',
-                                nn: 'Har du budd saman med BARN 234567 89876 sin andre forelder?',
+                                en: "Have you ever lived with Barn 234567 89876's other parent?",
+                                nb: 'Har du bodd sammen med Barn 234567 89876 sin andre forelder?',
+                                nn: 'Har du budd saman med Barn 234567 89876 sin andre forelder?',
                             },
                             verdi: {
                                 nb: null,
@@ -1489,9 +1489,9 @@ export const testdata3: TilKontraktTestData = {
                     },
                     borFastMedSøker: {
                         label: {
-                            en: 'Does BARN 234567 89876 live with you on a permanent basis?',
-                            nb: 'Bor BARN 234567 89876 fast sammen med deg?',
-                            nn: 'Bur BARN 234567 89876 fast saman med deg?',
+                            en: 'Does Barn 234567 89876 live with you on a permanent basis?',
+                            nb: 'Bor Barn 234567 89876 fast sammen med deg?',
+                            nn: 'Bur Barn 234567 89876 fast saman med deg?',
                         },
                         verdi: {
                             nb: 'JA',
@@ -1501,9 +1501,9 @@ export const testdata3: TilKontraktTestData = {
                     },
                     søkerForTidsrom: {
                         label: {
-                            en: 'Are you applying for child benefit for a particular period of time for BARN 234567 89876?',
-                            nb: 'Søker du barnetrygd for et spesielt tidsrom for BARN 234567 89876?',
-                            nn: 'Søker du barnetrygd for eit spesielt tidsrom for BARN 234567 89876?',
+                            en: 'Are you applying for child benefit for a particular period of time for Barn 234567 89876?',
+                            nb: 'Søker du barnetrygd for et spesielt tidsrom for Barn 234567 89876?',
+                            nn: 'Søker du barnetrygd for eit spesielt tidsrom for Barn 234567 89876?',
                         },
                         verdi: {
                             nb: 'JA',
@@ -1609,9 +1609,9 @@ export const testdata3: TilKontraktTestData = {
                             nb: {
                                 utenlandsoppholdÅrsak: {
                                     label: {
-                                        en: 'What best describes the period BARN BARNESSEN III stayed outside of Norway?',
-                                        nb: 'Hva beskriver perioden BARN BARNESSEN III oppholdt seg utenfor Norge best?',
-                                        nn: 'Kva beskriv perioden BARN BARNESSEN III har opphalde seg utanfor Noreg best',
+                                        en: 'What best describes the period Barn Barnessen III stayed outside of Norway?',
+                                        nb: 'Hva beskriver perioden Barn Barnessen III oppholdt seg utenfor Norge best?',
+                                        nn: 'Kva beskriv perioden Barn Barnessen III har opphalde seg utanfor Noreg best',
                                     },
                                     verdi: {
                                         en: 'The child is currently staying outside of Norway',
@@ -1621,9 +1621,9 @@ export const testdata3: TilKontraktTestData = {
                                 },
                                 oppholdsland: {
                                     label: {
-                                        en: 'Which country is BARN BARNESSEN III currently in?',
-                                        nb: 'Hvilket land oppholder BARN BARNESSEN III seg i?',
-                                        nn: 'Kva land oppheld BARN BARNESSEN III seg i?',
+                                        en: 'Which country is Barn Barnessen III currently in?',
+                                        nb: 'Hvilket land oppholder Barn Barnessen III seg i?',
+                                        nn: 'Kva land oppheld Barn Barnessen III seg i?',
                                     },
                                     verdi: {
                                         nb: 'Hellas',
@@ -1659,9 +1659,9 @@ export const testdata3: TilKontraktTestData = {
                             nn: {
                                 utenlandsoppholdÅrsak: {
                                     label: {
-                                        en: 'What best describes the period BARN BARNESSEN III stayed outside of Norway?',
-                                        nb: 'Hva beskriver perioden BARN BARNESSEN III oppholdt seg utenfor Norge best?',
-                                        nn: 'Kva beskriv perioden BARN BARNESSEN III har opphalde seg utanfor Noreg best',
+                                        en: 'What best describes the period Barn Barnessen III stayed outside of Norway?',
+                                        nb: 'Hva beskriver perioden Barn Barnessen III oppholdt seg utenfor Norge best?',
+                                        nn: 'Kva beskriv perioden Barn Barnessen III har opphalde seg utanfor Noreg best',
                                     },
                                     verdi: {
                                         en: 'The child is currently staying outside of Norway',
@@ -1671,9 +1671,9 @@ export const testdata3: TilKontraktTestData = {
                                 },
                                 oppholdsland: {
                                     label: {
-                                        en: 'Which country is BARN BARNESSEN III currently in?',
-                                        nb: 'Hvilket land oppholder BARN BARNESSEN III seg i?',
-                                        nn: 'Kva land oppheld BARN BARNESSEN III seg i?',
+                                        en: 'Which country is Barn Barnessen III currently in?',
+                                        nb: 'Hvilket land oppholder Barn Barnessen III seg i?',
+                                        nn: 'Kva land oppheld Barn Barnessen III seg i?',
                                     },
                                     verdi: {
                                         nb: 'Hellas',
@@ -1709,9 +1709,9 @@ export const testdata3: TilKontraktTestData = {
                             en: {
                                 utenlandsoppholdÅrsak: {
                                     label: {
-                                        en: 'What best describes the period BARN BARNESSEN III stayed outside of Norway?',
-                                        nb: 'Hva beskriver perioden BARN BARNESSEN III oppholdt seg utenfor Norge best?',
-                                        nn: 'Kva beskriv perioden BARN BARNESSEN III har opphalde seg utanfor Noreg best',
+                                        en: 'What best describes the period Barn Barnessen III stayed outside of Norway?',
+                                        nb: 'Hva beskriver perioden Barn Barnessen III oppholdt seg utenfor Norge best?',
+                                        nn: 'Kva beskriv perioden Barn Barnessen III har opphalde seg utanfor Noreg best',
                                     },
                                     verdi: {
                                         en: 'The child is currently staying outside of Norway',
@@ -1721,9 +1721,9 @@ export const testdata3: TilKontraktTestData = {
                                 },
                                 oppholdsland: {
                                     label: {
-                                        en: 'Which country is BARN BARNESSEN III currently in?',
-                                        nb: 'Hvilket land oppholder BARN BARNESSEN III seg i?',
-                                        nn: 'Kva land oppheld BARN BARNESSEN III seg i?',
+                                        en: 'Which country is Barn Barnessen III currently in?',
+                                        nb: 'Hvilket land oppholder Barn Barnessen III seg i?',
+                                        nn: 'Kva land oppheld Barn Barnessen III seg i?',
                                     },
                                     verdi: {
                                         nb: 'Hellas',
@@ -1768,9 +1768,9 @@ export const testdata3: TilKontraktTestData = {
                             nb: {
                                 utenlandsoppholdÅrsak: {
                                     label: {
-                                        en: 'What best describes the period BARN BARNESSEN III stayed outside of Norway?',
-                                        nb: 'Hva beskriver perioden BARN BARNESSEN III oppholdt seg utenfor Norge best?',
-                                        nn: 'Kva beskriv perioden BARN BARNESSEN III har opphalde seg utanfor Noreg best',
+                                        en: 'What best describes the period Barn Barnessen III stayed outside of Norway?',
+                                        nb: 'Hva beskriver perioden Barn Barnessen III oppholdt seg utenfor Norge best?',
+                                        nn: 'Kva beskriv perioden Barn Barnessen III har opphalde seg utanfor Noreg best',
                                     },
                                     verdi: {
                                         en: 'The child is currently staying outside of Norway',
@@ -1780,9 +1780,9 @@ export const testdata3: TilKontraktTestData = {
                                 },
                                 oppholdsland: {
                                     label: {
-                                        en: 'Which country is BARN BARNESSEN III currently in?',
-                                        nb: 'Hvilket land oppholder BARN BARNESSEN III seg i?',
-                                        nn: 'Kva land oppheld BARN BARNESSEN III seg i?',
+                                        en: 'Which country is Barn Barnessen III currently in?',
+                                        nb: 'Hvilket land oppholder Barn Barnessen III seg i?',
+                                        nn: 'Kva land oppheld Barn Barnessen III seg i?',
                                     },
                                     verdi: {
                                         nb: 'Tuvalu',
@@ -1818,9 +1818,9 @@ export const testdata3: TilKontraktTestData = {
                             nn: {
                                 utenlandsoppholdÅrsak: {
                                     label: {
-                                        en: 'What best describes the period BARN BARNESSEN III stayed outside of Norway?',
-                                        nb: 'Hva beskriver perioden BARN BARNESSEN III oppholdt seg utenfor Norge best?',
-                                        nn: 'Kva beskriv perioden BARN BARNESSEN III har opphalde seg utanfor Noreg best',
+                                        en: 'What best describes the period Barn Barnessen III stayed outside of Norway?',
+                                        nb: 'Hva beskriver perioden Barn Barnessen III oppholdt seg utenfor Norge best?',
+                                        nn: 'Kva beskriv perioden Barn Barnessen III har opphalde seg utanfor Noreg best',
                                     },
                                     verdi: {
                                         en: 'The child is currently staying outside of Norway',
@@ -1830,9 +1830,9 @@ export const testdata3: TilKontraktTestData = {
                                 },
                                 oppholdsland: {
                                     label: {
-                                        en: 'Which country is BARN BARNESSEN III currently in?',
-                                        nb: 'Hvilket land oppholder BARN BARNESSEN III seg i?',
-                                        nn: 'Kva land oppheld BARN BARNESSEN III seg i?',
+                                        en: 'Which country is Barn Barnessen III currently in?',
+                                        nb: 'Hvilket land oppholder Barn Barnessen III seg i?',
+                                        nn: 'Kva land oppheld Barn Barnessen III seg i?',
                                     },
                                     verdi: {
                                         nb: 'Tuvalu',
@@ -1868,9 +1868,9 @@ export const testdata3: TilKontraktTestData = {
                             en: {
                                 utenlandsoppholdÅrsak: {
                                     label: {
-                                        en: 'What best describes the period BARN BARNESSEN III stayed outside of Norway?',
-                                        nb: 'Hva beskriver perioden BARN BARNESSEN III oppholdt seg utenfor Norge best?',
-                                        nn: 'Kva beskriv perioden BARN BARNESSEN III har opphalde seg utanfor Noreg best',
+                                        en: 'What best describes the period Barn Barnessen III stayed outside of Norway?',
+                                        nb: 'Hva beskriver perioden Barn Barnessen III oppholdt seg utenfor Norge best?',
+                                        nn: 'Kva beskriv perioden Barn Barnessen III har opphalde seg utanfor Noreg best',
                                     },
                                     verdi: {
                                         en: 'The child is currently staying outside of Norway',
@@ -1880,9 +1880,9 @@ export const testdata3: TilKontraktTestData = {
                                 },
                                 oppholdsland: {
                                     label: {
-                                        en: 'Which country is BARN BARNESSEN III currently in?',
-                                        nb: 'Hvilket land oppholder BARN BARNESSEN III seg i?',
-                                        nn: 'Kva land oppheld BARN BARNESSEN III seg i?',
+                                        en: 'Which country is Barn Barnessen III currently in?',
+                                        nb: 'Hvilket land oppholder Barn Barnessen III seg i?',
+                                        nn: 'Kva land oppheld Barn Barnessen III seg i?',
                                     },
                                     verdi: {
                                         nb: 'Tuvalu',
@@ -2066,9 +2066,9 @@ export const testdata3: TilKontraktTestData = {
                     },
                     planleggerÅBoINorge12Mnd: {
                         label: {
-                            en: 'Is it planned that BARN BARNESSEN III will live in Norway continuously for more than 12 months?',
-                            nb: 'Er det planlagt at BARN BARNESSEN III skal bo sammenhengende i Norge i mer enn tolv måneder?',
-                            nn: 'Er det planlagd at BARN BARNESSEN III skal bu i Noreg samanhengande i meir enn tolv månadar?',
+                            en: 'Is it planned that Barn Barnessen III will live in Norway continuously for more than 12 months?',
+                            nb: 'Er det planlagt at Barn Barnessen III skal bo sammenhengende i Norge i mer enn tolv måneder?',
+                            nn: 'Er det planlagd at Barn Barnessen III skal bu i Noreg samanhengande i meir enn tolv månadar?',
                         },
                         verdi: {
                             nb: 'NEI',
@@ -2090,9 +2090,9 @@ export const testdata3: TilKontraktTestData = {
                     },
                     borFastMedSøker: {
                         label: {
-                            en: 'Does BARN BARNESSEN III live with you on a permanent basis?',
-                            nb: 'Bor BARN BARNESSEN III fast sammen med deg?',
-                            nn: 'Bur BARN BARNESSEN III fast saman med deg?',
+                            en: 'Does Barn Barnessen III live with you on a permanent basis?',
+                            nb: 'Bor Barn Barnessen III fast sammen med deg?',
+                            nn: 'Bur Barn Barnessen III fast saman med deg?',
                         },
                         verdi: {
                             nb: 'JA',
@@ -2102,9 +2102,9 @@ export const testdata3: TilKontraktTestData = {
                     },
                     søkerForTidsrom: {
                         label: {
-                            en: 'Are you applying for child benefit for a particular period of time for BARN BARNESSEN III?',
-                            nb: 'Søker du barnetrygd for et spesielt tidsrom for BARN BARNESSEN III?',
-                            nn: 'Søker du barnetrygd for eit spesielt tidsrom for BARN BARNESSEN III?',
+                            en: 'Are you applying for child benefit for a particular period of time for Barn Barnessen III?',
+                            nb: 'Søker du barnetrygd for et spesielt tidsrom for Barn Barnessen III?',
+                            nn: 'Søker du barnetrygd for eit spesielt tidsrom for Barn Barnessen III?',
                         },
                         verdi: {
                             nb: 'NEI',

--- a/src/frontend/hooks/useSendInnSkjemaTest/test-data/testdata4.ts
+++ b/src/frontend/hooks/useSendInnSkjemaTest/test-data/testdata4.ts
@@ -7,7 +7,7 @@ export const testdata4: TilKontraktTestData = {
         barnInkludertISøknaden: [
             {
                 id: '786fb149-2331-4dc2-9b0e-b5f4768952d5',
-                navn: null,
+                navn: 'Barn 234567 89876',
                 ident: '23456789876',
                 alder: '13',
                 borMedSøker: false,
@@ -1282,9 +1282,9 @@ export const testdata4: TilKontraktTestData = {
                     },
                     borFastMedSøker: {
                         label: {
-                            en: 'Does BARN 234567 89876 live with you on a permanent basis?',
-                            nb: 'Bor BARN 234567 89876 fast sammen med deg?',
-                            nn: 'Bur BARN 234567 89876 fast saman med deg?',
+                            en: 'Does Barn 234567 89876 live with you on a permanent basis?',
+                            nb: 'Bor Barn 234567 89876 fast sammen med deg?',
+                            nn: 'Bur Barn 234567 89876 fast saman med deg?',
                         },
                         verdi: {
                             nb: 'NEI',
@@ -1294,9 +1294,9 @@ export const testdata4: TilKontraktTestData = {
                     },
                     søkerForTidsrom: {
                         label: {
-                            en: 'Are you applying for child benefit for a particular period of time for BARN 234567 89876?',
-                            nb: 'Søker du barnetrygd for et spesielt tidsrom for BARN 234567 89876?',
-                            nn: 'Søker du barnetrygd for eit spesielt tidsrom for BARN 234567 89876?',
+                            en: 'Are you applying for child benefit for a particular period of time for Barn 234567 89876?',
+                            nb: 'Søker du barnetrygd for et spesielt tidsrom for Barn 234567 89876?',
+                            nn: 'Søker du barnetrygd for eit spesielt tidsrom for Barn 234567 89876?',
                         },
                         verdi: {
                             nb: 'JA',
@@ -1402,9 +1402,9 @@ export const testdata4: TilKontraktTestData = {
                             nb: {
                                 utenlandsoppholdÅrsak: {
                                     label: {
-                                        en: 'What best describes the period BARN BARNESSEN III stayed outside of Norway?',
-                                        nb: 'Hva beskriver perioden BARN BARNESSEN III oppholdt seg utenfor Norge best?',
-                                        nn: 'Kva beskriv perioden BARN BARNESSEN III har opphalde seg utanfor Noreg best',
+                                        en: 'What best describes the period Barn Barnessen III stayed outside of Norway?',
+                                        nb: 'Hva beskriver perioden Barn Barnessen III oppholdt seg utenfor Norge best?',
+                                        nn: 'Kva beskriv perioden Barn Barnessen III har opphalde seg utanfor Noreg best',
                                     },
                                     verdi: {
                                         en: 'The child has stayed outside of Norway earlier',
@@ -1414,9 +1414,9 @@ export const testdata4: TilKontraktTestData = {
                                 },
                                 oppholdsland: {
                                     label: {
-                                        en: 'Which country was BARN BARNESSEN III staying in?',
-                                        nb: 'Hvilket land oppholdt BARN BARNESSEN III seg i?',
-                                        nn: 'Kva land oppheldt BARN BARNESSEN III seg i?',
+                                        en: 'Which country was Barn Barnessen III staying in?',
+                                        nb: 'Hvilket land oppholdt Barn Barnessen III seg i?',
+                                        nn: 'Kva land oppheldt Barn Barnessen III seg i?',
                                     },
                                     verdi: {
                                         nb: 'Belgia',
@@ -1452,9 +1452,9 @@ export const testdata4: TilKontraktTestData = {
                             nn: {
                                 utenlandsoppholdÅrsak: {
                                     label: {
-                                        en: 'What best describes the period BARN BARNESSEN III stayed outside of Norway?',
-                                        nb: 'Hva beskriver perioden BARN BARNESSEN III oppholdt seg utenfor Norge best?',
-                                        nn: 'Kva beskriv perioden BARN BARNESSEN III har opphalde seg utanfor Noreg best',
+                                        en: 'What best describes the period Barn Barnessen III stayed outside of Norway?',
+                                        nb: 'Hva beskriver perioden Barn Barnessen III oppholdt seg utenfor Norge best?',
+                                        nn: 'Kva beskriv perioden Barn Barnessen III har opphalde seg utanfor Noreg best',
                                     },
                                     verdi: {
                                         en: 'The child has stayed outside of Norway earlier',
@@ -1464,9 +1464,9 @@ export const testdata4: TilKontraktTestData = {
                                 },
                                 oppholdsland: {
                                     label: {
-                                        en: 'Which country was BARN BARNESSEN III staying in?',
-                                        nb: 'Hvilket land oppholdt BARN BARNESSEN III seg i?',
-                                        nn: 'Kva land oppheldt BARN BARNESSEN III seg i?',
+                                        en: 'Which country was Barn Barnessen III staying in?',
+                                        nb: 'Hvilket land oppholdt Barn Barnessen III seg i?',
+                                        nn: 'Kva land oppheldt Barn Barnessen III seg i?',
                                     },
                                     verdi: {
                                         nb: 'Belgia',
@@ -1502,9 +1502,9 @@ export const testdata4: TilKontraktTestData = {
                             en: {
                                 utenlandsoppholdÅrsak: {
                                     label: {
-                                        en: 'What best describes the period BARN BARNESSEN III stayed outside of Norway?',
-                                        nb: 'Hva beskriver perioden BARN BARNESSEN III oppholdt seg utenfor Norge best?',
-                                        nn: 'Kva beskriv perioden BARN BARNESSEN III har opphalde seg utanfor Noreg best',
+                                        en: 'What best describes the period Barn Barnessen III stayed outside of Norway?',
+                                        nb: 'Hva beskriver perioden Barn Barnessen III oppholdt seg utenfor Norge best?',
+                                        nn: 'Kva beskriv perioden Barn Barnessen III har opphalde seg utanfor Noreg best',
                                     },
                                     verdi: {
                                         en: 'The child has stayed outside of Norway earlier',
@@ -1514,9 +1514,9 @@ export const testdata4: TilKontraktTestData = {
                                 },
                                 oppholdsland: {
                                     label: {
-                                        en: 'Which country was BARN BARNESSEN III staying in?',
-                                        nb: 'Hvilket land oppholdt BARN BARNESSEN III seg i?',
-                                        nn: 'Kva land oppheldt BARN BARNESSEN III seg i?',
+                                        en: 'Which country was Barn Barnessen III staying in?',
+                                        nb: 'Hvilket land oppholdt Barn Barnessen III seg i?',
+                                        nn: 'Kva land oppheldt Barn Barnessen III seg i?',
                                     },
                                     verdi: {
                                         nb: 'Belgia',
@@ -1591,9 +1591,9 @@ export const testdata4: TilKontraktTestData = {
                     },
                     pensjonUtland: {
                         label: {
-                            en: "Does BARN BARNESSEN III's other parent receive, or have they received a pension from abroad?",
-                            nb: 'Får eller har den andre forelderen til BARN BARNESSEN III fått pensjon fra utlandet?',
-                            nn: 'Får eller har den andre forelderen til BARN BARNESSEN III fått pensjon frå utlandet?',
+                            en: "Does Barn Barnessen III's other parent receive, or have they received a pension from abroad?",
+                            nb: 'Får eller har den andre forelderen til Barn Barnessen III fått pensjon fra utlandet?',
+                            nn: 'Får eller har den andre forelderen til Barn Barnessen III fått pensjon frå utlandet?',
                         },
                         verdi: {
                             nb: null,
@@ -1603,9 +1603,9 @@ export const testdata4: TilKontraktTestData = {
                     },
                     pensjonHvilketLand: {
                         label: {
-                            en: "What country does BARN BARNESSEN III's other parent receive a pension from?",
-                            nb: 'Hvilket land får den andre forelderen til BARN BARNESSEN III pensjon fra?',
-                            nn: 'Kva land får den andre forelderen til BARN BARNESSEN III pensjon frå?',
+                            en: "What country does Barn Barnessen III's other parent receive a pension from?",
+                            nb: 'Hvilket land får den andre forelderen til Barn Barnessen III pensjon fra?',
+                            nn: 'Kva land får den andre forelderen til Barn Barnessen III pensjon frå?',
                         },
                         verdi: {
                             nb: 'UKJENT',
@@ -1615,9 +1615,9 @@ export const testdata4: TilKontraktTestData = {
                     },
                     arbeidUtlandet: {
                         label: {
-                            en: "Does BARN BARNESSEN III's other parent work, or have they worked outside of Norway, on a foreign ship or on a foreign continental shelf?",
-                            nb: 'Arbeider eller har den andre forelderen til BARN BARNESSEN III arbeidet utenfor Norge, på utenlandsk skip eller på utenlandsk kontinentalsokkel?',
-                            nn: 'Arbeidar eller har den andre forelderen til BARN BARNESSEN III arbeida utanfor Noreg, på utanlandsk skip eller på utanlandsk kontinentalsokkel?',
+                            en: "Does Barn Barnessen III's other parent work, or have they worked outside of Norway, on a foreign ship or on a foreign continental shelf?",
+                            nb: 'Arbeider eller har den andre forelderen til Barn Barnessen III arbeidet utenfor Norge, på utenlandsk skip eller på utenlandsk kontinentalsokkel?',
+                            nn: 'Arbeidar eller har den andre forelderen til Barn Barnessen III arbeida utanfor Noreg, på utanlandsk skip eller på utanlandsk kontinentalsokkel?',
                         },
                         verdi: {
                             nb: null,
@@ -1639,9 +1639,9 @@ export const testdata4: TilKontraktTestData = {
                     },
                     skriftligAvtaleOmDeltBosted: {
                         label: {
-                            en: 'Do you and the other parent have a written agreement on dual residence for BARN BARNESSEN III?',
-                            nb: 'Har du og den andre forelderen skriftlig avtale om delt bosted for BARN BARNESSEN III?',
-                            nn: 'Har du og den andre forelderen skriftleg avtale om delt bustad for BARN BARNESSEN III?',
+                            en: 'Do you and the other parent have a written agreement on dual residence for Barn Barnessen III?',
+                            nb: 'Har du og den andre forelderen skriftlig avtale om delt bosted for Barn Barnessen III?',
+                            nn: 'Har du og den andre forelderen skriftleg avtale om delt bustad for Barn Barnessen III?',
                         },
                         verdi: {
                             nb: 'JA',
@@ -1652,9 +1652,9 @@ export const testdata4: TilKontraktTestData = {
                     utvidet: {
                         søkerHarBoddMedAndreForelder: {
                             label: {
-                                en: "Have you ever lived with BARN BARNESSEN III's other parent?",
-                                nb: 'Har du bodd sammen med BARN BARNESSEN III sin andre forelder?',
-                                nn: 'Har du budd saman med BARN BARNESSEN III sin andre forelder?',
+                                en: "Have you ever lived with Barn Barnessen III's other parent?",
+                                nb: 'Har du bodd sammen med Barn Barnessen III sin andre forelder?',
+                                nn: 'Har du budd saman med Barn Barnessen III sin andre forelder?',
                             },
                             verdi: {
                                 nb: 'JA',
@@ -1823,9 +1823,9 @@ export const testdata4: TilKontraktTestData = {
                     },
                     planleggerÅBoINorge12Mnd: {
                         label: {
-                            en: 'Is it planned that BARN BARNESSEN III will live in Norway continuously for more than 12 months?',
-                            nb: 'Er det planlagt at BARN BARNESSEN III skal bo sammenhengende i Norge i mer enn tolv måneder?',
-                            nn: 'Er det planlagd at BARN BARNESSEN III skal bu i Noreg samanhengande i meir enn tolv månadar?',
+                            en: 'Is it planned that Barn Barnessen III will live in Norway continuously for more than 12 months?',
+                            nb: 'Er det planlagt at Barn Barnessen III skal bo sammenhengende i Norge i mer enn tolv måneder?',
+                            nn: 'Er det planlagd at Barn Barnessen III skal bu i Noreg samanhengande i meir enn tolv månadar?',
                         },
                         verdi: {
                             nb: 'NEI',
@@ -1835,9 +1835,9 @@ export const testdata4: TilKontraktTestData = {
                     },
                     borFastMedSøker: {
                         label: {
-                            en: 'Does BARN BARNESSEN III live with you on a permanent basis?',
-                            nb: 'Bor BARN BARNESSEN III fast sammen med deg?',
-                            nn: 'Bur BARN BARNESSEN III fast saman med deg?',
+                            en: 'Does Barn Barnessen III live with you on a permanent basis?',
+                            nb: 'Bor Barn Barnessen III fast sammen med deg?',
+                            nn: 'Bur Barn Barnessen III fast saman med deg?',
                         },
                         verdi: {
                             nb: 'NEI',
@@ -1847,9 +1847,9 @@ export const testdata4: TilKontraktTestData = {
                     },
                     søkerForTidsrom: {
                         label: {
-                            en: 'Are you applying for child benefit for a particular period of time for BARN BARNESSEN III?',
-                            nb: 'Søker du barnetrygd for et spesielt tidsrom for BARN BARNESSEN III?',
-                            nn: 'Søker du barnetrygd for eit spesielt tidsrom for BARN BARNESSEN III?',
+                            en: 'Are you applying for child benefit for a particular period of time for Barn Barnessen III?',
+                            nb: 'Søker du barnetrygd for et spesielt tidsrom for Barn Barnessen III?',
+                            nn: 'Søker du barnetrygd for eit spesielt tidsrom for Barn Barnessen III?',
                         },
                         verdi: {
                             nb: 'NEI',

--- a/src/frontend/hooks/useSendInnSkjemaTest/test-data/testdata5.ts
+++ b/src/frontend/hooks/useSendInnSkjemaTest/test-data/testdata5.ts
@@ -7,7 +7,7 @@ export const testdata5: TilKontraktTestData = {
         barnInkludertISøknaden: [
             {
                 id: '786fb149-2331-4dc2-9b0e-b5f4768952d5',
-                navn: null,
+                navn: 'Barn 234567 89876',
                 ident: '23456789876',
                 alder: '13',
                 borMedSøker: false,
@@ -412,7 +412,7 @@ export const testdata5: TilKontraktTestData = {
             barn: [
                 {
                     id: '786fb149-2331-4dc2-9b0e-b5f4768952d5',
-                    navn: null,
+                    navn: 'Barn 234567 89876',
                     ident: '23456789876',
                     alder: '13',
                     borMedSøker: false,
@@ -1056,9 +1056,9 @@ export const testdata5: TilKontraktTestData = {
                     },
                     pensjonUtland: {
                         label: {
-                            en: "Does BARN 234567 89876's other parent receive, or have they received a pension from abroad?",
-                            nb: 'Får eller har den andre forelderen til BARN 234567 89876 fått pensjon fra utlandet?',
-                            nn: 'Får eller har den andre forelderen til BARN 234567 89876 fått pensjon frå utlandet?',
+                            en: "Does Barn 234567 89876's other parent receive, or have they received a pension from abroad?",
+                            nb: 'Får eller har den andre forelderen til Barn 234567 89876 fått pensjon fra utlandet?',
+                            nn: 'Får eller har den andre forelderen til Barn 234567 89876 fått pensjon frå utlandet?',
                         },
                         verdi: {
                             nb: 'VET_IKKE',
@@ -1068,9 +1068,9 @@ export const testdata5: TilKontraktTestData = {
                     },
                     pensjonHvilketLand: {
                         label: {
-                            en: "What country does BARN 234567 89876's other parent receive a pension from?",
-                            nb: 'Hvilket land får den andre forelderen til BARN 234567 89876 pensjon fra?',
-                            nn: 'Kva land får den andre forelderen til BARN 234567 89876 pensjon frå?',
+                            en: "What country does Barn 234567 89876's other parent receive a pension from?",
+                            nb: 'Hvilket land får den andre forelderen til Barn 234567 89876 pensjon fra?',
+                            nn: 'Kva land får den andre forelderen til Barn 234567 89876 pensjon frå?',
                         },
                         verdi: {
                             nb: 'UKJENT',
@@ -1080,9 +1080,9 @@ export const testdata5: TilKontraktTestData = {
                     },
                     arbeidUtlandet: {
                         label: {
-                            en: "Does BARN 234567 89876's other parent work, or have they worked outside of Norway, on a foreign ship or on a foreign continental shelf?",
-                            nb: 'Arbeider eller har den andre forelderen til BARN 234567 89876 arbeidet utenfor Norge, på utenlandsk skip eller på utenlandsk kontinentalsokkel?',
-                            nn: 'Arbeidar eller har den andre forelderen til BARN 234567 89876 arbeida utanfor Noreg, på utanlandsk skip eller på utanlandsk kontinentalsokkel?',
+                            en: "Does Barn 234567 89876's other parent work, or have they worked outside of Norway, on a foreign ship or on a foreign continental shelf?",
+                            nb: 'Arbeider eller har den andre forelderen til Barn 234567 89876 arbeidet utenfor Norge, på utenlandsk skip eller på utenlandsk kontinentalsokkel?',
+                            nn: 'Arbeidar eller har den andre forelderen til Barn 234567 89876 arbeida utanfor Noreg, på utanlandsk skip eller på utanlandsk kontinentalsokkel?',
                         },
                         verdi: {
                             nb: 'VET_IKKE',
@@ -1104,9 +1104,9 @@ export const testdata5: TilKontraktTestData = {
                     },
                     skriftligAvtaleOmDeltBosted: {
                         label: {
-                            en: 'Do you and the other parent have a written agreement on dual residence for BARN 234567 89876?',
-                            nb: 'Har du og den andre forelderen skriftlig avtale om delt bosted for BARN 234567 89876?',
-                            nn: 'Har du og den andre forelderen skriftleg avtale om delt bustad for BARN 234567 89876?',
+                            en: 'Do you and the other parent have a written agreement on dual residence for Barn 234567 89876?',
+                            nb: 'Har du og den andre forelderen skriftlig avtale om delt bosted for Barn 234567 89876?',
+                            nn: 'Har du og den andre forelderen skriftleg avtale om delt bustad for Barn 234567 89876?',
                         },
                         verdi: {
                             nb: 'NEI',
@@ -1117,9 +1117,9 @@ export const testdata5: TilKontraktTestData = {
                     utvidet: {
                         søkerHarBoddMedAndreForelder: {
                             label: {
-                                en: "Have you ever lived with BARN 234567 89876's other parent?",
-                                nb: 'Har du bodd sammen med BARN 234567 89876 sin andre forelder?',
-                                nn: 'Har du budd saman med BARN 234567 89876 sin andre forelder?',
+                                en: "Have you ever lived with Barn 234567 89876's other parent?",
+                                nb: 'Har du bodd sammen med Barn 234567 89876 sin andre forelder?',
+                                nn: 'Har du budd saman med Barn 234567 89876 sin andre forelder?',
                             },
                             verdi: {
                                 nb: 'JA',
@@ -1240,9 +1240,9 @@ export const testdata5: TilKontraktTestData = {
                     },
                     borFastMedSøker: {
                         label: {
-                            en: 'Does BARN 234567 89876 live with you on a permanent basis?',
-                            nb: 'Bor BARN 234567 89876 fast sammen med deg?',
-                            nn: 'Bur BARN 234567 89876 fast saman med deg?',
+                            en: 'Does Barn 234567 89876 live with you on a permanent basis?',
+                            nb: 'Bor Barn 234567 89876 fast sammen med deg?',
+                            nn: 'Bur Barn 234567 89876 fast saman med deg?',
                         },
                         verdi: {
                             nb: 'JA',
@@ -1252,9 +1252,9 @@ export const testdata5: TilKontraktTestData = {
                     },
                     søkerForTidsrom: {
                         label: {
-                            en: 'Are you applying for child benefit for a particular period of time for BARN 234567 89876?',
-                            nb: 'Søker du barnetrygd for et spesielt tidsrom for BARN 234567 89876?',
-                            nn: 'Søker du barnetrygd for eit spesielt tidsrom for BARN 234567 89876?',
+                            en: 'Are you applying for child benefit for a particular period of time for Barn 234567 89876?',
+                            nb: 'Søker du barnetrygd for et spesielt tidsrom for Barn 234567 89876?',
+                            nn: 'Søker du barnetrygd for eit spesielt tidsrom for Barn 234567 89876?',
                         },
                         verdi: {
                             nb: 'NEI',
@@ -1348,9 +1348,9 @@ export const testdata5: TilKontraktTestData = {
                             nb: {
                                 utenlandsoppholdÅrsak: {
                                     label: {
-                                        en: 'What best describes the period BARN BARNESSEN III stayed outside of Norway?',
-                                        nb: 'Hva beskriver perioden BARN BARNESSEN III oppholdt seg utenfor Norge best?',
-                                        nn: 'Kva beskriv perioden BARN BARNESSEN III har opphalde seg utanfor Noreg best',
+                                        en: 'What best describes the period Barn Barnessen III stayed outside of Norway?',
+                                        nb: 'Hva beskriver perioden Barn Barnessen III oppholdt seg utenfor Norge best?',
+                                        nn: 'Kva beskriv perioden Barn Barnessen III har opphalde seg utanfor Noreg best',
                                     },
                                     verdi: {
                                         en: 'The child has stayed outside of Norway earlier',
@@ -1360,9 +1360,9 @@ export const testdata5: TilKontraktTestData = {
                                 },
                                 oppholdsland: {
                                     label: {
-                                        en: 'Which country was BARN BARNESSEN III staying in?',
-                                        nb: 'Hvilket land oppholdt BARN BARNESSEN III seg i?',
-                                        nn: 'Kva land oppheldt BARN BARNESSEN III seg i?',
+                                        en: 'Which country was Barn Barnessen III staying in?',
+                                        nb: 'Hvilket land oppholdt Barn Barnessen III seg i?',
+                                        nn: 'Kva land oppheldt Barn Barnessen III seg i?',
                                     },
                                     verdi: {
                                         nb: 'Belgia',
@@ -1398,9 +1398,9 @@ export const testdata5: TilKontraktTestData = {
                             nn: {
                                 utenlandsoppholdÅrsak: {
                                     label: {
-                                        en: 'What best describes the period BARN BARNESSEN III stayed outside of Norway?',
-                                        nb: 'Hva beskriver perioden BARN BARNESSEN III oppholdt seg utenfor Norge best?',
-                                        nn: 'Kva beskriv perioden BARN BARNESSEN III har opphalde seg utanfor Noreg best',
+                                        en: 'What best describes the period Barn Barnessen III stayed outside of Norway?',
+                                        nb: 'Hva beskriver perioden Barn Barnessen III oppholdt seg utenfor Norge best?',
+                                        nn: 'Kva beskriv perioden Barn Barnessen III har opphalde seg utanfor Noreg best',
                                     },
                                     verdi: {
                                         en: 'The child has stayed outside of Norway earlier',
@@ -1410,9 +1410,9 @@ export const testdata5: TilKontraktTestData = {
                                 },
                                 oppholdsland: {
                                     label: {
-                                        en: 'Which country was BARN BARNESSEN III staying in?',
-                                        nb: 'Hvilket land oppholdt BARN BARNESSEN III seg i?',
-                                        nn: 'Kva land oppheldt BARN BARNESSEN III seg i?',
+                                        en: 'Which country was Barn Barnessen III staying in?',
+                                        nb: 'Hvilket land oppholdt Barn Barnessen III seg i?',
+                                        nn: 'Kva land oppheldt Barn Barnessen III seg i?',
                                     },
                                     verdi: {
                                         nb: 'Belgia',
@@ -1448,9 +1448,9 @@ export const testdata5: TilKontraktTestData = {
                             en: {
                                 utenlandsoppholdÅrsak: {
                                     label: {
-                                        en: 'What best describes the period BARN BARNESSEN III stayed outside of Norway?',
-                                        nb: 'Hva beskriver perioden BARN BARNESSEN III oppholdt seg utenfor Norge best?',
-                                        nn: 'Kva beskriv perioden BARN BARNESSEN III har opphalde seg utanfor Noreg best',
+                                        en: 'What best describes the period Barn Barnessen III stayed outside of Norway?',
+                                        nb: 'Hva beskriver perioden Barn Barnessen III oppholdt seg utenfor Norge best?',
+                                        nn: 'Kva beskriv perioden Barn Barnessen III har opphalde seg utanfor Noreg best',
                                     },
                                     verdi: {
                                         en: 'The child has stayed outside of Norway earlier',
@@ -1460,9 +1460,9 @@ export const testdata5: TilKontraktTestData = {
                                 },
                                 oppholdsland: {
                                     label: {
-                                        en: 'Which country was BARN BARNESSEN III staying in?',
-                                        nb: 'Hvilket land oppholdt BARN BARNESSEN III seg i?',
-                                        nn: 'Kva land oppheldt BARN BARNESSEN III seg i?',
+                                        en: 'Which country was Barn Barnessen III staying in?',
+                                        nb: 'Hvilket land oppholdt Barn Barnessen III seg i?',
+                                        nn: 'Kva land oppheldt Barn Barnessen III seg i?',
                                     },
                                     verdi: {
                                         nb: 'Belgia',
@@ -1537,9 +1537,9 @@ export const testdata5: TilKontraktTestData = {
                     },
                     pensjonUtland: {
                         label: {
-                            en: "Does BARN BARNESSEN III's other parent receive, or have they received a pension from abroad?",
-                            nb: 'Får eller har den andre forelderen til BARN BARNESSEN III fått pensjon fra utlandet?',
-                            nn: 'Får eller har den andre forelderen til BARN BARNESSEN III fått pensjon frå utlandet?',
+                            en: "Does Barn Barnessen III's other parent receive, or have they received a pension from abroad?",
+                            nb: 'Får eller har den andre forelderen til Barn Barnessen III fått pensjon fra utlandet?',
+                            nn: 'Får eller har den andre forelderen til Barn Barnessen III fått pensjon frå utlandet?',
                         },
                         verdi: {
                             nb: 'VET_IKKE',
@@ -1549,9 +1549,9 @@ export const testdata5: TilKontraktTestData = {
                     },
                     pensjonHvilketLand: {
                         label: {
-                            en: "What country does BARN BARNESSEN III's other parent receive a pension from?",
-                            nb: 'Hvilket land får den andre forelderen til BARN BARNESSEN III pensjon fra?',
-                            nn: 'Kva land får den andre forelderen til BARN BARNESSEN III pensjon frå?',
+                            en: "What country does Barn Barnessen III's other parent receive a pension from?",
+                            nb: 'Hvilket land får den andre forelderen til Barn Barnessen III pensjon fra?',
+                            nn: 'Kva land får den andre forelderen til Barn Barnessen III pensjon frå?',
                         },
                         verdi: {
                             nb: 'UKJENT',
@@ -1561,9 +1561,9 @@ export const testdata5: TilKontraktTestData = {
                     },
                     arbeidUtlandet: {
                         label: {
-                            en: "Does BARN BARNESSEN III's other parent work, or have they worked outside of Norway, on a foreign ship or on a foreign continental shelf?",
-                            nb: 'Arbeider eller har den andre forelderen til BARN BARNESSEN III arbeidet utenfor Norge, på utenlandsk skip eller på utenlandsk kontinentalsokkel?',
-                            nn: 'Arbeidar eller har den andre forelderen til BARN BARNESSEN III arbeida utanfor Noreg, på utanlandsk skip eller på utanlandsk kontinentalsokkel?',
+                            en: "Does Barn Barnessen III's other parent work, or have they worked outside of Norway, on a foreign ship or on a foreign continental shelf?",
+                            nb: 'Arbeider eller har den andre forelderen til Barn Barnessen III arbeidet utenfor Norge, på utenlandsk skip eller på utenlandsk kontinentalsokkel?',
+                            nn: 'Arbeidar eller har den andre forelderen til Barn Barnessen III arbeida utanfor Noreg, på utanlandsk skip eller på utanlandsk kontinentalsokkel?',
                         },
                         verdi: {
                             nb: 'VET_IKKE',
@@ -1585,9 +1585,9 @@ export const testdata5: TilKontraktTestData = {
                     },
                     skriftligAvtaleOmDeltBosted: {
                         label: {
-                            en: 'Do you and the other parent have a written agreement on dual residence for BARN BARNESSEN III?',
-                            nb: 'Har du og den andre forelderen skriftlig avtale om delt bosted for BARN BARNESSEN III?',
-                            nn: 'Har du og den andre forelderen skriftleg avtale om delt bustad for BARN BARNESSEN III?',
+                            en: 'Do you and the other parent have a written agreement on dual residence for Barn Barnessen III?',
+                            nb: 'Har du og den andre forelderen skriftlig avtale om delt bosted for Barn Barnessen III?',
+                            nn: 'Har du og den andre forelderen skriftleg avtale om delt bustad for Barn Barnessen III?',
                         },
                         verdi: {
                             nb: 'NEI',
@@ -1598,9 +1598,9 @@ export const testdata5: TilKontraktTestData = {
                     utvidet: {
                         søkerHarBoddMedAndreForelder: {
                             label: {
-                                en: "Have you ever lived with BARN BARNESSEN III's other parent?",
-                                nb: 'Har du bodd sammen med BARN BARNESSEN III sin andre forelder?',
-                                nn: 'Har du budd saman med BARN BARNESSEN III sin andre forelder?',
+                                en: "Have you ever lived with Barn Barnessen III's other parent?",
+                                nb: 'Har du bodd sammen med Barn Barnessen III sin andre forelder?',
+                                nn: 'Har du budd saman med Barn Barnessen III sin andre forelder?',
                             },
                             verdi: {
                                 nb: 'JA',
@@ -1625,9 +1625,9 @@ export const testdata5: TilKontraktTestData = {
                 spørsmål: {
                     sammeForelderSomAnnetBarnMedId: {
                         label: {
-                            en: "Who is BARN BARNESSEN III's other parent?",
-                            nb: 'Hvem er BARN BARNESSEN III sin andre forelder?',
-                            nn: 'Kven er BARN BARNESSEN III sin andre forelder?',
+                            en: "Who is Barn Barnessen III's other parent?",
+                            nb: 'Hvem er Barn Barnessen III sin andre forelder?',
+                            nn: 'Kven er Barn Barnessen III sin andre forelder?',
                         },
                         verdi: {
                             nb: 'ANNEN_FORELDER',
@@ -1733,9 +1733,9 @@ export const testdata5: TilKontraktTestData = {
                     },
                     planleggerÅBoINorge12Mnd: {
                         label: {
-                            en: 'Is it planned that BARN BARNESSEN III will live in Norway continuously for more than 12 months?',
-                            nb: 'Er det planlagt at BARN BARNESSEN III skal bo sammenhengende i Norge i mer enn tolv måneder?',
-                            nn: 'Er det planlagd at BARN BARNESSEN III skal bu i Noreg samanhengande i meir enn tolv månadar?',
+                            en: 'Is it planned that Barn Barnessen III will live in Norway continuously for more than 12 months?',
+                            nb: 'Er det planlagt at Barn Barnessen III skal bo sammenhengende i Norge i mer enn tolv måneder?',
+                            nn: 'Er det planlagd at Barn Barnessen III skal bu i Noreg samanhengande i meir enn tolv månadar?',
                         },
                         verdi: {
                             nb: 'NEI',
@@ -1745,9 +1745,9 @@ export const testdata5: TilKontraktTestData = {
                     },
                     borFastMedSøker: {
                         label: {
-                            en: 'Does BARN BARNESSEN III live with you on a permanent basis?',
-                            nb: 'Bor BARN BARNESSEN III fast sammen med deg?',
-                            nn: 'Bur BARN BARNESSEN III fast saman med deg?',
+                            en: 'Does Barn Barnessen III live with you on a permanent basis?',
+                            nb: 'Bor Barn Barnessen III fast sammen med deg?',
+                            nn: 'Bur Barn Barnessen III fast saman med deg?',
                         },
                         verdi: {
                             nb: 'JA',
@@ -1757,9 +1757,9 @@ export const testdata5: TilKontraktTestData = {
                     },
                     søkerForTidsrom: {
                         label: {
-                            en: 'Are you applying for child benefit for a particular period of time for BARN BARNESSEN III?',
-                            nb: 'Søker du barnetrygd for et spesielt tidsrom for BARN BARNESSEN III?',
-                            nn: 'Søker du barnetrygd for eit spesielt tidsrom for BARN BARNESSEN III?',
+                            en: 'Are you applying for child benefit for a particular period of time for Barn Barnessen III?',
+                            nb: 'Søker du barnetrygd for et spesielt tidsrom for Barn Barnessen III?',
+                            nn: 'Søker du barnetrygd for eit spesielt tidsrom for Barn Barnessen III?',
                         },
                         verdi: {
                             nb: 'JA',

--- a/src/frontend/typer/person.ts
+++ b/src/frontend/typer/person.ts
@@ -34,7 +34,7 @@ export interface ISøkerRespons extends IPerson {
 
 export interface IBarn extends IPerson {
     id: BarnetsId;
-    navn: string | null;
+    navn: string;
     borMedSøker: boolean | undefined;
     alder: string | undefined;
 }

--- a/src/frontend/utils/barn.ts
+++ b/src/frontend/utils/barn.ts
@@ -532,10 +532,10 @@ export const hentUid = () => {
     });
 };
 
-export const mapBarnResponsTilBarn = (barn: IBarnRespons[]): IBarn[] => {
+export const mapBarnResponsTilBarn = (barn: IBarnRespons[], intl): IBarn[] => {
     return barn.map(barnRespons => ({
         id: hentUid(),
-        navn: barnRespons.navn,
+        navn: barnetsNavnValue(barnRespons, intl),
         ident: barnRespons.ident,
         alder: barnRespons.fødselsdato && hentAlder(barnRespons.fødselsdato),
         borMedSøker: barnRespons.borMedSøker,
@@ -543,9 +543,9 @@ export const mapBarnResponsTilBarn = (barn: IBarnRespons[]): IBarn[] => {
     }));
 };
 
-export const barnetsNavnValue = (barn: IBarn, intl: IntlShape): string => {
+export const barnetsNavnValue = (barn: IBarnRespons, intl: IntlShape): string => {
     return barn.navn
-        ? barn.navn.toUpperCase()
+        ? barn.navn
         : intl.formatMessage(
               { id: 'felles.anonym.barn.fnr' },
               { fødselsnummer: formaterFnr(barn.ident) }

--- a/src/frontend/utils/mappingTilKontrakt/andreForelder.ts
+++ b/src/frontend/utils/mappingTilKontrakt/andreForelder.ts
@@ -1,5 +1,3 @@
-import { IntlShape } from 'react-intl';
-
 import { ESvar } from '@navikt/familie-form-elements';
 
 import {
@@ -23,7 +21,6 @@ import {
 } from './hjelpefunksjoner';
 
 export const andreForelderTilISøknadsfelt = (
-    intl: IntlShape,
     andreForelder: IAndreForelder,
     barn: IBarnMedISøknad
 ): IAndreForelderIKontraktFormat => {
@@ -31,7 +28,6 @@ export const andreForelderTilISøknadsfelt = (
     const forelderErDød = barn[barnDataKeySpørsmål.andreForelderErDød].svar === ESvar.JA;
     return {
         [andreForelderDataKeySpørsmål.navn]: søknadsfeltBarn(
-            intl,
             språktekstIdFraSpørsmålId(OmBarnetSpørsmålsId.andreForelderNavn),
             sammeVerdiAlleSpråkEllerUkjentSpråktekst(
                 navn.svar,
@@ -40,7 +36,6 @@ export const andreForelderTilISøknadsfelt = (
             barn
         ),
         [andreForelderDataKeySpørsmål.fnr]: søknadsfeltBarn(
-            intl,
             språktekstIdFraSpørsmålId(OmBarnetSpørsmålsId.andreForelderFnr),
             sammeVerdiAlleSpråkEllerUkjentSpråktekst(
                 fnr.svar,
@@ -49,7 +44,6 @@ export const andreForelderTilISøknadsfelt = (
             barn
         ),
         [andreForelderDataKeySpørsmål.fødselsdato]: søknadsfeltBarn(
-            intl,
             språktekstIdFraSpørsmålId(OmBarnetSpørsmålsId.andreForelderFødselsdato),
             sammeVerdiAlleSpråkEllerUkjentSpråktekst(
                 fødselsdato.svar,
@@ -58,7 +52,6 @@ export const andreForelderTilISøknadsfelt = (
             barn
         ),
         [andreForelderDataKeySpørsmål.pensjonUtland]: søknadsfeltBarn(
-            intl,
             språktekstIdFraSpørsmålId(
                 forelderErDød
                     ? OmBarnetSpørsmålsId.andreForelderPensjonUtlandEnke
@@ -69,7 +62,6 @@ export const andreForelderTilISøknadsfelt = (
         ),
 
         [andreForelderDataKeySpørsmål.pensjonHvilketLand]: søknadsfeltBarn(
-            intl,
             språktekstIdFraSpørsmålId(
                 forelderErDød
                     ? OmBarnetSpørsmålsId.andreForelderPensjonHvilketLandEnke
@@ -84,7 +76,6 @@ export const andreForelderTilISøknadsfelt = (
             barn
         ),
         [andreForelderDataKeySpørsmål.arbeidUtlandet]: søknadsfeltBarn(
-            intl,
             språktekstIdFraSpørsmålId(
                 forelderErDød
                     ? OmBarnetSpørsmålsId.andreForelderArbeidUtlandetEnke
@@ -94,7 +85,6 @@ export const andreForelderTilISøknadsfelt = (
             barn
         ),
         [andreForelderDataKeySpørsmål.arbeidUtlandetHvilketLand]: søknadsfeltBarn(
-            intl,
             språktekstIdFraSpørsmålId(
                 forelderErDød
                     ? OmBarnetSpørsmålsId.andreForelderArbeidUtlandetHvilketLandEnke
@@ -109,7 +99,6 @@ export const andreForelderTilISøknadsfelt = (
             barn
         ),
         [andreForelderDataKeySpørsmål.skriftligAvtaleOmDeltBosted]: søknadsfeltBarn(
-            intl,
             språktekstIdFraSpørsmålId(OmBarnetSpørsmålsId.skriftligAvtaleOmDeltBosted),
             sammeVerdiAlleSpråk(
                 andreForelder[andreForelderDataKeySpørsmål.skriftligAvtaleOmDeltBosted].svar
@@ -118,7 +107,6 @@ export const andreForelderTilISøknadsfelt = (
         ),
         utvidet: {
             [andreForelderDataKeySpørsmål.søkerHarBoddMedAndreForelder]: søknadsfeltBarn(
-                intl,
                 språktekstIdFraSpørsmålId(OmBarnetSpørsmålsId.søkerHarBoddMedAndreForelder),
                 sammeVerdiAlleSpråk(
                     andreForelder.utvidet[andreForelderDataKeySpørsmål.søkerHarBoddMedAndreForelder]
@@ -127,7 +115,6 @@ export const andreForelderTilISøknadsfelt = (
                 barn
             ),
             [andreForelderDataKeySpørsmål.søkerFlyttetFraAndreForelderDato]: søknadsfeltBarn(
-                intl,
                 språktekstIdFraSpørsmålId(OmBarnetSpørsmålsId.søkerFlyttetFraAndreForelderDato),
                 sammeVerdiAlleSpråkEllerUkjentSpråktekst(
                     andreForelder.utvidet[

--- a/src/frontend/utils/mappingTilKontrakt/andreForelderV7.ts
+++ b/src/frontend/utils/mappingTilKontrakt/andreForelderV7.ts
@@ -1,5 +1,3 @@
-import { IntlShape } from 'react-intl';
-
 import { ESvar } from '@navikt/familie-form-elements';
 import { LocaleType } from '@navikt/familie-sprakvelger';
 
@@ -18,7 +16,6 @@ import {
     IBarnMedISøknad,
 } from '../../typer/barn';
 import { IAndreForelderIKontraktFormatV7 } from '../../typer/kontrakt/v7';
-import { barnetsNavnValue } from '../barn';
 import { tilIAndreUtbetalingsperioderIKontraktFormat } from './andreUtbetalingsperioder';
 import { tilIArbeidsperiodeIKontraktFormat } from './arbeidsperioder';
 import {
@@ -31,7 +28,6 @@ import { idNummerTilISøknadsfelt } from './idNummer';
 import { tilIPensjonsperiodeIKontraktFormat } from './pensjonsperioder';
 
 export const andreForelderTilISøknadsfeltV7 = (
-    intl: IntlShape,
     andreForelder: IAndreForelder,
     barn: IBarnMedISøknad,
     valgtSpråk: LocaleType
@@ -53,7 +49,6 @@ export const andreForelderTilISøknadsfeltV7 = (
     return {
         kanIkkeGiOpplysninger,
         [andreForelderDataKeySpørsmål.navn]: søknadsfeltBarn(
-            intl,
             språktekstIdFraSpørsmålId(OmBarnetSpørsmålsId.andreForelderNavn),
             sammeVerdiAlleSpråkEllerUkjentSpråktekst(
                 navn.svar,
@@ -62,7 +57,6 @@ export const andreForelderTilISøknadsfeltV7 = (
             barn
         ),
         [andreForelderDataKeySpørsmål.fnr]: søknadsfeltBarn(
-            intl,
             språktekstIdFraSpørsmålId(OmBarnetSpørsmålsId.andreForelderFnr),
             sammeVerdiAlleSpråkEllerUkjentSpråktekst(
                 fnr.svar,
@@ -71,7 +65,6 @@ export const andreForelderTilISøknadsfeltV7 = (
             barn
         ),
         [andreForelderDataKeySpørsmål.fødselsdato]: søknadsfeltBarn(
-            intl,
             språktekstIdFraSpørsmålId(OmBarnetSpørsmålsId.andreForelderFødselsdato),
             sammeVerdiAlleSpråkEllerUkjentSpråktekst(
                 fødselsdato.svar,
@@ -80,7 +73,6 @@ export const andreForelderTilISøknadsfeltV7 = (
             barn
         ),
         [andreForelderDataKeySpørsmål.pensjonUtland]: søknadsfeltBarn(
-            intl,
             språktekstIdFraSpørsmålId(
                 forelderErDød
                     ? OmBarnetSpørsmålsId.andreForelderPensjonUtlandEnke
@@ -90,7 +82,6 @@ export const andreForelderTilISøknadsfeltV7 = (
             barn
         ),
         [andreForelderDataKeySpørsmål.arbeidUtlandet]: søknadsfeltBarn(
-            intl,
             språktekstIdFraSpørsmålId(
                 forelderErDød
                     ? OmBarnetSpørsmålsId.andreForelderArbeidUtlandetEnke
@@ -100,7 +91,6 @@ export const andreForelderTilISøknadsfeltV7 = (
             barn
         ),
         [andreForelderDataKeySpørsmål.pensjonNorge]: søknadsfeltBarn(
-            intl,
             språktekstIdFraSpørsmålId(
                 forelderErDød
                     ? EøsBarnSpørsmålId.andreForelderPensjonNorgeEnke
@@ -110,7 +100,6 @@ export const andreForelderTilISøknadsfeltV7 = (
             barn
         ),
         [andreForelderDataKeySpørsmål.arbeidNorge]: søknadsfeltBarn(
-            intl,
             språktekstIdFraSpørsmålId(
                 forelderErDød
                     ? EøsBarnSpørsmålId.andreForelderArbeidNorgeEnke
@@ -120,7 +109,6 @@ export const andreForelderTilISøknadsfeltV7 = (
             barn
         ),
         [andreForelderDataKeySpørsmål.andreUtbetalinger]: søknadsfeltBarn(
-            intl,
             språktekstIdFraSpørsmålId(
                 forelderErDød
                     ? EøsBarnSpørsmålId.andreForelderAndreUtbetalingerEnke
@@ -130,7 +118,6 @@ export const andreForelderTilISøknadsfeltV7 = (
             barn
         ),
         [andreForelderDataKeySpørsmål.skriftligAvtaleOmDeltBosted]: søknadsfeltBarn(
-            intl,
             språktekstIdFraSpørsmålId(OmBarnetSpørsmålsId.skriftligAvtaleOmDeltBosted),
             sammeVerdiAlleSpråk(
                 andreForelder[andreForelderDataKeySpørsmål.skriftligAvtaleOmDeltBosted].svar
@@ -138,7 +125,6 @@ export const andreForelderTilISøknadsfeltV7 = (
             barn
         ),
         [andreForelderDataKeySpørsmål.adresse]: søknadsfeltBarn(
-            intl,
             språktekstIdFraSpørsmålId(EøsBarnSpørsmålId.andreForelderAdresse),
             sammeVerdiAlleSpråkEllerUkjentSpråktekst(
                 adresse.svar,
@@ -148,7 +134,6 @@ export const andreForelderTilISøknadsfeltV7 = (
         ),
         utvidet: {
             [andreForelderDataKeySpørsmål.søkerHarBoddMedAndreForelder]: søknadsfeltBarn(
-                intl,
                 språktekstIdFraSpørsmålId(OmBarnetSpørsmålsId.søkerHarBoddMedAndreForelder),
                 sammeVerdiAlleSpråk(
                     andreForelder.utvidet[andreForelderDataKeySpørsmål.søkerHarBoddMedAndreForelder]
@@ -157,7 +142,6 @@ export const andreForelderTilISøknadsfeltV7 = (
                 barn
             ),
             [andreForelderDataKeySpørsmål.søkerFlyttetFraAndreForelderDato]: søknadsfeltBarn(
-                intl,
                 språktekstIdFraSpørsmålId(OmBarnetSpørsmålsId.søkerFlyttetFraAndreForelderDato),
                 sammeVerdiAlleSpråkEllerUkjentSpråktekst(
                     andreForelder.utvidet[
@@ -184,7 +168,6 @@ export const andreForelderTilISøknadsfeltV7 = (
                 erAndreForelderDød: forelderErDød,
                 gjelderUtlandet: true,
                 barn,
-                intl,
             })
         ),
         arbeidsperioderNorge: arbeidsperioderNorge.map((periode, index) =>
@@ -204,7 +187,6 @@ export const andreForelderTilISøknadsfeltV7 = (
                 erAndreForelderDød: forelderErDød,
                 gjelderUtlandet: false,
                 barn,
-                intl,
             })
         ),
         andreUtbetalingsperioder: andreUtbetalingsperioder.map((periode, index) =>
@@ -214,7 +196,6 @@ export const andreForelderTilISøknadsfeltV7 = (
                 gjelderAndreForelder: true,
                 erAndreForelderDød: forelderErDød,
                 barn,
-                intl,
             })
         ),
         idNummer: idNummer.map(idnummerObj =>
@@ -223,7 +204,7 @@ export const andreForelderTilISøknadsfeltV7 = (
                 eøsBarnSpørsmålSpråkId[EøsBarnSpørsmålId.idNummerAndreForelder],
                 eøsBarnSpørsmålSpråkId[EøsBarnSpørsmålId.idNummerUkjent],
                 valgtSpråk,
-                barnetsNavnValue(barn, intl)
+                barn.navn
             )
         ),
     };

--- a/src/frontend/utils/mappingTilKontrakt/andreUtbetalingsperioder.ts
+++ b/src/frontend/utils/mappingTilKontrakt/andreUtbetalingsperioder.ts
@@ -1,5 +1,3 @@
-import { IntlShape } from 'react-intl';
-
 import { ESvar } from '@navikt/familie-form-elements';
 
 import {
@@ -10,7 +8,6 @@ import { IBarnMedISøknad } from '../../typer/barn';
 import { ISøknadsfelt } from '../../typer/kontrakt/generelle';
 import { IUtbetalingsperiodeIKontraktFormatV7 } from '../../typer/kontrakt/v7';
 import { IUtbetalingsperiode } from '../../typer/perioder';
-import { barnetsNavnValue } from '../barn';
 import { hentTekster, landkodeTilSpråk } from '../språk';
 import {
     sammeVerdiAlleSpråk,
@@ -24,14 +21,12 @@ export const tilIAndreUtbetalingsperioderIKontraktFormat = ({
     gjelderAndreForelder,
     erAndreForelderDød,
     barn,
-    intl,
 }: {
     periode: IUtbetalingsperiode;
     periodeNummer: number;
     gjelderAndreForelder: boolean;
     erAndreForelderDød: boolean;
     barn?: IBarnMedISøknad;
-    intl?: IntlShape;
 }): ISøknadsfelt<IUtbetalingsperiodeIKontraktFormatV7> => {
     const { fårUtbetalingNå, utbetalingLand, utbetalingFraDato, utbetalingTilDato } = periode;
     const periodenErAvsluttet = fårUtbetalingNå?.svar === ESvar.NEI || erAndreForelderDød;
@@ -41,7 +36,7 @@ export const tilIAndreUtbetalingsperioderIKontraktFormat = ({
             hentUtbetalingsperiodeSpørsmålIder(gjelderAndreForelder, periodenErAvsluttet)[
                 utbetalingsSpørsmålId
             ],
-            { ...(barn && intl && { barn: barnetsNavnValue(barn, intl) }) }
+            { ...(barn && { barn: barn.navn }) }
         );
     return {
         label: hentTekster('felles.flereytelser.periode', {

--- a/src/frontend/utils/mappingTilKontrakt/barn.ts
+++ b/src/frontend/utils/mappingTilKontrakt/barn.ts
@@ -1,5 +1,3 @@
-import { IntlShape } from 'react-intl';
-
 import {
     OmBarnetSpørsmålsId,
     omBarnetSpørsmålSpråkId,
@@ -9,7 +7,6 @@ import { AlternativtSvarForInput } from '../../typer/common';
 import { ISøknadKontraktBarn } from '../../typer/kontrakt/barn';
 import { ERegistrertBostedType } from '../../typer/kontrakt/generelle';
 import { ISøknadSpørsmålMap } from '../../typer/spørsmål';
-import { barnetsNavnValue } from '../barn';
 import { hentTekster } from '../språk';
 import { formaterFnr } from '../visning';
 import { andreForelderTilISøknadsfelt } from './andreForelder';
@@ -22,7 +19,7 @@ import {
 } from './hjelpefunksjoner';
 import { utenlandsperiodeTilISøknadsfelt } from './utenlandsperiode';
 
-export const barnISøknadsFormat = (intl: IntlShape, barn: IBarnMedISøknad): ISøknadKontraktBarn => {
+export const barnISøknadsFormat = (barn: IBarnMedISøknad): ISøknadKontraktBarn => {
     /* eslint-disable @typescript-eslint/no-unused-vars */
     const {
         id,
@@ -73,28 +70,21 @@ export const barnISøknadsFormat = (intl: IntlShape, barn: IBarnMedISøknad): IS
 
     return {
         navn: søknadsfeltBarn(
-            intl,
             'pdf.barn.navn.label',
             sammeVerdiAlleSpråk(navn ?? `Barn ${formaterFnr(ident)}`),
             barn
         ),
         ident: søknadsfeltBarn(
-            intl,
-
             'pdf.barn.ident.label',
             ident ? sammeVerdiAlleSpråk(ident) : hentTekster('pdf.barn.ikke-oppgitt'),
             barn
         ),
         registrertBostedType: søknadsfeltBarn(
-            intl,
-
             'hvilkebarn.barn.bosted',
             sammeVerdiAlleSpråk(registertBostedVerdi()),
             barn
         ),
         alder: søknadsfeltBarn(
-            intl,
-
             'pdf.barn.alder.label',
             alder
                 ? hentTekster('felles.år', { alder })
@@ -102,19 +92,15 @@ export const barnISøknadsFormat = (intl: IntlShape, barn: IBarnMedISøknad): IS
             barn
         ),
         utenlandsperioder: utenlandsperioder.map((periode, index) =>
-            utenlandsperiodeTilISøknadsfelt(intl, periode, index + 1, barn)
+            utenlandsperiodeTilISøknadsfelt(periode, index + 1, barn)
         ),
-        andreForelder: andreForelder
-            ? andreForelderTilISøknadsfelt(intl, andreForelder, barn)
-            : null,
+        andreForelder: andreForelder ? andreForelderTilISøknadsfelt(andreForelder, barn) : null,
         spørsmål: {
             ...spørmålISøknadsFormat(typetBarnSpørsmål, {
-                navn: barnetsNavnValue(barn, intl),
-                barn: barnetsNavnValue(barn, intl),
+                navn: barn.navn,
+                barn: barn.navn,
             }),
             [barnDataKeySpørsmål.søkerForTidsromSluttdato]: søknadsfeltBarn(
-                intl,
-
                 språktekstIdFraSpørsmålId(OmBarnetSpørsmålsId.søkerForTidsromSluttdato),
                 sammeVerdiAlleSpråkEllerUkjentSpråktekst(
                     søkerForTidsromSluttdato.svar,
@@ -124,8 +110,6 @@ export const barnISøknadsFormat = (intl: IntlShape, barn: IBarnMedISøknad): IS
             ),
 
             [barnDataKeySpørsmål.institusjonOppholdSluttdato]: søknadsfeltBarn(
-                intl,
-
                 språktekstIdFraSpørsmålId(OmBarnetSpørsmålsId.institusjonOppholdSluttdato),
                 sammeVerdiAlleSpråkEllerUkjentSpråktekst(
                     institusjonOppholdSluttdato.svar,

--- a/src/frontend/utils/mappingTilKontrakt/barnV7.ts
+++ b/src/frontend/utils/mappingTilKontrakt/barnV7.ts
@@ -1,5 +1,3 @@
-import { IntlShape } from 'react-intl';
-
 import { LocaleType } from '@navikt/familie-sprakvelger';
 
 import {
@@ -16,9 +14,7 @@ import { ERegistrertBostedType } from '../../typer/kontrakt/generelle';
 import { ISøknadIKontraktBarnV7 } from '../../typer/kontrakt/v7';
 import { ISøker } from '../../typer/person';
 import { ISøknadSpørsmålMap } from '../../typer/spørsmål';
-import { barnetsNavnValue } from '../barn';
 import { hentTekster } from '../språk';
-import { formaterFnr } from '../visning';
 import { andreForelderTilISøknadsfeltV7 } from './andreForelderV7';
 import { tilIEøsBarnetrygsperiodeIKontraktFormat } from './eøsBarnetrygdsperiode';
 import {
@@ -33,7 +29,6 @@ import { omsorgspersonTilISøknadsfeltV7 } from './omsorgspersonV7';
 import { utenlandsperiodeTilISøknadsfelt } from './utenlandsperiode';
 
 export const barnISøknadsFormatV7 = (
-    intl: IntlShape,
     barn: IBarnMedISøknad,
     søker: ISøker,
     valgtSpråk: LocaleType
@@ -89,29 +84,18 @@ export const barnISøknadsFormatV7 = (
 
     return {
         harEøsSteg: triggetEøs || søker.triggetEøs,
-        navn: søknadsfeltBarn(
-            intl,
-            'pdf.barn.navn.label',
-            sammeVerdiAlleSpråk(navn ?? `Barn ${formaterFnr(ident)}`),
-            barn
-        ),
+        navn: søknadsfeltBarn('pdf.barn.navn.label', sammeVerdiAlleSpråk(navn), barn),
         ident: søknadsfeltBarn(
-            intl,
-
             'pdf.barn.ident.label',
             ident ? sammeVerdiAlleSpråk(ident) : hentTekster('pdf.barn.ikke-oppgitt'),
             barn
         ),
         registrertBostedType: søknadsfeltBarn(
-            intl,
-
             'hvilkebarn.barn.bosted',
             sammeVerdiAlleSpråk(registertBostedVerdi()),
             barn
         ),
         alder: søknadsfeltBarn(
-            intl,
-
             'pdf.barn.alder.label',
             alder
                 ? hentTekster('felles.år', { alder })
@@ -119,11 +103,10 @@ export const barnISøknadsFormatV7 = (
             barn
         ),
         utenlandsperioder: utenlandsperioder.map((periode, index) =>
-            utenlandsperiodeTilISøknadsfelt(intl, periode, index + 1, barn)
+            utenlandsperiodeTilISøknadsfelt(periode, index + 1, barn)
         ),
         eøsBarnetrygdsperioder: barn.eøsBarnetrygdsperioder.map((periode, index) =>
             tilIEøsBarnetrygsperiodeIKontraktFormat({
-                intl,
                 periode,
                 periodeNummer: index + 1,
                 barn,
@@ -135,23 +118,20 @@ export const barnISøknadsFormatV7 = (
                 eøsBarnSpørsmålSpråkId[EøsBarnSpørsmålId.idNummer],
                 eøsBarnSpørsmålSpråkId[EøsBarnSpørsmålId.idNummerUkjent],
                 valgtSpråk,
-                barnetsNavnValue(barn, intl)
+                barn.navn
             )
         ),
         andreForelder: andreForelder
-            ? andreForelderTilISøknadsfeltV7(intl, andreForelder, barn, valgtSpråk)
+            ? andreForelderTilISøknadsfeltV7(andreForelder, barn, valgtSpråk)
             : null,
 
-        omsorgsperson: omsorgsperson
-            ? omsorgspersonTilISøknadsfeltV7(intl, omsorgsperson, barn)
-            : null,
+        omsorgsperson: omsorgsperson ? omsorgspersonTilISøknadsfeltV7(omsorgsperson, barn) : null,
         spørsmål: {
             ...spørmålISøknadsFormat(typetBarnSpørsmål, {
-                navn: barnetsNavnValue(barn, intl),
-                barn: barnetsNavnValue(barn, intl),
+                navn: barn.navn,
+                barn: barn.navn,
             }),
             [barnDataKeySpørsmål.søkerForTidsromSluttdato]: søknadsfeltBarn(
-                intl,
                 språktekstIdFraSpørsmålId(OmBarnetSpørsmålsId.søkerForTidsromSluttdato),
                 sammeVerdiAlleSpråkEllerUkjentSpråktekst(
                     søkerForTidsromSluttdato.svar,
@@ -160,7 +140,6 @@ export const barnISøknadsFormatV7 = (
                 barn
             ),
             [barnDataKeySpørsmål.institusjonOppholdSluttdato]: søknadsfeltBarn(
-                intl,
                 språktekstIdFraSpørsmålId(OmBarnetSpørsmålsId.institusjonOppholdSluttdato),
                 sammeVerdiAlleSpråkEllerUkjentSpråktekst(
                     institusjonOppholdSluttdato.svar,
@@ -169,7 +148,6 @@ export const barnISøknadsFormatV7 = (
                 barn
             ),
             [barnDataKeySpørsmål.adresse]: søknadsfeltBarn(
-                intl,
                 språktekstIdFraSpørsmålId(EøsBarnSpørsmålId.barnetsAdresse),
                 sammeVerdiAlleSpråkEllerUkjentSpråktekst(
                     adresse.svar,

--- a/src/frontend/utils/mappingTilKontrakt/eøsBarnetrygdsperiode.ts
+++ b/src/frontend/utils/mappingTilKontrakt/eøsBarnetrygdsperiode.ts
@@ -1,5 +1,3 @@
-import { IntlShape } from 'react-intl';
-
 import { ESvar } from '@navikt/familie-form-elements';
 
 import {
@@ -10,17 +8,14 @@ import { IBarnMedISøknad } from '../../typer/barn';
 import { ISøknadsfelt } from '../../typer/kontrakt/generelle';
 import { IEøsBarnetrygdsperiodeIKontraktFormatV7 } from '../../typer/kontrakt/v7';
 import { IEøsBarnetrygdsperiode } from '../../typer/perioder';
-import { barnetsNavnValue } from '../barn';
 import { hentTekster, landkodeTilSpråk } from '../språk';
 import { sammeVerdiAlleSpråk, verdiCallbackAlleSpråk } from './hjelpefunksjoner';
 
 export const tilIEøsBarnetrygsperiodeIKontraktFormat = ({
-    intl,
     periode,
     periodeNummer,
     barn,
 }: {
-    intl: IntlShape;
     periode: IEøsBarnetrygdsperiode;
     periodeNummer: number;
     barn: IBarnMedISøknad;
@@ -35,7 +30,7 @@ export const tilIEøsBarnetrygsperiodeIKontraktFormat = ({
     const periodenErAvsluttet = mottarEøsBarnetrygdNå.svar === ESvar.NEI;
     const hentSpørsmålTekstId = (spørsmålId: string) =>
         hentTekster(barnetrygdperiodeSpørsmålSpråkId(periodenErAvsluttet)[spørsmålId], {
-            ...(barn && intl && { barn: barnetsNavnValue(barn, intl) }),
+            ...(barn && { barn: barn.navn }),
         });
 
     return {

--- a/src/frontend/utils/mappingTilKontrakt/hjelpefunksjoner.ts
+++ b/src/frontend/utils/mappingTilKontrakt/hjelpefunksjoner.ts
@@ -1,7 +1,5 @@
 import { ReactNode } from 'react';
 
-import { IntlShape } from 'react-intl';
-
 import { ESvar } from '@navikt/familie-form-elements';
 import { LocaleType } from '@navikt/familie-sprakvelger';
 
@@ -11,7 +9,6 @@ import { Slektsforhold } from '../../typer/kontrakt/barn';
 import { ISøknadsfelt, SpørsmålMap as KontraktpørsmålMap } from '../../typer/kontrakt/generelle';
 import { ISøknadSpørsmål, SpørsmålId, ISøknadSpørsmålMap } from '../../typer/spørsmål';
 import { Årsak } from '../../typer/utvidet';
-import { barnetsNavnValue } from '../barn';
 import { hentTekster, landkodeTilSpråk, toSlektsforholdSpråkId, toÅrsakSpråkId } from '../språk';
 import { språkIndexListe } from '../spørsmål';
 import { isAlpha3Code } from '../typeguards';
@@ -101,7 +98,6 @@ export const språktekstIdFraSpørsmålId = (spørsmålId: SpørsmålId): string
 };
 
 export const søknadsfeltBarn = <T>(
-    intl: IntlShape,
     labelTekstId: string,
     value: Record<LocaleType, T>,
     barn?: IBarnMedISøknad,
@@ -110,7 +106,7 @@ export const søknadsfeltBarn = <T>(
     barn
         ? søknadsfelt(labelTekstId, value, {
               ...labelMessageValues,
-              navn: barnetsNavnValue(barn, intl),
-              barn: barnetsNavnValue(barn, intl),
+              navn: barn.navn,
+              barn: barn.navn,
           })
         : søknadsfelt(labelTekstId, value);

--- a/src/frontend/utils/mappingTilKontrakt/omsorgspersonV7.ts
+++ b/src/frontend/utils/mappingTilKontrakt/omsorgspersonV7.ts
@@ -1,5 +1,3 @@
-import { IntlShape } from 'react-intl';
-
 import {
     EøsBarnSpørsmålId,
     eøsBarnSpørsmålSpråkId,
@@ -16,35 +14,30 @@ import {
 } from './hjelpefunksjoner';
 
 export const omsorgspersonTilISøknadsfeltV7 = (
-    intl: IntlShape,
     omsorgsperson: IOmsorgsperson,
     barn: IBarnMedISøknad
 ): IOmsorgspersonIKontraktFormatV7 => {
     const { navn, slektsforhold, slektsforholdSpesifisering, idNummer, adresse } = omsorgsperson;
     return {
         navn: søknadsfeltBarn(
-            intl,
             språktekstIdFraSpørsmålId(EøsBarnSpørsmålId.omsorgspersonNavn),
             sammeVerdiAlleSpråk(navn.svar),
             barn
         ),
 
         slektsforhold: søknadsfeltBarn(
-            intl,
             språktekstIdFraSpørsmålId(EøsBarnSpørsmålId.omsorgspersonSlektsforhold),
             hentTekster(toSlektsforholdSpråkId(slektsforhold.svar as Slektsforhold)),
             barn
         ),
 
         slektsforholdSpesifisering: søknadsfeltBarn(
-            intl,
             språktekstIdFraSpørsmålId(EøsBarnSpørsmålId.omsorgspersonSlektsforholdSpesifisering),
             sammeVerdiAlleSpråk(slektsforholdSpesifisering.svar),
             barn
         ),
 
         idNummer: søknadsfeltBarn(
-            intl,
             språktekstIdFraSpørsmålId(EøsBarnSpørsmålId.omsorgspersonIdNummer),
             sammeVerdiAlleSpråkEllerUkjentSpråktekst(
                 idNummer.svar,
@@ -54,7 +47,6 @@ export const omsorgspersonTilISøknadsfeltV7 = (
         ),
 
         adresse: søknadsfeltBarn(
-            intl,
             språktekstIdFraSpørsmålId(EøsBarnSpørsmålId.omsorgspersonAdresse),
             sammeVerdiAlleSpråk(adresse.svar),
             barn

--- a/src/frontend/utils/mappingTilKontrakt/pensjonsperioder.ts
+++ b/src/frontend/utils/mappingTilKontrakt/pensjonsperioder.ts
@@ -1,5 +1,3 @@
-import { IntlShape } from 'react-intl';
-
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { pensjonsperiodeOppsummeringOverskrift } from '../../components/Felleskomponenter/Pensjonsmodal/språkUtils';
@@ -11,7 +9,6 @@ import { IBarnMedISøknad } from '../../typer/barn';
 import { ISøknadsfelt } from '../../typer/kontrakt/generelle';
 import { IPensjonsperiodeIKontraktFormatV7 } from '../../typer/kontrakt/v7';
 import { IPensjonsperiode } from '../../typer/perioder';
-import { barnetsNavnValue } from '../barn';
 import { hentTekster, landkodeTilSpråk } from '../språk';
 import { sammeVerdiAlleSpråk, verdiCallbackAlleSpråk } from './hjelpefunksjoner';
 
@@ -22,7 +19,6 @@ export const tilIPensjonsperiodeIKontraktFormat = ({
     erAndreForelderDød,
     gjelderUtlandet,
     barn,
-    intl,
 }: {
     periode: IPensjonsperiode;
     periodeNummer: number;
@@ -30,7 +26,6 @@ export const tilIPensjonsperiodeIKontraktFormat = ({
     erAndreForelderDød: boolean;
     gjelderUtlandet: boolean;
     barn?: IBarnMedISøknad;
-    intl?: IntlShape;
 }): ISøknadsfelt<IPensjonsperiodeIKontraktFormatV7> => {
     const { mottarPensjonNå, pensjonsland, pensjonFra, pensjonTil } = periode;
     const periodenErAvsluttet = mottarPensjonNå?.svar === ESvar.NEI || erAndreForelderDød;
@@ -40,7 +35,7 @@ export const tilIPensjonsperiodeIKontraktFormat = ({
             hentPensjonsperiodeSpørsmålIder(gjelderAndreForelder, periodenErAvsluttet)[
                 pensjonSpørsmålId
             ],
-            { ...(barn && intl && { barn: barnetsNavnValue(barn, intl) }) }
+            { ...(barn && { barn: barn.navn }) }
         );
 
     return {

--- a/src/frontend/utils/mappingTilKontrakt/søknad.ts
+++ b/src/frontend/utils/mappingTilKontrakt/søknad.ts
@@ -1,5 +1,3 @@
-import { IntlShape } from 'react-intl';
-
 import { ESvar } from '@navikt/familie-form-elements';
 import { LocaleType } from '@navikt/familie-sprakvelger';
 
@@ -30,7 +28,6 @@ import { tidligereSamboerISøknadKontraktFormat } from './tidligereSamboer';
 import { utenlandsperiodeTilISøknadsfelt } from './utenlandsperiode';
 
 export const dataISøknadKontraktFormat = (
-    intl: IntlShape,
     valgtSpråk: LocaleType,
     søknad: ISøknad
 ): ISøknadKontrakt => {
@@ -84,7 +81,7 @@ export const dataISøknadKontraktFormat = (
                 sammeVerdiAlleSpråk(søker.adresse ?? {})
             ),
             utenlandsperioder: utenlandsperioder.map((periode, index) =>
-                utenlandsperiodeTilISøknadsfelt(intl, periode, index + 1)
+                utenlandsperiodeTilISøknadsfelt(periode, index + 1)
             ),
             spørsmål: {
                 ...spørmålISøknadsFormat(typetSøkerSpørsmål),
@@ -95,7 +92,7 @@ export const dataISøknadKontraktFormat = (
                 ? samboerISøknadKontraktFormat(nåværendeSamboer)
                 : null,
         },
-        barn: barnInkludertISøknaden.map(barn => barnISøknadsFormat(intl, barn)),
+        barn: barnInkludertISøknaden.map(barn => barnISøknadsFormat(barn)),
         spørsmål: {
             erNoenAvBarnaFosterbarn: søknadsfelt(
                 språktekstIdFraSpørsmålId(OmBarnaDineSpørsmålId.erNoenAvBarnaFosterbarn),

--- a/src/frontend/utils/mappingTilKontrakt/søknadV7.ts
+++ b/src/frontend/utils/mappingTilKontrakt/søknadV7.ts
@@ -1,5 +1,3 @@
-import { IntlShape } from 'react-intl';
-
 import { ESvar } from '@navikt/familie-form-elements';
 import { LocaleType } from '@navikt/familie-sprakvelger';
 
@@ -51,7 +49,6 @@ const antallEøsSteg = (søker: ISøker, barnInkludertISøknaden: IBarnMedISøkn
 };
 
 export const dataISøknadKontraktFormatV7 = (
-    intl: IntlShape,
     valgtSpråk: LocaleType,
     søknad: ISøknad
 ): ISøknadKontraktV7 => {
@@ -106,7 +103,7 @@ export const dataISøknadKontraktFormatV7 = (
             ),
             adresse: søknadsfelt('pdf.søker.adresse.label', sammeVerdiAlleSpråk(adresse ?? {})),
             utenlandsperioder: utenlandsperioder.map((periode, index) =>
-                utenlandsperiodeTilISøknadsfelt(intl, periode, index + 1)
+                utenlandsperiodeTilISøknadsfelt(periode, index + 1)
             ),
             idNummer: idNummer.map(idnummerObj =>
                 idNummerTilISøknadsfelt(
@@ -169,9 +166,7 @@ export const dataISøknadKontraktFormatV7 = (
                 })
             ),
         },
-        barn: barnInkludertISøknaden.map(barn =>
-            barnISøknadsFormatV7(intl, barn, søker, valgtSpråk)
-        ),
+        barn: barnInkludertISøknaden.map(barn => barnISøknadsFormatV7(barn, søker, valgtSpråk)),
         spørsmål: {
             erNoenAvBarnaFosterbarn: søknadsfelt(
                 språktekstIdFraSpørsmålId(OmBarnaDineSpørsmålId.erNoenAvBarnaFosterbarn),

--- a/src/frontend/utils/mappingTilKontrakt/utenlandsperiode.ts
+++ b/src/frontend/utils/mappingTilKontrakt/utenlandsperiode.ts
@@ -1,5 +1,3 @@
-import { IntlShape } from 'react-intl';
-
 import { tilDatoUkjentLabelSpråkId } from '../../components/Felleskomponenter/UtenlandsoppholdModal/spørsmål';
 import {
     fraDatoLabelSpråkId,
@@ -11,7 +9,6 @@ import {
 import { IBarnMedISøknad } from '../../typer/barn';
 import { ISøknadsfelt, IUtenlandsperiodeIKontraktFormat } from '../../typer/kontrakt/generelle';
 import { IUtenlandsperiode } from '../../typer/perioder';
-import { barnetsNavnValue } from '../barn';
 import { hentTekster, landkodeTilSpråk } from '../språk';
 import {
     sammeVerdiAlleSpråk,
@@ -20,7 +17,6 @@ import {
 } from './hjelpefunksjoner';
 
 export const utenlandsperiodeTilISøknadsfelt = (
-    intl: IntlShape,
     utenlandperiode: IUtenlandsperiode,
     periodeNummer: number,
     barn?: IBarnMedISøknad
@@ -30,14 +26,14 @@ export const utenlandsperiodeTilISøknadsfelt = (
         verdi: sammeVerdiAlleSpråk({
             utenlandsoppholdÅrsak: {
                 label: hentTekster(årsakLabelSpråkId(barn), {
-                    ...(barn && { barn: barnetsNavnValue(barn, intl) }),
+                    ...(barn && { barn: barn.navn }),
                 }),
                 verdi: hentTekster(årsakSpråkId(utenlandperiode.utenlandsoppholdÅrsak.svar, barn)),
             },
             oppholdsland: {
                 label: hentTekster(
                     landLabelSpråkId(utenlandperiode.utenlandsoppholdÅrsak.svar, barn),
-                    { ...(barn && { barn: barnetsNavnValue(barn, intl) }) }
+                    { ...(barn && { barn: barn.navn }) }
                 ),
                 verdi: verdiCallbackAlleSpråk(locale =>
                     landkodeTilSpråk(utenlandperiode.oppholdsland.svar, locale)
@@ -46,14 +42,14 @@ export const utenlandsperiodeTilISøknadsfelt = (
             oppholdslandFraDato: {
                 label: hentTekster(
                     fraDatoLabelSpråkId(utenlandperiode.utenlandsoppholdÅrsak.svar, barn),
-                    { ...(barn && { barn: barnetsNavnValue(barn, intl) }) }
+                    { ...(barn && { barn: barn.navn }) }
                 ),
                 verdi: sammeVerdiAlleSpråk(utenlandperiode.oppholdslandFraDato?.svar),
             },
             oppholdslandTilDato: {
                 label: hentTekster(
                     tilDatoLabelSpråkId(utenlandperiode.utenlandsoppholdÅrsak.svar, barn),
-                    { ...(barn && { barn: barnetsNavnValue(barn, intl) }) }
+                    { ...(barn && { barn: barn.navn }) }
                 ),
                 verdi: utenlandperiode.oppholdslandTilDato?.svar
                     ? sammeVerdiAlleSpråkEllerUkjentSpråktekst(


### PR DESCRIPTION
… appen

### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._

Refaktorer slik at barnets navn ikke kan være null. Dersom det er null skal vi bruke fødselsnummer så når får responsen tilbake fra barn i backend ønsker vi bare å sette dette som navn med en gang, ett sted, i stedet for å gjøre denne formateringen overalt ellers i appen.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
