### PR TITLE
Korriger syntaks for å ignorere main-branch

### DIFF
--- a/.github/workflows/build_pr.yaml
+++ b/.github/workflows/build_pr.yaml
@@ -2,7 +2,7 @@ name: Build PR
 
 on:
   push:
-    ignore-branches:
+    branches-ignore:
       - main
 
 env:


### PR DESCRIPTION
Vi kjører tester og bygg på PR-nivå, og bygger fra main mot prod i egen action. Trenger ikke å gjøre det også i denne action. Men enten så har github endret syntaks for å ignorere branches eller så har jeg rett og slett "visst feil"! 😮

