### PR TITLE
Feat: støtte ny implementasjon av flettefelt

### DIFF
--- a/src/frontend/components/Felleskomponenter/Sanity/TekstBlock.tsx
+++ b/src/frontend/components/Felleskomponenter/Sanity/TekstBlock.tsx
@@ -109,6 +109,10 @@ const TekstBlock: React.FC<{
                         );
                     },
                 },
+                types: {
+                    flettefelt: props =>
+                        flettefeltTilTekst(props.value.flettefelt, flettefelter, valgtLocale),
+                },
             }}
         />
     ) : null;

--- a/src/frontend/utils/sanity.ts
+++ b/src/frontend/utils/sanity.ts
@@ -129,6 +129,8 @@ export const plainTekstHof =
                         ? pipe(node => node, ...transformedMarks)(child).text
                         : pipe(node => node)(child).text;
                     previousElementIsNonSpan = false;
+                } else if (child._type == 'flettefelt') {
+                    tekst += flettefeltTilTekst(child.flettefelt, flettefelter, spesifikkLocale);
                 } else {
                     previousElementIsNonSpan = true;
                 }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Del av denne: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18565

Legger til støtte for ny implementasjon av flettefelt. I en mellomfase vil koden nå støtte både gammel og ny variant, frem til alt gammelt er slettet fra Sanity. Tanken er at BA-tekster ikke skal bruke de gamle flettefeltene, men det er greit å beholde den gamle implementasjonen enn så lenge, just in case. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._
Kommer til å legge til tilsvarende i ks-soknad, slik at denne også støtter begge type flettefelter i en mellomperiode.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
Har testet manuelt at det funker

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Alt er i samme commit

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei, men kan også forklare muntlig om det er ønskelig
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
Har testet å legge til det nye flettefeltet i en test-tekst. Har deretter testet å legge inn denne teksten i koden, og rendret ut både som TekstBlock-komponent og brukt stringen fra plainTekst-funksjonen. Hvor jeg har puttet inn komponentene gir ikke nødvendigvis mening, men teksten som rendres er riktig:)

Fra `plainTekst`-funksjon:
![image](https://github.com/navikt/familie-ba-soknad/assets/25459913/caae1b21-c5a4-48c5-8c6b-4d61dc1d73c1)


Fra `TekstBlock`-funksjon:
![image](https://github.com/navikt/familie-ba-soknad/assets/25459913/60bbacec-5916-4c05-9342-d96f66e2ca3c)
