### PR TITLE
Lag grupperingsregler for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,25 @@ updates:
     ignore:
     - dependency-name: "*"
       update-types: ["version-update:semver-patch"]
+    groups:
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/eslint-plugin"
+          - "@typescript-eslint/parser"
+      react:
+        patterns:
+          - "react"
+          - "@types/react"
+          - "react-dom"
+      babel:
+        patterns:
+          - "@babel/*"
+      aksel:
+        patterns:
+          - "@navikt/aksel-icons"
+          - "@navikt/ds-*"
+        exclude-patterns:
+          - "@navikt/ds-icons"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Lager grupperingsregler for Dependabot, slik som vi har for BA-sak og KS-sak. Dette gjør at dependabot ser på grupperte avhengigheter som en helhet, og lager felles PR for disse. 

Se tilsvarende konfigurasjon i ks-sak: https://github.com/navikt/familie-ks-sak-frontend/blob/main/.github/dependabot.yml