### PR TITLE
Legg aria-hidden på ikoner på knapper som ikke skal leses opp av skje…

### DIFF
--- a/src/frontend/assets/Barn1.tsx
+++ b/src/frontend/assets/Barn1.tsx
@@ -12,6 +12,7 @@ const Barn1: React.FC = () => {
             viewBox="0 0 63 90"
             xmlns="http://www.w3.org/2000/svg"
             aria-label={formatMessage({ id: 'felles.barneillustrasjon.tittel' })}
+            role="img"
         >
             <defs>
                 <path

--- a/src/frontend/assets/Barn2.tsx
+++ b/src/frontend/assets/Barn2.tsx
@@ -12,6 +12,7 @@ const Barn2: React.FC = () => {
             viewBox="0 0 63 90"
             xmlns="http://www.w3.org/2000/svg"
             aria-label={formatMessage({ id: 'felles.barneillustrasjon.tittel' })}
+            role="img"
         >
             <defs>
                 <path

--- a/src/frontend/assets/Barn3.tsx
+++ b/src/frontend/assets/Barn3.tsx
@@ -12,6 +12,7 @@ const Barn3: React.FC = () => {
             viewBox="0 0 63 90"
             xmlns="http://www.w3.org/2000/svg"
             aria-label={formatMessage({ id: 'felles.barneillustrasjon.tittel' })}
+            role="img"
         >
             <defs>
                 <path

--- a/src/frontend/components/Felleskomponenter/LeggTilKnapp/LeggTilKnapp.tsx
+++ b/src/frontend/components/Felleskomponenter/LeggTilKnapp/LeggTilKnapp.tsx
@@ -30,7 +30,7 @@ export const LeggTilKnapp: React.FC<Props> = ({ onClick, språkTekst, feilmeldin
             type={'button'}
             onClick={onClick}
             $feilmelding={!!feilmelding}
-            icon={<PlusCircleIcon />}
+            icon={<PlusCircleIcon aria-hidden />}
         >
             <SpråkTekst id={språkTekst} />
         </StyledButton>

--- a/src/frontend/components/Felleskomponenter/PeriodeOppsummering/PeriodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/PeriodeOppsummering/PeriodeOppsummering.tsx
@@ -53,7 +53,7 @@ const PeriodeOppsummering: React.FC<{
                     type={'button'}
                     variant={'tertiary'}
                     onClick={() => fjernPeriodeCallback()}
-                    icon={<TrashFillIcon />}
+                    icon={<TrashFillIcon aria-hidden />}
                 >
                     <SpråkTekst id={fjernKnappSpråkId} />
                 </StyledButton>

--- a/src/frontend/components/Felleskomponenter/SkjemaFieldset.tsx
+++ b/src/frontend/components/Felleskomponenter/SkjemaFieldset.tsx
@@ -6,7 +6,7 @@ import { Fieldset } from '@navikt/ds-react';
 
 import SpråkTekst from './SpråkTekst/SpråkTekst';
 
-const Container = styled(Fieldset)`
+const StyledFieldset = styled(Fieldset)`
     border: none;
     padding: 0;
 
@@ -20,16 +20,16 @@ const ChildContainer = styled.div`
 `;
 
 const SkjemaFieldset: React.FC<{
-    tittelId: string;
+    legendSpråkId: string;
     språkValues?: { [key: string]: ReactNode };
     dynamisk?: boolean;
     children?: ReactNode;
-}> = ({ tittelId, språkValues, dynamisk = false, children }) => {
+}> = ({ legendSpråkId, språkValues, dynamisk = false, children }) => {
     const childrenLengde = React.Children.count(children);
     return (
-        <Container
+        <StyledFieldset
             aria-live={dynamisk ? 'polite' : 'off'}
-            legend={<SpråkTekst id={tittelId} values={språkValues} />}
+            legend={<SpråkTekst id={legendSpråkId} values={språkValues} />}
         >
             {React.Children.map(children, (child, index) => {
                 return (
@@ -41,7 +41,7 @@ const SkjemaFieldset: React.FC<{
                     ))
                 );
             })}
-        </Container>
+        </StyledFieldset>
     );
 };
 

--- a/src/frontend/components/Felleskomponenter/expandableContent/InfoToggleButton.tsx
+++ b/src/frontend/components/Felleskomponenter/expandableContent/InfoToggleButton.tsx
@@ -73,9 +73,9 @@ const InfoToggleButton = (props: Props) => {
                 <LabelContainer>{children}</LabelContainer>
                 <ChevronContainer>
                     {isOpen ? (
-                        <ChevronUpIcon fontSize={'1.5rem'} />
+                        <ChevronUpIcon fontSize={'1.5rem'} aria-hidden />
                     ) : (
-                        <ChevronDownIcon fontSize={'1.5rem'} />
+                        <ChevronDownIcon fontSize={'1.5rem'} aria-hidden />
                     )}
                 </ChevronContainer>
             </ButtonInnholdWrapper>

--- a/src/frontend/components/SøknadsSteg/DinLivssituasjon/SamboerOpplysninger.tsx
+++ b/src/frontend/components/SøknadsSteg/DinLivssituasjon/SamboerOpplysninger.tsx
@@ -77,7 +77,7 @@ const SamboerOpplysninger: React.FC<{
                 type={'button'}
                 variant={'tertiary'}
                 onClick={() => fjernTidligereSamboer(samboer)}
-                icon={<TrashFillIcon />}
+                icon={<TrashFillIcon aria-hidden />}
             >
                 <SpråkTekst id={'omdeg.fjernsamboer.knapp'} />
             </StyledButton>

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/OpplastedeFiler.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/OpplastedeFiler.tsx
@@ -59,7 +59,7 @@ const OpplastedeFiler: React.FC<Props> = ({ filliste, slettVedlegg }) => {
                         <Button
                             variant={'tertiary'}
                             onClick={() => slettVedlegg(fil)}
-                            icon={<TrashFillIcon focusable={false} />}
+                            icon={<TrashFillIcon focusable={false} aria-hidden />}
                         >
                             <SpråkTekst id={'felles.slett'} />
                         </Button>

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Barn/EøsForBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Barn/EøsForBarn.tsx
@@ -183,7 +183,7 @@ const EøsForBarn: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
             )}
 
             {!skalSkjuleAndreForelderFelt(barn) && (
-                <SkjemaFieldset tittelId={'ombarnet.andre-forelder'}>
+                <SkjemaFieldset legendSpråkId={'ombarnet.andre-forelder'}>
                     {!barnMedSammeForelder ? (
                         <>
                             <IdNummerForAndreForelder

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Barn/Omsorgsperson.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Barn/Omsorgsperson.tsx
@@ -66,7 +66,7 @@ const Omsorgsperson: React.FC<OmsorgspersonProps> = ({ skjema, barn, periodeFunk
 
     return (
         <SkjemaFieldset
-            tittelId={'eøs-om-barn.annenomsorgsperson.gjenlevende'}
+            legendSpråkId={'eøs-om-barn.annenomsorgsperson.gjenlevende'}
             språkValues={{ barn: barn.navn }}
         >
             <SkjemaFeltInput

--- a/src/frontend/components/SøknadsSteg/OmBarnet/AndreForelder.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/AndreForelder.tsx
@@ -44,7 +44,7 @@ const AndreForelder: React.FC<{
     );
 
     return (
-        <SkjemaFieldset tittelId={'ombarnet.andre-forelder'}>
+        <SkjemaFieldset legendSpråkId={'ombarnet.andre-forelder'}>
             <KomponentGruppe>
                 {skjema.felter.sammeForelderSomAnnetBarn.erSynlig && (
                     <SammeSomAnnetBarnRadio

--- a/src/frontend/components/SøknadsSteg/OmBarnet/OmBarnet.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/OmBarnet.tsx
@@ -79,7 +79,7 @@ const OmBarnet: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
             )}
 
             {skjema.felter.borFastMedSøker.erSynlig && (
-                <SkjemaFieldset tittelId={'ombarnet.bosted'} dynamisk>
+                <SkjemaFieldset legendSpråkId={'ombarnet.bosted'} dynamisk>
                     {barn.andreForelderErDød?.svar !== ESvar.JA && (
                         <>
                             <div>

--- a/src/frontend/components/SøknadsSteg/OmBarnet/Oppfølgningsspørsmål.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/Oppfølgningsspørsmål.tsx
@@ -88,7 +88,10 @@ const Oppfølgningsspørsmål: React.FC<{
             )}
 
             {barn[barnDataKeySpørsmål.oppholderSegIInstitusjon].svar === ESvar.JA && (
-                <SkjemaFieldset tittelId={'ombarnet.institusjon'} språkValues={{ navn: barn.navn }}>
+                <SkjemaFieldset
+                    legendSpråkId={'ombarnet.institusjon'}
+                    språkValues={{ navn: barn.navn }}
+                >
                     <SkjemaCheckbox
                         labelSpråkTekstId={
                             omBarnetSpørsmålSpråkId[OmBarnetSpørsmålsId.institusjonIUtland]
@@ -166,7 +169,7 @@ const Oppfølgningsspørsmål: React.FC<{
             )}
             {barn[barnDataKeySpørsmål.boddMindreEnn12MndINorge].svar === ESvar.JA && (
                 <SkjemaFieldset
-                    tittelId={'ombarnet.opplystatbarnutlandopphold.info'}
+                    legendSpråkId={'ombarnet.opplystatbarnutlandopphold.info'}
                     språkValues={{ navn: barn.navn }}
                 >
                     {utenlandsperioder.map((periode, index) => (
@@ -223,7 +226,7 @@ const Oppfølgningsspørsmål: React.FC<{
             )}
             {barn[barnDataKeySpørsmål.barnetrygdFraAnnetEøsland].svar === ESvar.JA && (
                 <SkjemaFieldset
-                    tittelId={'ombarnet.barnetrygd-eøs'}
+                    legendSpråkId={'ombarnet.barnetrygd-eøs'}
                     språkValues={{ navn: barn.navn }}
                 >
                     <KomponentGruppe>


### PR DESCRIPTION
…rmleser

### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._

Vi ønsker ikke at ikoner på knapper skal leses opp av skjermleser da knappen allerede har en beskrivende tekst. Legger derfor på aria-hidden på disse ikonene det gjelder.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
