### PR TITLE
Endret alle forekomster av familie-ba-soknad-api til familie-baks-soknad-api

### DIFF
--- a/build_n_deploy/naiserator/naiserator_dev.yaml
+++ b/build_n_deploy/naiserator/naiserator_dev.yaml
@@ -27,7 +27,7 @@ spec:
   accessPolicy:
     outbound:
       rules:
-        - application: familie-ba-soknad-api
+        - application: familie-baks-soknad-api
       external:
         - host: "www-q1.nav.no"
   resources:

--- a/build_n_deploy/naiserator/naiserator_prod.yaml
+++ b/build_n_deploy/naiserator/naiserator_prod.yaml
@@ -30,7 +30,7 @@ spec:
   accessPolicy:
     outbound:
       rules:
-        - application: familie-ba-soknad-api
+        - application: familie-baks-soknad-api
       external:
         - host: "www.nav.no"
   resources:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
 #    ports:
 #      - "3000:3000"
 
-  # familie-ba-soknad-api, henter bl.a. data fra PDL og forwarder søknader til mottak
+  # familie-baks-soknad-api, henter bl.a. data fra PDL og forwarder søknader til mottak
   api:
     logging: *common-log-config
     container_name: "soknad-api"
@@ -92,8 +92,8 @@ services:
       - keys:/keys
     environment:
       <<: *common-token-environment
-      TOKEN_X_PRIVATE_JWK: '/keys/familie-ba-soknad-api.json'
-      TOKEN_X_CLIENT_ID: 'dev-local:teamfamilie:familie-ba-soknad-api'
+      TOKEN_X_PRIVATE_JWK: '/keys/familie-baks-soknad-api.json'
+      TOKEN_X_CLIENT_ID: 'dev-local:teamfamilie:familie-baks-soknad-api'
       FAMILIE_BA_MOTTAK_URL: 'http://mottak:8090'
 
   # familie-ba-mottak, tar imot søknader, lagrer dem, genererer PDFer via dokgen, sender til journalføring.
@@ -208,7 +208,7 @@ services:
       args:
         git_commit: 850963d98bfd4e04836212fcb2efb218d56db7f5
     environment:
-      APPS: "familie-ba-soknad-api,familie-ba-mottak,familie-dokument"
+      APPS: "familie-baks-soknad-api,familie-ba-mottak,familie-dokument"
       KEY_OUTPUT_DIRECTORY: /keys
     volumes:
       - keys:/keys

--- a/dockerstuff/soknad-api/Dockerfile
+++ b/dockerstuff/soknad-api/Dockerfile
@@ -5,7 +5,7 @@ ARG git_commit
 
 RUN apk add git maven
 
-RUN git clone https://github.com/navikt/familie-ba-soknad-api.git /app \
+RUN git clone https://github.com/navikt/familie-baks-soknad-api.git /app \
     && cd /app \
     && git checkout $git_commit
 WORKDIR /app

--- a/dockerstuff/soknad-api/gitdiff
+++ b/dockerstuff/soknad-api/gitdiff
@@ -20,7 +20,7 @@ index 00b9464..d26ac06 100644
 --- a/src/main/resources/application-lokal.yaml
 +++ b/src/main/resources/application-lokal.yaml
 @@ -24,15 +24,11 @@ TOKEN_X_PRIVATE_JWK: '{
- TOKEN_X_CLIENT_ID: dev-local:teamfamilie:familie-ba-soknad-api
+ TOKEN_X_CLIENT_ID: dev-local:teamfamilie:familie-baks-soknad-api
 
  no.nav.security.jwt:
 -  issuer.selvbetjening:

--- a/src/backend/environment.ts
+++ b/src/backend/environment.ts
@@ -1,12 +1,12 @@
 export default function () {
     if (process.env.ENV === 'prod') {
         return {
-            apiUrl: 'http://familie-ba-soknad-api',
+            apiUrl: 'http://familie-baks-soknad-api',
             port: 9000,
         };
     } else if (process.env.ENV === 'dev') {
         return {
-            apiUrl: 'http://familie-ba-soknad-api',
+            apiUrl: 'http://familie-baks-soknad-api',
             port: 9000,
         };
     } else if (process.env.ENV === 'docker-compose') {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Nå når `familie-ba-soknad-api` har fått nytt navn må alle referanser til applikasjonen endres til det nye navnet: `familie-baks-soknad-api`.

Denne kan ikke merges før ny app `familie-baks-soknad-api` har fått tilgang til `pdl` i prod.
