### PR TITLE
Feat/alertstripe fra aksel

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,8 +213,6 @@
     "lint-staged": "^13.2.0",
     "lodash.throttle": "^4.1.1",
     "mini-css-extract-plugin": "^2.4.1",
-    "nav-frontend-alertstriper": "^4.0.1",
-    "nav-frontend-alertstriper-style": "^3.0.1",
     "nav-frontend-chevron": "^1.0.30",
     "nav-frontend-chevron-style": "^1.0.4",
     "nav-frontend-ikoner-assets": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -98,9 +98,10 @@
   "dependencies": {
     "@formatjs/intl-datetimeformat": "^6.5.1",
     "@formatjs/intl-numberformat": "^8.3.5",
-    "@navikt/ds-css": "^2.6.0",
-    "@navikt/ds-react": "^2.6.0",
-    "@navikt/ds-tokens": "^2.6.0",
+    "@navikt/ds-css": "^2.9.2",
+    "@navikt/ds-react": "^2.9.2",
+    "@navikt/ds-tokens": "^2.9.2",
+    "@navikt/ds-icons": "^2.9.2",
     "@navikt/familie-logging": "^6.0.0",
     "@navikt/familie-typer": "^8.0.0",
     "compression": "^1.7.4",
@@ -129,7 +130,6 @@
   "devDependencies": {
     "@axe-core/react": "^4.6.1",
     "@babel/plugin-syntax-import-assertions": "^7.16.7",
-    "@navikt/ds-icons": "^2.6.0",
     "@navikt/familie-form-elements": "^10.1.0",
     "@navikt/familie-skjema": "^7.0.3",
     "@navikt/familie-sprakvelger": "^8.1.0",

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 
 import { BrowserRouter as Router } from 'react-router-dom';
 
-import { Alert } from '@navikt/ds-react';
-
 import AppContainer from './AppContainer';
+import FamilieAlert from './components/Felleskomponenter/FamilieAlert/FamilieAlert';
 import { AppProvider } from './context/AppContext';
 import { AppNavigationProvider } from './context/AppNavigationContext';
 import { EøsProvider } from './context/EøsContext';
@@ -28,12 +27,12 @@ function App() {
                                     <StegProvider>
                                         <GlobalStyle />
                                         {process.env.NODE_ENV !== 'production' && (
-                                            <Alert variant={'warning'}>
+                                            <FamilieAlert variant={'warning'}>
                                                 {`Denne siden er under utvikling. `}
                                                 <a href="https://www.nav.no/no/person/familie/barnetrygd-og-kontantstotte/barnetrygd">
                                                     Klikk her for å gå til våre sider for barnetrygd
                                                 </a>
-                                            </Alert>
+                                            </FamilieAlert>
                                         )}
                                         <AppNavigationProvider>
                                             <AppContainer />

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { BrowserRouter as Router } from 'react-router-dom';
 
-import AlertStripe from 'nav-frontend-alertstriper';
+import { Alert } from '@navikt/ds-react';
 
 import AppContainer from './AppContainer';
 import { AppProvider } from './context/AppContext';
@@ -28,12 +28,12 @@ function App() {
                                     <StegProvider>
                                         <GlobalStyle />
                                         {process.env.NODE_ENV !== 'production' && (
-                                            <AlertStripe type="advarsel">
+                                            <Alert variant={'warning'}>
                                                 {`Denne siden er under utvikling. `}
                                                 <a href="https://www.nav.no/no/person/familie/barnetrygd-og-kontantstotte/barnetrygd">
                                                     Klikk her for å gå til våre sider for barnetrygd
                                                 </a>
-                                            </AlertStripe>
+                                            </Alert>
                                         )}
                                         <AppNavigationProvider>
                                             <AppContainer />

--- a/src/frontend/AppContainer.tsx
+++ b/src/frontend/AppContainer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { RessursStatus } from '@navikt/familie-typer';
 
-import AlertStripe from './components/Felleskomponenter/AlertStripe/AlertStripe';
+import FamilieAlert from './components/Felleskomponenter/FamilieAlert/FamilieAlert';
 import { Feilside } from './components/Felleskomponenter/Feilside/Feilside';
 import SystemetLaster from './components/Felleskomponenter/SystemetLaster/SystemetLaster';
 import { useApp } from './context/AppContext';
@@ -15,12 +15,12 @@ const AppContainer = () => {
             {systemetLaster() && <SystemetLaster />}
             {sluttbruker.status === RessursStatus.IKKE_TILGANG && (
                 <div>
-                    <AlertStripe variant={'warning'}>
+                    <FamilieAlert variant={'warning'}>
                         {'Du må søke på papir. '}
                         <a href="https://www.nav.no/no/person/familie/barnetrygd-og-kontantstotte/barnetrygd">
                             Klikk her for å gå til våre sider for barnetrygd
                         </a>
-                    </AlertStripe>
+                    </FamilieAlert>
                 </div>
             )}
             {systemetOK() && <Søknad />}

--- a/src/frontend/AppContainer.tsx
+++ b/src/frontend/AppContainer.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
 
-import Alertstripe from 'nav-frontend-alertstriper';
-
 import { RessursStatus } from '@navikt/familie-typer';
 
+import AlertStripe from './components/Felleskomponenter/AlertStripe/AlertStripe';
 import { Feilside } from './components/Felleskomponenter/Feilside/Feilside';
 import SystemetLaster from './components/Felleskomponenter/SystemetLaster/SystemetLaster';
 import { useApp } from './context/AppContext';
 import Søknad from './Søknad';
-
 const AppContainer = () => {
     const { systemetLaster, systemetFeiler, sluttbruker, systemetOK } = useApp();
 
@@ -17,12 +15,12 @@ const AppContainer = () => {
             {systemetLaster() && <SystemetLaster />}
             {sluttbruker.status === RessursStatus.IKKE_TILGANG && (
                 <div>
-                    <Alertstripe type="advarsel">
+                    <AlertStripe variant={'warning'}>
                         {'Du må søke på papir. '}
                         <a href="https://www.nav.no/no/person/familie/barnetrygd-og-kontantstotte/barnetrygd">
                             Klikk her for å gå til våre sider for barnetrygd
                         </a>
-                    </Alertstripe>
+                    </AlertStripe>
                 </div>
             )}
             {systemetOK() && <Søknad />}

--- a/src/frontend/components/Felleskomponenter/AlertStripe/AlertStripe.tsx
+++ b/src/frontend/components/Felleskomponenter/AlertStripe/AlertStripe.tsx
@@ -2,37 +2,40 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { AlertStripeType, default as NavAlertStripe } from 'nav-frontend-alertstriper';
+import { Alert as NavAlert, AlertProps } from '@navikt/ds-react';
 
-interface AlertStripeProps {
-    type?: AlertStripeType;
-    form?: 'default' | 'inline' | undefined;
+interface AlertStripeProps extends AlertProps {
     dynamisk?: boolean;
     className?: '';
 }
 
-const StyledAlertStripe = styled(NavAlertStripe)`
+const StyledAlert = styled(NavAlert)`
     p {
         margin: 0;
     }
 `;
 
 const AlertStripe: React.FC<AlertStripeProps> = ({
-    type = 'info',
-    form = 'inline',
+    variant,
+    inline = true,
+    size = 'medium',
+    fullWidth = false,
     dynamisk = false,
     className,
     children,
 }) => {
     return (
-        <StyledAlertStripe
+        <StyledAlert
             className={className}
-            type={type}
-            form={form}
+            data-testid={'alertstripe'}
+            variant={variant}
+            inline={inline}
+            size={size}
+            fullWidth={fullWidth}
             aria-live={dynamisk ? 'polite' : 'off'}
         >
-            <p>{children}</p>
-        </StyledAlertStripe>
+            {children}
+        </StyledAlert>
     );
 };
 

--- a/src/frontend/components/Felleskomponenter/Barnetrygdperiode/BarnetrygdperiodeModal.tsx
+++ b/src/frontend/components/Felleskomponenter/Barnetrygdperiode/BarnetrygdperiodeModal.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import styled from 'styled-components';
-
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { IEøsBarnetrygdsperiode } from '../../../typer/perioder';
@@ -28,9 +26,6 @@ import {
 interface Props extends ReturnType<typeof useModal>, IUsePensjonsperiodeSkjemaParams {
     onLeggTilBarnetrygdsperiode: (periode: IEøsBarnetrygdsperiode) => void;
 }
-const StyledAlertStripe = styled(AlertStripe)`
-    margin: 1rem 0 1rem 0;
-`;
 
 export const BarnetrygdperiodeModal: React.FC<Props> = ({
     erÅpen,
@@ -165,9 +160,9 @@ export const BarnetrygdperiodeModal: React.FC<Props> = ({
                             }),
                         }}
                         tilleggsinfo={
-                            <StyledAlertStripe>
+                            <AlertStripe variant={'info'}>
                                 <SpråkTekst id={'ombarnet.trygdbeløp.info'} />
-                            </StyledAlertStripe>
+                            </AlertStripe>
                         }
                         bredde={'S'}
                     />

--- a/src/frontend/components/Felleskomponenter/Barnetrygdperiode/BarnetrygdperiodeModal.tsx
+++ b/src/frontend/components/Felleskomponenter/Barnetrygdperiode/BarnetrygdperiodeModal.tsx
@@ -6,9 +6,9 @@ import { IEøsBarnetrygdsperiode } from '../../../typer/perioder';
 import { PersonType } from '../../../typer/personType';
 import { dagenEtterDato, dagensDato, gårsdagensDato, stringTilDate } from '../../../utils/dato';
 import { trimWhiteSpace, visFeiloppsummering } from '../../../utils/hjelpefunksjoner';
-import AlertStripe from '../AlertStripe/AlertStripe';
 import Datovelger from '../Datovelger/Datovelger';
 import { LandDropdown } from '../Dropdowns/LandDropdown';
+import FamilieAlert from '../FamilieAlert/FamilieAlert';
 import JaNeiSpm from '../JaNeiSpm/JaNeiSpm';
 import KomponentGruppe from '../KomponentGruppe/KomponentGruppe';
 import { SkjemaFeiloppsummering } from '../SkjemaFeiloppsummering/SkjemaFeiloppsummering';
@@ -160,9 +160,9 @@ export const BarnetrygdperiodeModal: React.FC<Props> = ({
                             }),
                         }}
                         tilleggsinfo={
-                            <AlertStripe variant={'info'}>
+                            <FamilieAlert variant={'info'}>
                                 <SpråkTekst id={'ombarnet.trygdbeløp.info'} />
-                            </AlertStripe>
+                            </FamilieAlert>
                         }
                         bredde={'S'}
                     />

--- a/src/frontend/components/Felleskomponenter/FamilieAlert/FamilieAlert.tsx
+++ b/src/frontend/components/Felleskomponenter/FamilieAlert/FamilieAlert.tsx
@@ -2,20 +2,20 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { Alert as NavAlert, AlertProps } from '@navikt/ds-react';
+import { Alert, AlertProps } from '@navikt/ds-react';
 
 interface AlertStripeProps extends AlertProps {
     dynamisk?: boolean;
     className?: '';
 }
 
-const StyledAlert = styled(NavAlert)`
+const StyledAlert = styled(Alert)`
     p {
         margin: 0;
     }
 `;
 
-const AlertStripe: React.FC<AlertStripeProps> = ({
+const FamilieAlert: React.FC<AlertStripeProps> = ({
     variant,
     inline = true,
     size = 'medium',
@@ -39,4 +39,4 @@ const AlertStripe: React.FC<AlertStripeProps> = ({
     );
 };
 
-export default AlertStripe;
+export default FamilieAlert;

--- a/src/frontend/components/Felleskomponenter/Feilside/Feilside.tsx
+++ b/src/frontend/components/Felleskomponenter/Feilside/Feilside.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 
-import AlertStripe from '../AlertStripe/AlertStripe';
+import FamilieAlert from '../FamilieAlert/FamilieAlert';
 import SpråkTekst from '../SpråkTekst/SpråkTekst';
 
 export const Feilside: React.FC = () => {
     return (
         <div>
-            <AlertStripe variant={'error'} dynamisk>
+            <FamilieAlert variant={'error'} dynamisk>
                 <SpråkTekst id={'felles.crashmelding'} />
-            </AlertStripe>
+            </FamilieAlert>
         </div>
     );
 };

--- a/src/frontend/components/Felleskomponenter/Feilside/Feilside.tsx
+++ b/src/frontend/components/Felleskomponenter/Feilside/Feilside.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
 
-import Alertstripe from 'nav-frontend-alertstriper';
-
+import AlertStripe from '../AlertStripe/AlertStripe';
 import SpråkTekst from '../SpråkTekst/SpråkTekst';
 
 export const Feilside: React.FC = () => {
     return (
         <div>
-            <Alertstripe type="feil" aria-live={'polite'}>
+            <AlertStripe variant={'error'} dynamisk>
                 <SpråkTekst id={'felles.crashmelding'} />
-            </Alertstripe>
+            </AlertStripe>
         </div>
     );
 };

--- a/src/frontend/components/Felleskomponenter/Steg/ModellVersjonModal.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/ModellVersjonModal.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import { BodyLong, Button, Heading, Modal } from '@navikt/ds-react';
 
-import AlertStripe from '../AlertStripe/AlertStripe';
+import FamilieAlert from '../FamilieAlert/FamilieAlert';
 import ModalContent from '../ModalContent';
 import SpråkTekst from '../SpråkTekst/SpråkTekst';
 
@@ -37,7 +37,7 @@ const ModellVersjonModal: React.FC<{ erÅpen: boolean }> = ({ erÅpen }) => {
                     <SpråkTekst id={'felles.modal.deployfeil.tittel'} />
                 </Heading>
 
-                <AlertStripe
+                <FamilieAlert
                     inline={false}
                     variant={'error'}
                     children={<SpråkTekst id={'felles.modal.deployfeil.error'} />}

--- a/src/frontend/components/Felleskomponenter/Steg/ModellVersjonModal.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/ModellVersjonModal.tsx
@@ -38,8 +38,8 @@ const ModellVersjonModal: React.FC<{ erÅpen: boolean }> = ({ erÅpen }) => {
                 </Heading>
 
                 <AlertStripe
-                    form={'default'}
-                    type={'feil'}
+                    inline={false}
+                    variant={'error'}
                     children={<SpråkTekst id={'felles.modal.deployfeil.error'} />}
                 />
                 <StyledBodyLong>

--- a/src/frontend/components/Felleskomponenter/SøkerMåBrukePDF.tsx
+++ b/src/frontend/components/Felleskomponenter/SøkerMåBrukePDF.tsx
@@ -21,7 +21,7 @@ const LenkeContainer = styled.div`
 export const SøkerMåBrukePDF: FC<Props> = ({ advarselTekstId, utfyllendeAdvarselInfoId }) => {
     return (
         <Informasjonsbolk aria-live={'polite'}>
-            <AlertStripe type={'advarsel'}>
+            <AlertStripe variant={'warning'}>
                 <SpråkTekst id={advarselTekstId} />
             </AlertStripe>
             {utfyllendeAdvarselInfoId && (

--- a/src/frontend/components/Felleskomponenter/SøkerMåBrukePDF.tsx
+++ b/src/frontend/components/Felleskomponenter/SøkerMåBrukePDF.tsx
@@ -4,8 +4,8 @@ import styled from 'styled-components';
 
 import { BodyShort, Label } from '@navikt/ds-react';
 
-import AlertStripe from './AlertStripe/AlertStripe';
 import EksternLenke from './EksternLenke/EksternLenke';
+import FamilieAlert from './FamilieAlert/FamilieAlert';
 import Informasjonsbolk from './Informasjonsbolk/Informasjonsbolk';
 import SpråkTekst from './SpråkTekst/SpråkTekst';
 
@@ -21,9 +21,9 @@ const LenkeContainer = styled.div`
 export const SøkerMåBrukePDF: FC<Props> = ({ advarselTekstId, utfyllendeAdvarselInfoId }) => {
     return (
         <Informasjonsbolk aria-live={'polite'}>
-            <AlertStripe variant={'warning'}>
+            <FamilieAlert variant={'warning'}>
                 <SpråkTekst id={advarselTekstId} />
-            </AlertStripe>
+            </FamilieAlert>
             {utfyllendeAdvarselInfoId && (
                 <Informasjonsbolk>
                     <Label>

--- a/src/frontend/components/Felleskomponenter/expandableContent/ExpandableInfo.tsx
+++ b/src/frontend/components/Felleskomponenter/expandableContent/ExpandableInfo.tsx
@@ -4,10 +4,9 @@ import { css } from 'styled-components';
 import styled from 'styled-components';
 import { v4 as uuidv4 } from 'uuid';
 
-import { AlertStripeInfo } from 'nav-frontend-alertstriper';
-
 import { BodyShort } from '@navikt/ds-react';
 
+import AlertStripe from '../AlertStripe/AlertStripe';
 import CollapsableContainer from './CollapsableContainer';
 import InfoToggleButton from './InfoToggleButton';
 
@@ -68,7 +67,13 @@ const ExpandableInfo = ({
             </ButtonContainer>
             <InnholdContainer id={toggleContentId}>
                 <CollapsableContainer isOpen={isOpen} animated={true} ariaLive="polite">
-                    {filledBackground ? <AlertStripeInfo>{children}</AlertStripeInfo> : children}
+                    {filledBackground ? (
+                        <AlertStripe variant={'info'} inline={false}>
+                            {children}
+                        </AlertStripe>
+                    ) : (
+                        children
+                    )}
                 </CollapsableContainer>
             </InnholdContainer>
         </Container>

--- a/src/frontend/components/Felleskomponenter/expandableContent/ExpandableInfo.tsx
+++ b/src/frontend/components/Felleskomponenter/expandableContent/ExpandableInfo.tsx
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { BodyShort } from '@navikt/ds-react';
 
-import AlertStripe from '../AlertStripe/AlertStripe';
+import FamilieAlert from '../FamilieAlert/FamilieAlert';
 import CollapsableContainer from './CollapsableContainer';
 import InfoToggleButton from './InfoToggleButton';
 
@@ -68,9 +68,9 @@ const ExpandableInfo = ({
             <InnholdContainer id={toggleContentId}>
                 <CollapsableContainer isOpen={isOpen} animated={true} ariaLive="polite">
                     {filledBackground ? (
-                        <AlertStripe variant={'info'} inline={false}>
+                        <FamilieAlert variant={'info'} inline={false}>
                             {children}
-                        </AlertStripe>
+                        </FamilieAlert>
                     ) : (
                         children
                     )}

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/Dokumentasjon.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/Dokumentasjon.tsx
@@ -2,8 +2,6 @@ import React, { useState } from 'react';
 
 import { add, isBefore } from 'date-fns';
 
-import AlertStripe, { AlertStripeAdvarsel } from 'nav-frontend-alertstriper';
-
 import { BodyLong, BodyShort } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
@@ -13,6 +11,7 @@ import { useSendInnSkjema } from '../../../hooks/useSendInnSkjema';
 import { IDokumentasjon, IVedlegg } from '../../../typer/dokumentasjon';
 import { Dokumentasjonsbehov } from '../../../typer/kontrakt/dokumentasjon';
 import { erDokumentasjonRelevant } from '../../../utils/dokumentasjon';
+import AlertStripe from '../../Felleskomponenter/AlertStripe/AlertStripe';
 import { Feilside } from '../../Felleskomponenter/Feilside/Feilside';
 import KomponentGruppe from '../../Felleskomponenter/KomponentGruppe/KomponentGruppe';
 import PictureScanningGuide from '../../Felleskomponenter/PictureScanningGuide/PictureScanningGuide';
@@ -75,7 +74,7 @@ const Dokumentasjon: React.FC = () => {
         >
             {slettaVedlegg.length > 0 && (
                 <KomponentGruppe>
-                    <AlertStripeAdvarsel>
+                    <AlertStripe variant={'warning'} inline={false}>
                         <BodyShort>
                             <SpråkTekst id={'dokumentasjon.forlangtid.info'} />
                         </BodyShort>
@@ -86,11 +85,11 @@ const Dokumentasjon: React.FC = () => {
                                 </li>
                             ))}
                         </ul>
-                    </AlertStripeAdvarsel>
+                    </AlertStripe>
                 </KomponentGruppe>
             )}
             <KomponentGruppe>
-                <AlertStripe type={'info'}>
+                <AlertStripe variant={'info'}>
                     <SpråkTekst id={'dokumentasjon.nudge'} />
                 </AlertStripe>
 

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/Dokumentasjon.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/Dokumentasjon.tsx
@@ -89,7 +89,7 @@ const Dokumentasjon: React.FC = () => {
                 </KomponentGruppe>
             )}
             <KomponentGruppe>
-                <FamilieAlert variant={'info'}>
+                <FamilieAlert variant={'info'} inline={false}>
                     <SpråkTekst id={'dokumentasjon.nudge'} />
                 </FamilieAlert>
 

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/Dokumentasjon.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/Dokumentasjon.tsx
@@ -11,7 +11,7 @@ import { useSendInnSkjema } from '../../../hooks/useSendInnSkjema';
 import { IDokumentasjon, IVedlegg } from '../../../typer/dokumentasjon';
 import { Dokumentasjonsbehov } from '../../../typer/kontrakt/dokumentasjon';
 import { erDokumentasjonRelevant } from '../../../utils/dokumentasjon';
-import AlertStripe from '../../Felleskomponenter/AlertStripe/AlertStripe';
+import FamilieAlert from '../../Felleskomponenter/FamilieAlert/FamilieAlert';
 import { Feilside } from '../../Felleskomponenter/Feilside/Feilside';
 import KomponentGruppe from '../../Felleskomponenter/KomponentGruppe/KomponentGruppe';
 import PictureScanningGuide from '../../Felleskomponenter/PictureScanningGuide/PictureScanningGuide';
@@ -74,7 +74,7 @@ const Dokumentasjon: React.FC = () => {
         >
             {slettaVedlegg.length > 0 && (
                 <KomponentGruppe>
-                    <AlertStripe variant={'warning'} inline={false}>
+                    <FamilieAlert variant={'warning'} inline={false}>
                         <BodyShort>
                             <SpråkTekst id={'dokumentasjon.forlangtid.info'} />
                         </BodyShort>
@@ -85,13 +85,13 @@ const Dokumentasjon: React.FC = () => {
                                 </li>
                             ))}
                         </ul>
-                    </AlertStripe>
+                    </FamilieAlert>
                 </KomponentGruppe>
             )}
             <KomponentGruppe>
-                <AlertStripe variant={'info'}>
+                <FamilieAlert variant={'info'}>
                     <SpråkTekst id={'dokumentasjon.nudge'} />
-                </AlertStripe>
+                </FamilieAlert>
 
                 <BodyLong>
                     <SpråkTekst id={'dokumentasjon.info'} />

--- a/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
@@ -13,8 +13,8 @@ import { useApp } from '../../../context/AppContext';
 import useFørsteRender from '../../../hooks/useFørsteRender';
 import { RouteEnum } from '../../../typer/routes';
 import { logSidevisningBarnetrygd } from '../../../utils/amplitude';
-import AlertStripe from '../../Felleskomponenter/AlertStripe/AlertStripe';
 import EksternLenke from '../../Felleskomponenter/EksternLenke/EksternLenke';
+import FamilieAlert from '../../Felleskomponenter/FamilieAlert/FamilieAlert';
 import Informasjonsbolk from '../../Felleskomponenter/Informasjonsbolk/Informasjonsbolk';
 import InnholdContainer from '../../Felleskomponenter/InnholdContainer/InnholdContainer';
 import SpråkTekst from '../../Felleskomponenter/SpråkTekst/SpråkTekst';
@@ -31,7 +31,7 @@ const StyledSpråkvelger = styled(Sprakvelger)`
     margin: auto;
 `;
 
-const StyledAlertStripeUtvidetInfo = styled(AlertStripe)`
+const StyledAlertStripeUtvidetInfo = styled(FamilieAlert)`
     margin-top: 3rem;
 `;
 

--- a/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
@@ -70,7 +70,7 @@ const Forside: React.FC = () => {
             <StyledSpråkvelger støttedeSprak={[LocaleType.nn, LocaleType.nb, LocaleType.en]} />
 
             {!erUtvidet && (
-                <StyledAlertStripeUtvidetInfo type={'info'} form={'default'}>
+                <StyledAlertStripeUtvidetInfo variant={'info'} inline={false}>
                     <SpråkTekst id={'forside.utvidetinfo.info'} />
                     <EksternLenke
                         lenkeSpråkId={'forside.utvidetinfo.lenke'}

--- a/src/frontend/components/SøknadsSteg/Forside/FortsettPåSøknad.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/FortsettPåSøknad.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import { BodyLong, Button, Heading, Modal } from '@navikt/ds-react';
 
 import { device } from '../../../Theme';
-import AlertStripe from '../../Felleskomponenter/AlertStripe/AlertStripe';
+import FamilieAlert from '../../Felleskomponenter/FamilieAlert/FamilieAlert';
 import KomponentGruppe from '../../Felleskomponenter/KomponentGruppe/KomponentGruppe';
 import ModalContent from '../../Felleskomponenter/ModalContent';
 import SpråkTekst from '../../Felleskomponenter/SpråkTekst/SpråkTekst';
@@ -49,11 +49,11 @@ const FortsettPåSøknad: FC = () => {
     return (
         <StyledFortsettPåSøknad role={'navigation'}>
             <KomponentGruppe>
-                <AlertStripe variant={'info'} inline={false}>
+                <FamilieAlert variant={'info'} inline={false}>
                     <BodyLong>
                         <SpråkTekst id={'mellomlagring.info'} />
                     </BodyLong>
-                </AlertStripe>
+                </FamilieAlert>
             </KomponentGruppe>
             <StyledButton onClick={fortsettPåSøknaden}>
                 <SpråkTekst id={'mellomlagring.knapp.fortsett'} />

--- a/src/frontend/components/SøknadsSteg/Forside/FortsettPåSøknad.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/FortsettPåSøknad.tsx
@@ -3,11 +3,10 @@ import React, { FC } from 'react';
 import { useIntl } from 'react-intl';
 import styled from 'styled-components';
 
-import { AlertStripeInfo } from 'nav-frontend-alertstriper';
-
 import { BodyLong, Button, Heading, Modal } from '@navikt/ds-react';
 
 import { device } from '../../../Theme';
+import AlertStripe from '../../Felleskomponenter/AlertStripe/AlertStripe';
 import KomponentGruppe from '../../Felleskomponenter/KomponentGruppe/KomponentGruppe';
 import ModalContent from '../../Felleskomponenter/ModalContent';
 import SpråkTekst from '../../Felleskomponenter/SpråkTekst/SpråkTekst';
@@ -50,11 +49,11 @@ const FortsettPåSøknad: FC = () => {
     return (
         <StyledFortsettPåSøknad role={'navigation'}>
             <KomponentGruppe>
-                <AlertStripeInfo>
+                <AlertStripe variant={'info'} inline={false}>
                     <BodyLong>
                         <SpråkTekst id={'mellomlagring.info'} />
                     </BodyLong>
-                </AlertStripeInfo>
+                </AlertStripe>
             </KomponentGruppe>
             <StyledButton onClick={fortsettPåSøknaden}>
                 <SpråkTekst id={'mellomlagring.knapp.fortsett'} />

--- a/src/frontend/components/SøknadsSteg/Kvittering/Kvittering.tsx
+++ b/src/frontend/components/SøknadsSteg/Kvittering/Kvittering.tsx
@@ -9,9 +9,9 @@ import { useApp } from '../../../context/AppContext';
 import { useSteg } from '../../../context/StegContext';
 import { RouteEnum } from '../../../typer/routes';
 import { setUserProperty, UserProperty } from '../../../utils/amplitude';
-import AlertStripe from '../../Felleskomponenter/AlertStripe/AlertStripe';
 import BlokkerTilbakeKnappModal from '../../Felleskomponenter/BlokkerTilbakeKnappModal/BlokkerTilbakeKnappModal';
 import EksternLenke from '../../Felleskomponenter/EksternLenke/EksternLenke';
+import FamilieAlert from '../../Felleskomponenter/FamilieAlert/FamilieAlert';
 import Informasjonsbolk from '../../Felleskomponenter/Informasjonsbolk/Informasjonsbolk';
 import KomponentGruppe from '../../Felleskomponenter/KomponentGruppe/KomponentGruppe';
 import SpråkTekst from '../../Felleskomponenter/SpråkTekst/SpråkTekst';
@@ -52,7 +52,7 @@ const Kvittering: React.FC = () => {
     return (
         <Steg tittel={<SpråkTekst id={'kvittering.sidetittel'} />}>
             <KomponentGruppe>
-                <AlertStripe variant={'success'} inline={false}>
+                <FamilieAlert variant={'success'} inline={false}>
                     <SpråkTekst
                         id={'kvittering.mottatt'}
                         values={{
@@ -60,7 +60,7 @@ const Kvittering: React.FC = () => {
                             dato: dato,
                         }}
                     />
-                </AlertStripe>
+                </FamilieAlert>
             </KomponentGruppe>
             <KomponentGruppe>
                 <BodyLong>

--- a/src/frontend/components/SøknadsSteg/Kvittering/Kvittering.tsx
+++ b/src/frontend/components/SøknadsSteg/Kvittering/Kvittering.tsx
@@ -2,8 +2,6 @@ import React, { useEffect, useState } from 'react';
 
 import { format } from 'date-fns';
 
-import AlertStripe from 'nav-frontend-alertstriper';
-
 import { BodyLong } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
@@ -11,6 +9,7 @@ import { useApp } from '../../../context/AppContext';
 import { useSteg } from '../../../context/StegContext';
 import { RouteEnum } from '../../../typer/routes';
 import { setUserProperty, UserProperty } from '../../../utils/amplitude';
+import AlertStripe from '../../Felleskomponenter/AlertStripe/AlertStripe';
 import BlokkerTilbakeKnappModal from '../../Felleskomponenter/BlokkerTilbakeKnappModal/BlokkerTilbakeKnappModal';
 import EksternLenke from '../../Felleskomponenter/EksternLenke/EksternLenke';
 import Informasjonsbolk from '../../Felleskomponenter/Informasjonsbolk/Informasjonsbolk';
@@ -53,7 +52,7 @@ const Kvittering: React.FC = () => {
     return (
         <Steg tittel={<SpråkTekst id={'kvittering.sidetittel'} />}>
             <KomponentGruppe>
-                <AlertStripe type="suksess">
+                <AlertStripe variant={'success'} inline={false}>
                     <SpråkTekst
                         id={'kvittering.mottatt'}
                         values={{

--- a/src/frontend/components/SøknadsSteg/OmBarnaDine/OmBarnaDine.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnaDine/OmBarnaDine.tsx
@@ -7,7 +7,7 @@ import { ESvar } from '@navikt/familie-form-elements';
 
 import { useApp } from '../../../context/AppContext';
 import { barnDataKeySpørsmål } from '../../../typer/barn';
-import AlertStripe from '../../Felleskomponenter/AlertStripe/AlertStripe';
+import FamilieAlert from '../../Felleskomponenter/FamilieAlert/FamilieAlert';
 import JaNeiSpm from '../../Felleskomponenter/JaNeiSpm/JaNeiSpm';
 import KomponentGruppe from '../../Felleskomponenter/KomponentGruppe/KomponentGruppe';
 import SpråkTekst from '../../Felleskomponenter/SpråkTekst/SpråkTekst';
@@ -70,9 +70,9 @@ const OmBarnaDine: React.FC = () => {
                         ]
                     }
                     tilleggsinfo={
-                        <AlertStripe variant={'info'}>
+                        <FamilieAlert variant={'info'}>
                             <SpråkTekst id={'ombarna.institusjon.info'} />
-                        </AlertStripe>
+                        </FamilieAlert>
                     }
                 />
 
@@ -102,9 +102,9 @@ const OmBarnaDine: React.FC = () => {
                             ]
                         }
                         tilleggsinfo={
-                            <AlertStripe variant={'info'}>
+                            <FamilieAlert variant={'info'}>
                                 <SpråkTekst id={'ombarna.adoptert.info'} />
-                            </AlertStripe>
+                            </FamilieAlert>
                         }
                     />
                     <HvilkeBarnCheckboxGruppe
@@ -159,9 +159,9 @@ const OmBarnaDine: React.FC = () => {
                             ]
                         }
                         tilleggsinfo={
-                            <AlertStripe variant={'info'}>
+                            <FamilieAlert variant={'info'}>
                                 <SpråkTekst id={'felles.korteopphold.info'} />
-                            </AlertStripe>
+                            </FamilieAlert>
                         }
                     />
                     <HvilkeBarnCheckboxGruppe

--- a/src/frontend/components/SøknadsSteg/OmBarnaDine/OmBarnaDine.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnaDine/OmBarnaDine.tsx
@@ -70,7 +70,7 @@ const OmBarnaDine: React.FC = () => {
                         ]
                     }
                     tilleggsinfo={
-                        <AlertStripe>
+                        <AlertStripe variant={'info'}>
                             <SpråkTekst id={'ombarna.institusjon.info'} />
                         </AlertStripe>
                     }
@@ -102,7 +102,7 @@ const OmBarnaDine: React.FC = () => {
                             ]
                         }
                         tilleggsinfo={
-                            <AlertStripe>
+                            <AlertStripe variant={'info'}>
                                 <SpråkTekst id={'ombarna.adoptert.info'} />
                             </AlertStripe>
                         }
@@ -159,7 +159,7 @@ const OmBarnaDine: React.FC = () => {
                             ]
                         }
                         tilleggsinfo={
-                            <AlertStripe>
+                            <AlertStripe variant={'info'}>
                                 <SpråkTekst id={'felles.korteopphold.info'} />
                             </AlertStripe>
                         }

--- a/src/frontend/components/SøknadsSteg/OmBarnet/Oppfølgningsspørsmål.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/Oppfølgningsspørsmål.tsx
@@ -206,7 +206,7 @@ const Oppfølgningsspørsmål: React.FC<{
                                 språkValues={{ barn: barn.navn }}
                             />
                             {planleggerÅBoINorge12Mnd.verdi === ESvar.NEI && (
-                                <AlertStripe type={'advarsel'} dynamisk>
+                                <AlertStripe variant={'warning'} dynamisk>
                                     <SpråkTekst
                                         id={'ombarnet.planlagt-sammenhengende-opphold.alert'}
                                     />

--- a/src/frontend/components/SøknadsSteg/OmBarnet/Oppfølgningsspørsmål.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/Oppfølgningsspørsmål.tsx
@@ -14,10 +14,10 @@ import {
     morgendagensDato,
     stringTilDate,
 } from '../../../utils/dato';
-import AlertStripe from '../../Felleskomponenter/AlertStripe/AlertStripe';
 import { Barnetrygdperiode } from '../../Felleskomponenter/Barnetrygdperiode/Barnetrygdperiode';
 import Datovelger from '../../Felleskomponenter/Datovelger/Datovelger';
 import { LandDropdown } from '../../Felleskomponenter/Dropdowns/LandDropdown';
+import FamilieAlert from '../../Felleskomponenter/FamilieAlert/FamilieAlert';
 import Informasjonsbolk from '../../Felleskomponenter/Informasjonsbolk/Informasjonsbolk';
 import JaNeiSpm from '../../Felleskomponenter/JaNeiSpm/JaNeiSpm';
 import KomponentGruppe from '../../Felleskomponenter/KomponentGruppe/KomponentGruppe';
@@ -206,11 +206,11 @@ const Oppfølgningsspørsmål: React.FC<{
                                 språkValues={{ barn: barn.navn }}
                             />
                             {planleggerÅBoINorge12Mnd.verdi === ESvar.NEI && (
-                                <AlertStripe variant={'warning'} dynamisk>
+                                <FamilieAlert variant={'warning'} dynamisk>
                                     <SpråkTekst
                                         id={'ombarnet.planlagt-sammenhengende-opphold.alert'}
                                     />
-                                </AlertStripe>
+                                </FamilieAlert>
                             )}
                         </KomponentGruppe>
                     )}

--- a/src/frontend/components/SøknadsSteg/OmDeg/OmDeg.test.tsx
+++ b/src/frontend/components/SøknadsSteg/OmDeg/OmDeg.test.tsx
@@ -19,10 +19,6 @@ import {
 import OmDeg from './OmDeg';
 import { OmDegSpørsmålId, omDegSpørsmålSpråkId } from './spørsmål';
 
-jest.mock('nav-frontend-alertstriper', () => ({ children }) => (
-    <div data-testid="alertstripe">{children}</div>
-));
-
 const TestKomponent = () => (
     <TestProvidere>
         <OmDeg />

--- a/src/frontend/components/SøknadsSteg/OmDeg/OmDeg.tsx
+++ b/src/frontend/components/SøknadsSteg/OmDeg/OmDeg.tsx
@@ -52,7 +52,7 @@ const OmDeg: React.FC = () => {
                 />
 
                 {skjema.felter.borPåRegistrertAdresse.verdi === ESvar.NEI && (
-                    <AlertStripe type={'advarsel'}>
+                    <AlertStripe variant={'warning'}>
                         <SpråkTekst
                             id={'omdeg.borpådenneadressen.kontakt-folkeregister-ukjent.alert'}
                         />
@@ -68,7 +68,7 @@ const OmDeg: React.FC = () => {
                             omDegSpørsmålSpråkId[OmDegSpørsmålId.værtINorgeITolvMåneder]
                         }
                         tilleggsinfo={
-                            <AlertStripe>
+                            <AlertStripe variant={'info'}>
                                 <SpråkTekst id={'felles.korteopphold.info'} />
                             </AlertStripe>
                         }
@@ -114,7 +114,7 @@ const OmDeg: React.FC = () => {
                         />
                         {skjema.felter.planleggerÅBoINorgeTolvMnd.erSynlig &&
                             skjema.felter.planleggerÅBoINorgeTolvMnd.verdi === ESvar.NEI && (
-                                <AlertStripe type={'advarsel'} dynamisk>
+                                <AlertStripe variant={'warning'} dynamisk>
                                     <SpråkTekst
                                         id={'omdeg.planlagt-opphold-sammenhengende.alert'}
                                     />

--- a/src/frontend/components/SøknadsSteg/OmDeg/OmDeg.tsx
+++ b/src/frontend/components/SøknadsSteg/OmDeg/OmDeg.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Label } from '@navikt/ds-react';
 import { ESvar } from '@navikt/familie-form-elements';
 
-import AlertStripe from '../../Felleskomponenter/AlertStripe/AlertStripe';
+import FamilieAlert from '../../Felleskomponenter/FamilieAlert/FamilieAlert';
 import JaNeiSpm from '../../Felleskomponenter/JaNeiSpm/JaNeiSpm';
 import KomponentGruppe from '../../Felleskomponenter/KomponentGruppe/KomponentGruppe';
 import { LeggTilKnapp } from '../../Felleskomponenter/LeggTilKnapp/LeggTilKnapp';
@@ -52,11 +52,11 @@ const OmDeg: React.FC = () => {
                 />
 
                 {skjema.felter.borPåRegistrertAdresse.verdi === ESvar.NEI && (
-                    <AlertStripe variant={'warning'}>
+                    <FamilieAlert variant={'warning'}>
                         <SpråkTekst
                             id={'omdeg.borpådenneadressen.kontakt-folkeregister-ukjent.alert'}
                         />
-                    </AlertStripe>
+                    </FamilieAlert>
                 )}
             </KomponentGruppe>
             <KomponentGruppe>
@@ -68,9 +68,9 @@ const OmDeg: React.FC = () => {
                             omDegSpørsmålSpråkId[OmDegSpørsmålId.værtINorgeITolvMåneder]
                         }
                         tilleggsinfo={
-                            <AlertStripe variant={'info'}>
+                            <FamilieAlert variant={'info'}>
                                 <SpråkTekst id={'felles.korteopphold.info'} />
-                            </AlertStripe>
+                            </FamilieAlert>
                         }
                     />
                     {skjema.felter.værtINorgeITolvMåneder.verdi === ESvar.NEI && (
@@ -114,11 +114,11 @@ const OmDeg: React.FC = () => {
                         />
                         {skjema.felter.planleggerÅBoINorgeTolvMnd.erSynlig &&
                             skjema.felter.planleggerÅBoINorgeTolvMnd.verdi === ESvar.NEI && (
-                                <AlertStripe variant={'warning'} dynamisk>
+                                <FamilieAlert variant={'warning'} dynamisk>
                                     <SpråkTekst
                                         id={'omdeg.planlagt-opphold-sammenhengende.alert'}
                                     />
-                                </AlertStripe>
+                                </FamilieAlert>
                             )}
                     </KomponentGruppe>
                 )}

--- a/src/frontend/components/SøknadsSteg/OmDeg/Personopplysninger.tsx
+++ b/src/frontend/components/SøknadsSteg/OmDeg/Personopplysninger.tsx
@@ -8,8 +8,8 @@ import { useSprakContext } from '@navikt/familie-sprakvelger';
 import { useApp } from '../../../context/AppContext';
 import { genererAdresseVisning } from '../../../utils/adresse';
 import { hentSivilstatusSpråkId, landkodeTilSpråk } from '../../../utils/språk';
-import AlertStripe from '../../Felleskomponenter/AlertStripe/AlertStripe';
 import EksternLenke from '../../Felleskomponenter/EksternLenke/EksternLenke';
+import FamilieAlert from '../../Felleskomponenter/FamilieAlert/FamilieAlert';
 import Informasjonsbolk from '../../Felleskomponenter/Informasjonsbolk/Informasjonsbolk';
 import SpråkTekst from '../../Felleskomponenter/SpråkTekst/SpråkTekst';
 import { omDegPersonopplysningerSpråkId } from './spørsmål';
@@ -22,14 +22,14 @@ export const Personopplysninger: React.FC = () => {
 
     return (
         <>
-            <AlertStripe variant={'info'}>
+            <FamilieAlert variant={'info'}>
                 <SpråkTekst id={'omdeg.personopplysninger.info.alert'} />
                 <EksternLenke
                     lenkeTekstSpråkId={'omdeg.endre-opplysninger.lenketekst'}
                     lenkeSpråkId={'omdeg.endre-opplysninger.lenke'}
                     target="_blank"
                 />
-            </AlertStripe>
+            </FamilieAlert>
 
             <Informasjonsbolk>
                 <Label>

--- a/src/frontend/components/SøknadsSteg/OmDeg/Personopplysninger.tsx
+++ b/src/frontend/components/SøknadsSteg/OmDeg/Personopplysninger.tsx
@@ -22,7 +22,7 @@ export const Personopplysninger: React.FC = () => {
 
     return (
         <>
-            <AlertStripe>
+            <AlertStripe variant={'info'}>
                 <SpråkTekst id={'omdeg.personopplysninger.info.alert'} />
                 <EksternLenke
                     lenkeTekstSpråkId={'omdeg.endre-opplysninger.lenketekst'}

--- a/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/LeggTilBarnModal.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/LeggTilBarnModal.tsx
@@ -7,7 +7,7 @@ import { ESvar } from '@navikt/familie-form-elements';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 
 import { visFeiloppsummering } from '../../../../utils/hjelpefunksjoner';
-import AlertStripe from '../../../Felleskomponenter/AlertStripe/AlertStripe';
+import FamilieAlert from '../../../Felleskomponenter/FamilieAlert/FamilieAlert';
 import JaNeiSpm from '../../../Felleskomponenter/JaNeiSpm/JaNeiSpm';
 import KomponentGruppe from '../../../Felleskomponenter/KomponentGruppe/KomponentGruppe';
 import { SkjemaCheckbox } from '../../../Felleskomponenter/SkjemaCheckbox/SkjemaCheckbox';
@@ -51,9 +51,9 @@ const LeggTilBarnModal: React.FC<{
                     spørsmålTekstId={velgBarnSpørsmålSpråkId[VelgBarnSpørsmålId.leggTilBarnErFødt]}
                 />
                 {skjema.felter.erFødt.verdi === ESvar.NEI && (
-                    <AlertStripe variant={'warning'}>
+                    <FamilieAlert variant={'warning'}>
                         <SpråkTekst id={'hvilkebarn.leggtilbarn.barn-ikke-født.alert'} />
-                    </AlertStripe>
+                    </FamilieAlert>
                 )}
             </KomponentGruppe>
             {skjema.felter.erFødt.valideringsstatus === Valideringsstatus.OK && (

--- a/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/LeggTilBarnModal.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/LeggTilBarnModal.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import AlertStripe from 'nav-frontend-alertstriper';
 import { SkjemaGruppe } from 'nav-frontend-skjema';
 
 import { Fieldset } from '@navikt/ds-react';
@@ -8,6 +7,7 @@ import { ESvar } from '@navikt/familie-form-elements';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 
 import { visFeiloppsummering } from '../../../../utils/hjelpefunksjoner';
+import AlertStripe from '../../../Felleskomponenter/AlertStripe/AlertStripe';
 import JaNeiSpm from '../../../Felleskomponenter/JaNeiSpm/JaNeiSpm';
 import KomponentGruppe from '../../../Felleskomponenter/KomponentGruppe/KomponentGruppe';
 import { SkjemaCheckbox } from '../../../Felleskomponenter/SkjemaCheckbox/SkjemaCheckbox';
@@ -51,7 +51,7 @@ const LeggTilBarnModal: React.FC<{
                     spørsmålTekstId={velgBarnSpørsmålSpråkId[VelgBarnSpørsmålId.leggTilBarnErFødt]}
                 />
                 {skjema.felter.erFødt.verdi === ESvar.NEI && (
-                    <AlertStripe type={'advarsel'} form={'inline'}>
+                    <AlertStripe variant={'warning'}>
                         <SpråkTekst id={'hvilkebarn.leggtilbarn.barn-ikke-født.alert'} />
                     </AlertStripe>
                 )}

--- a/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.tsx
@@ -4,8 +4,8 @@ import Masonry from 'react-masonry-css';
 import styled from 'styled-components';
 
 import { useApp } from '../../../context/AppContext';
-import AlertStripe from '../../Felleskomponenter/AlertStripe/AlertStripe';
 import EksternLenke from '../../Felleskomponenter/EksternLenke/EksternLenke';
+import FamilieAlert from '../../Felleskomponenter/FamilieAlert/FamilieAlert';
 import useModal from '../../Felleskomponenter/SkjemaModal/useModal';
 import SpråkTekst from '../../Felleskomponenter/SpråkTekst/SpråkTekst';
 import Steg from '../../Felleskomponenter/Steg/Steg';
@@ -58,14 +58,14 @@ const VelgBarn: React.FC = () => {
                     },
                 }}
             >
-                <AlertStripe variant={'info'}>
+                <FamilieAlert variant={'info'}>
                     <SpråkTekst id={'hvilkebarn.info.alert'} />
                     <EksternLenke
                         lenkeSpråkId={'hvilkebarn.endre-opplysninger.lenke'}
                         lenkeTekstSpråkId={'hvilkebarn.endre-opplysninger.lenketekst'}
                         target="_blank"
                     />
-                </AlertStripe>
+                </FamilieAlert>
 
                 <BarnekortContainer
                     id={VelgBarnSpørsmålId.velgBarn}

--- a/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.tsx
@@ -58,7 +58,7 @@ const VelgBarn: React.FC = () => {
                     },
                 }}
             >
-                <AlertStripe form={'inline'}>
+                <AlertStripe variant={'info'}>
                     <SpråkTekst id={'hvilkebarn.info.alert'} />
                     <EksternLenke
                         lenkeSpråkId={'hvilkebarn.endre-opplysninger.lenke'}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9827,16 +9827,6 @@ nav-datovelger@^12.6.0:
   dependencies:
     focus-trap-react "^8.6.0"
 
-nav-frontend-alertstriper-style@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/nav-frontend-alertstriper-style/-/nav-frontend-alertstriper-style-3.0.1.tgz#a5b6adf1cbe8adff0714fd162f33ed8a551ae190"
-  integrity sha512-kbeepa7BBhhRcwbdkwFNeL4JsnVKJZmREOxN4T7QkPtzhhIdsngZTtGfxcmJE2YHyuyAQeNF3rgFlAtxaxgQow==
-
-nav-frontend-alertstriper@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/nav-frontend-alertstriper/-/nav-frontend-alertstriper-4.0.1.tgz#e725ad099d9a26283e6ff3302ba9abe9e8602bdc"
-  integrity sha512-b+IWJsiyumtZPcxkQt+luwAUYC5i3f/MRVvDZsxn7l554PTXGLguW0j5ruOozlZSIzXBe/xnGskh5iyw3J5rew==
-
 nav-frontend-chevron-style@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/nav-frontend-chevron-style/-/nav-frontend-chevron-style-1.0.4.tgz#9cad6d1f19507147771e9ff26ebecf6e0964a50c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2292,23 +2292,29 @@
   resolved "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
-"@navikt/ds-css@^2.6.0":
-  version "2.6.0"
-  resolved "https://npm.pkg.github.com/download/@navikt/ds-css/2.6.0/6398a31d3a289deef89608262ba0ee5d18b719cf#6398a31d3a289deef89608262ba0ee5d18b719cf"
-  integrity sha512-6TOGywogGNJgpmlY4GoQZ/UngUxdKq927uWYeIwrFBRZufU0xFhZlxWbEJRQB9UcWp1ARs4Sr9swkFxRxp717w==
+"@navikt/aksel-icons@^2.9.2":
+  version "2.9.2"
+  resolved "https://npm.pkg.github.com/download/@navikt/aksel-icons/2.9.2/8b1dac941cac93dd8ba6f7e7d377a2336e275364#8b1dac941cac93dd8ba6f7e7d377a2336e275364"
+  integrity sha512-+n2m0sQU+FE63FkS6W5erwHJevBsgLPe3yn9BhVUZeq/oQyTMAExKOnGAsCm/EiJdDKVFuvFCZvoHBkMpCd56g==
 
-"@navikt/ds-icons@^2.6.0":
-  version "2.6.0"
-  resolved "https://npm.pkg.github.com/download/@navikt/ds-icons/2.6.0/0b6155d61669d9817708bfb703c4b57b23e1754b#0b6155d61669d9817708bfb703c4b57b23e1754b"
-  integrity sha512-//0sXWPL8TmjP4pcfcPn+tzm4t0gafLhUqs0WRGf/jCQTWO16yHod4PPEc7jXTJeisZpWkcjjsGlasIU5wMMdg==
+"@navikt/ds-css@^2.9.2":
+  version "2.9.2"
+  resolved "https://npm.pkg.github.com/download/@navikt/ds-css/2.9.2/7a71f76f3a4b251308d5c260b0ecb19a0415e486#7a71f76f3a4b251308d5c260b0ecb19a0415e486"
+  integrity sha512-p9myBj9Y7zJd0u0aj8T/iMDHlfmX/1I0H+QGNvCQj+30YjBwWfqIA86nqVjHneG8vgWef2q/wGXGaHQcpMZSJA==
 
-"@navikt/ds-react@^2.6.0":
-  version "2.6.0"
-  resolved "https://npm.pkg.github.com/download/@navikt/ds-react/2.6.0/e086a6763da9890fc99c69f14b9b80e1c964bf42#e086a6763da9890fc99c69f14b9b80e1c964bf42"
-  integrity sha512-wRf8SzP2b84FM8nZmsQJWWpclG0EVH4m6YaptUoU+KurAuVkLnIPMf0PYL+NqUVxG+9Q08WInzy2tn46f7NJ/A==
+"@navikt/ds-icons@^2.9.2":
+  version "2.9.2"
+  resolved "https://npm.pkg.github.com/download/@navikt/ds-icons/2.9.2/70e4b5a43a7e5c6447c0e7bac77f80ddf622ceb7#70e4b5a43a7e5c6447c0e7bac77f80ddf622ceb7"
+  integrity sha512-bbRlAPJN6nL0zYF/HDRGHGkXh4m9/4ErMXllZJyKzGymQ1p9dsvht4AsNi68RpNcYfx7BXxde1H1tj9E/pQgwA==
+
+"@navikt/ds-react@^2.9.2":
+  version "2.9.2"
+  resolved "https://npm.pkg.github.com/download/@navikt/ds-react/2.9.2/8020187ca495c862d5524d7d92493d02a079f314#8020187ca495c862d5524d7d92493d02a079f314"
+  integrity sha512-ZCZEGo9VeWv5sO0lnpKHGACriWSGy4HJ8t/mKYq/Sn7CRuC6VkEMN3s7AUJv35wV4wkcDcQR3NxKAzv8UKqYDQ==
   dependencies:
     "@floating-ui/react" "0.17.0"
-    "@navikt/ds-icons" "^2.6.0"
+    "@navikt/aksel-icons" "^2.9.2"
+    "@navikt/ds-icons" "^2.9.2"
     "@radix-ui/react-tabs" "1.0.0"
     "@radix-ui/react-toggle-group" "1.0.0"
     clsx "^1.2.1"
@@ -2316,10 +2322,10 @@
     react-day-picker "8.3.4"
     react-modal "3.15.1"
 
-"@navikt/ds-tokens@^2.6.0":
-  version "2.6.0"
-  resolved "https://npm.pkg.github.com/download/@navikt/ds-tokens/2.6.0/680f42f3c4fee3d7119140daf95053cd626783ab#680f42f3c4fee3d7119140daf95053cd626783ab"
-  integrity sha512-VcSU8GwRrODLtp7/fsqk3NI2q6GPJQDN3j8I9Me4BT2GI6b0NKaNw1Yqt1L7/a+RntUcfSn367NP4qGYwA6EMA==
+"@navikt/ds-tokens@^2.9.2":
+  version "2.9.2"
+  resolved "https://npm.pkg.github.com/download/@navikt/ds-tokens/2.9.2/056d822dbec03a2ab1dca260990c4cc73267e568#056d822dbec03a2ab1dca260990c4cc73267e568"
+  integrity sha512-taE+kAT9A/MX2v314rDINxYyHziUMe/u5HzBYZHayRZENbjmyNE2P724qVJb7kkON6WQkwUvhOHUc0/LMXkV9g==
 
 "@navikt/familie-form-elements@^10.1.0":
   version "10.1.0"


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._

Sletter pakkene "nav-frontend-alertstriper" og "nav-frontend-alertstriper-style"
Erstattes med designsystemets nye pakker "@navikt/ds-react"


### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._
Renamet den interne alerten fra AlertStripe til `FamilieAlert` fordi det ellers er lett å blande bruk av intern og ekstern alert, da den fra nav heter `Alert`

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Eget ønske

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
Er utkast av alerts i søknaden:

![Screenshot 2023-04-28 at 12 32 11](https://user-images.githubusercontent.com/8656966/235125051-93005178-b551-415f-904c-989b3b2e0836.png)
![Screenshot 2023-04-28 at 12 32 36](https://user-images.githubusercontent.com/8656966/235125054-082456ed-a208-4988-bf24-68f9e8bce036.png)
![Screenshot 2023-04-28 at 12 33 16](https://user-images.githubusercontent.com/8656966/235125059-8176762f-9904-430f-9960-b5626af0198f.png)
![Screenshot 2023-04-28 at 12 31 04](https://user-images.githubusercontent.com/8656966/235125040-409cd08f-921d-438e-bcb2-13d1fd6e26e2.png)
![Screenshot 2023-04-28 at 12 31 12](https://user-images.githubusercontent.com/8656966/235125046-038780d4-54fe-48a8-920b-60f494e78238.png)
![Screenshot 2023-04-28 at 12 31 33](https://user-images.githubusercontent.com/8656966/235125047-6522880f-303c-4b3e-b42c-bfe6c5bba0ac.png)
![Screenshot 2023-04-28 at 12 31 40](https://user-images.githubusercontent.com/8656966/235125049-d6fdb89f-0e27-4d40-a5d4-5d2e96e5ab6d.png)

