### PR TITLE
Sørger for at vi validerer at dato er på rett format for Backend

### DIFF
--- a/src/frontend/utils/dato.tsx
+++ b/src/frontend/utils/dato.tsx
@@ -65,9 +65,9 @@ export const validerDato = (
         return feil(feltState, feilmeldingSpråkId ? <SpråkTekst id={feilmeldingSpråkId} /> : '');
     }
 
-    const dato = stringTilDate(feltState.verdi);
+    const dato = parseTilGyldigDato(feltState.verdi, 'yyyy-MM-dd');
 
-    if (!erDatoFormatGodkjent(dato)) {
+    if (!dato) {
         return feil(feltState, <SpråkTekst id={'felles.dato-format.feilmelding'} />);
     }
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Validering av datofeltet sjekket ikke at formatet på datoen var riktig. Legger inn korrekt parsing av string til dato slik at dato blir invalid dersom formatet ikke er riktig.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
 
