### PR TITLE
Fjern spørsmål om samboer i søknad om ordinær barnetrygd

### DIFF
--- a/src/frontend/components/SøknadsSteg/DinLivssituasjon/DinLivssituasjon.test.tsx
+++ b/src/frontend/components/SøknadsSteg/DinLivssituasjon/DinLivssituasjon.test.tsx
@@ -26,18 +26,18 @@ const søknad = mockDeep<ISøknad>({
     ],
     søker: {
         sivilstand: { type: ESivilstand.UGIFT },
-        nåværendeSamboer: null,
-        harSamboerNå: {
-            id: DinLivssituasjonSpørsmålId.harSamboerNå,
-            svar: null,
-        },
         utvidet: {
             spørsmål: {
                 årsak: {
                     id: DinLivssituasjonSpørsmålId.årsak,
                     svar: '',
                 },
+                harSamboerNå: {
+                    id: DinLivssituasjonSpørsmålId.harSamboerNå,
+                    svar: null,
+                },
             },
+            nåværendeSamboer: null,
         },
     },
 });

--- a/src/frontend/components/SøknadsSteg/DinLivssituasjon/DinLivssituasjon.tsx
+++ b/src/frontend/components/SøknadsSteg/DinLivssituasjon/DinLivssituasjon.tsx
@@ -108,39 +108,42 @@ const DinLivssituasjon: React.FC = () => {
                             </KomponentGruppe>
                         )}
                     </KomponentGruppe>
+
+                    <KomponentGruppe>
+                        <JaNeiSpm
+                            skjema={skjema}
+                            felt={skjema.felter.harSamboerNå}
+                            spørsmålTekstId={
+                                dinLivssituasjonSpørsmålSpråkId[søknad.søker.harSamboerNå.id]
+                            }
+                        />
+
+                        {skjema.felter.harSamboerNå.verdi === ESvar.JA && (
+                            <KomponentGruppe dynamisk>
+                                <SamboerSkjema
+                                    skjema={skjema}
+                                    samboerFelter={{
+                                        navn: skjema.felter.nåværendeSamboerNavn,
+                                        fnr: skjema.felter.nåværendeSamboerFnr,
+                                        fnrUkjent: skjema.felter.nåværendeSamboerFnrUkjent,
+                                        fødselsdato: skjema.felter.nåværendeSamboerFødselsdato,
+                                        fødselsdatoUkjent:
+                                            skjema.felter.nåværendeSamboerFødselsdatoUkjent,
+                                        samboerFraDato: skjema.felter.nåværendeSamboerFraDato,
+                                    }}
+                                />
+                            </KomponentGruppe>
+                        )}
+
+                        <TidligereSamboere
+                            tidligereSamboere={tidligereSamboere}
+                            leggTilTidligereSamboer={leggTilTidligereSamboer}
+                            fjernTidligereSamboer={fjernTidligereSamboer}
+                        />
+                    </KomponentGruppe>
                 </>
             )}
 
-            <KomponentGruppe>
-                <JaNeiSpm
-                    skjema={skjema}
-                    felt={skjema.felter.harSamboerNå}
-                    spørsmålTekstId={dinLivssituasjonSpørsmålSpråkId[søknad.søker.harSamboerNå.id]}
-                />
-
-                {skjema.felter.harSamboerNå.verdi === ESvar.JA && (
-                    <KomponentGruppe dynamisk>
-                        <SamboerSkjema
-                            skjema={skjema}
-                            samboerFelter={{
-                                navn: skjema.felter.nåværendeSamboerNavn,
-                                fnr: skjema.felter.nåværendeSamboerFnr,
-                                fnrUkjent: skjema.felter.nåværendeSamboerFnrUkjent,
-                                fødselsdato: skjema.felter.nåværendeSamboerFødselsdato,
-                                fødselsdatoUkjent: skjema.felter.nåværendeSamboerFødselsdatoUkjent,
-                                samboerFraDato: skjema.felter.nåværendeSamboerFraDato,
-                            }}
-                        />
-                    </KomponentGruppe>
-                )}
-                {erUtvidet && (
-                    <TidligereSamboere
-                        tidligereSamboere={tidligereSamboere}
-                        leggTilTidligereSamboer={leggTilTidligereSamboer}
-                        fjernTidligereSamboer={fjernTidligereSamboer}
-                    />
-                )}
-            </KomponentGruppe>
             <KomponentGruppe>
                 <JaNeiSpm
                     skjema={skjema}

--- a/src/frontend/components/SøknadsSteg/DinLivssituasjon/DinLivssituasjon.tsx
+++ b/src/frontend/components/SøknadsSteg/DinLivssituasjon/DinLivssituasjon.tsx
@@ -114,7 +114,9 @@ const DinLivssituasjon: React.FC = () => {
                             skjema={skjema}
                             felt={skjema.felter.harSamboerNå}
                             spørsmålTekstId={
-                                dinLivssituasjonSpørsmålSpråkId[søknad.søker.harSamboerNå.id]
+                                dinLivssituasjonSpørsmålSpråkId[
+                                    søknad.søker.utvidet.spørsmål.harSamboerNå.id
+                                ]
                             }
                         />
 

--- a/src/frontend/components/SøknadsSteg/DinLivssituasjon/LeggTilSamboerModal.test.tsx
+++ b/src/frontend/components/SøknadsSteg/DinLivssituasjon/LeggTilSamboerModal.test.tsx
@@ -23,8 +23,12 @@ const søknad = mockDeep<ISøknad>({
         },
     ],
     søker: {
-        nåværendeSamboer: null,
-        harSamboerNå: { id: DinLivssituasjonSpørsmålId.harSamboerNå, svar: null },
+        utvidet: {
+            spørsmål: {
+                harSamboerNå: { id: DinLivssituasjonSpørsmålId.harSamboerNå, svar: null },
+            },
+            nåværendeSamboer: null,
+        },
     },
 });
 

--- a/src/frontend/components/SøknadsSteg/DinLivssituasjon/NåværendeSamboer.test.tsx
+++ b/src/frontend/components/SøknadsSteg/DinLivssituasjon/NåværendeSamboer.test.tsx
@@ -47,11 +47,15 @@ const søknad = {
     ],
     søker: {
         sivilstand: { type: ESivilstand.UGIFT },
-        harSamboerNå: {
-            id: DinLivssituasjonSpørsmålId.harSamboerNå,
-            svar: ESvar.JA,
+        utvidet: {
+            spørsmål: {
+                harSamboerNå: {
+                    id: DinLivssituasjonSpørsmålId.harSamboerNå,
+                    svar: ESvar.JA,
+                },
+            },
+            nåværendeSamboer: null,
         },
-        nåværendeSamboer: null,
     },
 };
 
@@ -59,22 +63,25 @@ const søknadGyldigNåværendeSamboerBase = {
     ...søknad,
     søker: {
         ...søknad.søker,
-        nåværendeSamboer: {
-            navn: {
-                id: SamboerSpørsmålId.nåværendeSamboerNavn,
-                svar: 'Initial verdi for samboer sitt navn',
-            },
-            ident: {
-                id: SamboerSpørsmålId.nåværendeSamboerFnr,
-                svar: AlternativtSvarForInput.UKJENT,
-            },
-            fødselsdato: {
-                id: SamboerSpørsmålId.nåværendeSamboerFødselsdato,
-                svar: AlternativtSvarForInput.UKJENT,
-            },
-            samboerFraDato: {
-                id: SamboerSpørsmålId.nåværendeSamboerFraDato,
-                svar: '2000-01-01',
+        utvidet: {
+            ...søknad.søker.utvidet,
+            nåværendeSamboer: {
+                navn: {
+                    id: SamboerSpørsmålId.nåværendeSamboerNavn,
+                    svar: 'Initial verdi for samboer sitt navn',
+                },
+                ident: {
+                    id: SamboerSpørsmålId.nåværendeSamboerFnr,
+                    svar: AlternativtSvarForInput.UKJENT,
+                },
+                fødselsdato: {
+                    id: SamboerSpørsmålId.nåværendeSamboerFødselsdato,
+                    svar: AlternativtSvarForInput.UKJENT,
+                },
+                samboerFraDato: {
+                    id: SamboerSpørsmålId.nåværendeSamboerFraDato,
+                    svar: '2000-01-01',
+                },
             },
         },
     },

--- a/src/frontend/components/SøknadsSteg/DinLivssituasjon/TidligereSamboere.test.tsx
+++ b/src/frontend/components/SøknadsSteg/DinLivssituasjon/TidligereSamboere.test.tsx
@@ -36,21 +36,22 @@ const søknad = mockDeep<ISøknad>({
     ],
     søker: {
         sivilstand: { type: ESivilstand.SKILT },
-        nåværendeSamboer: {
-            navn: { svar: '' },
-            ident: { svar: '' },
-            fødselsdato: { svar: '' },
-            samboerFraDato: { svar: '' },
-        },
-        harSamboerNå: {
-            id: DinLivssituasjonSpørsmålId.harSamboerNå,
-            svar: ESvar.JA,
-        },
+
         utvidet: {
             spørsmål: {
                 årsak: { svar: '' },
+                harSamboerNå: {
+                    id: DinLivssituasjonSpørsmålId.harSamboerNå,
+                    svar: ESvar.JA,
+                },
             },
             tidligereSamboere: [],
+            nåværendeSamboer: {
+                navn: { svar: '' },
+                ident: { svar: '' },
+                fødselsdato: { svar: '' },
+                samboerFraDato: { svar: '' },
+            },
         },
     },
 });

--- a/src/frontend/components/SøknadsSteg/DinLivssituasjon/useDinLivssituasjon.tsx
+++ b/src/frontend/components/SøknadsSteg/DinLivssituasjon/useDinLivssituasjon.tsx
@@ -104,7 +104,7 @@ export const useDinLivssituasjon = (): {
 
     /*---- NÅVÆRENDE SAMBOER ----*/
     const harSamboerNå: Felt<ESvar | null> = useJaNeiSpmFelt({
-        søknadsfelt: søker.harSamboerNå,
+        søknadsfelt: søker.utvidet.spørsmål.harSamboerNå,
         feilmeldingSpråkId:
             søker.sivilstand.type === ESivilstand.GIFT
                 ? 'omdeg.samboernå.gift.feilmelding'
@@ -115,7 +115,7 @@ export const useDinLivssituasjon = (): {
     const nåværendeSamboerNavn = useInputFelt({
         søknadsfelt: {
             id: SamboerSpørsmålId.nåværendeSamboerNavn,
-            svar: søknad.søker.nåværendeSamboer?.navn.svar || '',
+            svar: søknad.søker.utvidet.nåværendeSamboer?.navn.svar || '',
         },
         feilmeldingSpråkId: 'omdeg.samboerNavn.feilmelding',
         skalVises: harSamboerNå.verdi === ESvar.JA,
@@ -128,7 +128,7 @@ export const useDinLivssituasjon = (): {
     };
     const nåværendeSamboerFnrUkjent = useFelt<ESvar>({
         feltId: SamboerSpørsmålId.nåværendeSamboerFnrUkjent,
-        verdi: fnrUkjentInitiellVerdi(søker.nåværendeSamboer),
+        verdi: fnrUkjentInitiellVerdi(søker.utvidet.nåværendeSamboer),
         avhengigheter: { harSamboerNå },
         skalFeltetVises: avhengigheter => avhengigheter.harSamboerNå.verdi === ESvar.JA,
     });
@@ -140,7 +140,7 @@ export const useDinLivssituasjon = (): {
     const nåværendeSamboerFnr = useInputFeltMedUkjent({
         søknadsfelt: {
             id: SamboerSpørsmålId.nåværendeSamboerFnr,
-            svar: fnrInitiellVerdi(søker.nåværendeSamboer),
+            svar: fnrInitiellVerdi(søker.utvidet.nåværendeSamboer),
         },
         avhengighet: nåværendeSamboerFnrUkjent,
         feilmeldingSpråkId: 'omdeg.samboer.ident.ikkebesvart.feilmelding',
@@ -154,7 +154,7 @@ export const useDinLivssituasjon = (): {
     };
     const nåværendeSamboerFødselsdatoUkjent = useFelt<ESvar>({
         feltId: SamboerSpørsmålId.nåværendeSamboerFødselsdatoUkjent,
-        verdi: settKjennerIkkeFødselsdatoInitialValue(søker.nåværendeSamboer),
+        verdi: settKjennerIkkeFødselsdatoInitialValue(søker.utvidet.nåværendeSamboer),
         avhengigheter: { fnrUkjent: nåværendeSamboerFnrUkjent },
         skalFeltetVises: avhengigheter => avhengigheter.fnrUkjent.verdi === ESvar.JA,
         nullstillVedAvhengighetEndring: false,
@@ -167,7 +167,7 @@ export const useDinLivssituasjon = (): {
 
     const nåværendeSamboerFødselsdato = useDatovelgerFeltMedUkjent({
         feltId: SamboerSpørsmålId.nåværendeSamboerFødselsdato,
-        initiellVerdi: getInitialFødselsdato(søker.nåværendeSamboer),
+        initiellVerdi: getInitialFødselsdato(søker.utvidet.nåværendeSamboer),
         vetIkkeCheckbox: nåværendeSamboerFødselsdatoUkjent,
         feilmeldingSpråkId: 'omdeg.nåværendesamboer.fødselsdato.ukjent',
         skalFeltetVises: nåværendeSamboerFnrUkjent.verdi === ESvar.JA,
@@ -177,7 +177,7 @@ export const useDinLivssituasjon = (): {
     const nåværendeSamboerFraDato = useDatovelgerFeltMedJaNeiAvhengighet({
         søknadsfelt: {
             id: SamboerSpørsmålId.nåværendeSamboerFraDato,
-            svar: søker.nåværendeSamboer?.samboerFraDato.svar || '',
+            svar: søker.utvidet.nåværendeSamboer?.samboerFraDato.svar || '',
         },
         avhengigSvarCondition: ESvar.JA,
         avhengighet: harSamboerNå,
@@ -305,38 +305,6 @@ export const useDinLivssituasjon = (): {
 
     const genererOppdatertSøker = (): ISøker => ({
         ...søknad.søker,
-        harSamboerNå: {
-            ...søknad.søker.harSamboerNå,
-            svar: skjema.felter.harSamboerNå.verdi,
-        },
-        nåværendeSamboer:
-            harSamboerNå.verdi === ESvar.JA
-                ? {
-                      ...søknad.søker.nåværendeSamboer,
-                      navn: {
-                          id: SamboerSpørsmålId.nåværendeSamboerNavn,
-                          svar: trimWhiteSpace(skjema.felter.nåværendeSamboerNavn.verdi),
-                      },
-                      ident: {
-                          id: SamboerSpørsmålId.nåværendeSamboerFnr,
-                          svar: svarForSpørsmålMedUkjent(
-                              skjema.felter.nåværendeSamboerFnrUkjent,
-                              skjema.felter.nåværendeSamboerFnr
-                          ),
-                      },
-                      fødselsdato: {
-                          id: SamboerSpørsmålId.nåværendeSamboerFødselsdato,
-                          svar: svarForSpørsmålMedUkjent(
-                              skjema.felter.nåværendeSamboerFødselsdatoUkjent,
-                              skjema.felter.nåværendeSamboerFødselsdato
-                          ),
-                      },
-                      samboerFraDato: {
-                          id: SamboerSpørsmålId.nåværendeSamboerFraDato,
-                          svar: skjema.felter.nåværendeSamboerFraDato.verdi,
-                      },
-                  }
-                : null,
         erAsylsøker: {
             ...søknad.søker.erAsylsøker,
             svar: skjema.felter.erAsylsøker.verdi,
@@ -379,7 +347,39 @@ export const useDinLivssituasjon = (): {
                     ...søknad.søker.utvidet.spørsmål.separertEnkeSkiltDato,
                     svar: skjema.felter.separertEnkeSkiltDato.verdi,
                 },
+                harSamboerNå: {
+                    ...søknad.søker.utvidet.spørsmål.harSamboerNå,
+                    svar: skjema.felter.harSamboerNå.verdi,
+                },
             },
+            nåværendeSamboer:
+                harSamboerNå.verdi === ESvar.JA
+                    ? {
+                          ...søknad.søker.utvidet.nåværendeSamboer,
+                          navn: {
+                              id: SamboerSpørsmålId.nåværendeSamboerNavn,
+                              svar: trimWhiteSpace(skjema.felter.nåværendeSamboerNavn.verdi),
+                          },
+                          ident: {
+                              id: SamboerSpørsmålId.nåværendeSamboerFnr,
+                              svar: svarForSpørsmålMedUkjent(
+                                  skjema.felter.nåværendeSamboerFnrUkjent,
+                                  skjema.felter.nåværendeSamboerFnr
+                              ),
+                          },
+                          fødselsdato: {
+                              id: SamboerSpørsmålId.nåværendeSamboerFødselsdato,
+                              svar: svarForSpørsmålMedUkjent(
+                                  skjema.felter.nåværendeSamboerFødselsdatoUkjent,
+                                  skjema.felter.nåværendeSamboerFødselsdato
+                              ),
+                          },
+                          samboerFraDato: {
+                              id: SamboerSpørsmålId.nåværendeSamboerFraDato,
+                              svar: skjema.felter.nåværendeSamboerFraDato.verdi,
+                          },
+                      }
+                    : null,
         },
     });
 

--- a/src/frontend/components/SøknadsSteg/DinLivssituasjon/useDinLivssituasjon.tsx
+++ b/src/frontend/components/SøknadsSteg/DinLivssituasjon/useDinLivssituasjon.tsx
@@ -109,6 +109,7 @@ export const useDinLivssituasjon = (): {
             søker.sivilstand.type === ESivilstand.GIFT
                 ? 'omdeg.samboernå.gift.feilmelding'
                 : 'omdeg.samboernå.feilmelding',
+        skalSkjules: !erUtvidet,
     });
 
     const nåværendeSamboerNavn = useInputFelt({

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/DinLivssituasjonOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/DinLivssituasjonOppsummering.tsx
@@ -163,23 +163,25 @@ const DinLivssituasjonOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
                             )}
                         </StyledOppsummeringsFeltGruppe>
                     )}
-                </>
-            )}
-            <StyledOppsummeringsFeltGruppe>
-                <OppsummeringFelt
-                    tittel={
-                        <SpråkTekst
-                            id={dinLivssituasjonSpørsmålSpråkId[søknad.søker.harSamboerNå.id]}
+
+                    <StyledOppsummeringsFeltGruppe>
+                        <OppsummeringFelt
+                            tittel={
+                                <SpråkTekst
+                                    id={
+                                        dinLivssituasjonSpørsmålSpråkId[
+                                            søknad.søker.harSamboerNå.id
+                                        ]
+                                    }
+                                />
+                            }
+                            søknadsvar={søknad.søker.harSamboerNå.svar}
                         />
-                    }
-                    søknadsvar={søknad.søker.harSamboerNå.svar}
-                />
-                {søknad.søker.nåværendeSamboer && (
-                    <SamboerOppsummering samboer={søknad.søker.nåværendeSamboer} />
-                )}
-            </StyledOppsummeringsFeltGruppe>
-            {erUtvidet && (
-                <>
+                        {søknad.søker.nåværendeSamboer && (
+                            <SamboerOppsummering samboer={søknad.søker.nåværendeSamboer} />
+                        )}
+                    </StyledOppsummeringsFeltGruppe>
+
                     <StyledOppsummeringsFeltGruppe>
                         <OppsummeringFelt
                             tittel={

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/DinLivssituasjonOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/DinLivssituasjonOppsummering.tsx
@@ -170,15 +170,15 @@ const DinLivssituasjonOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
                                 <SpråkTekst
                                     id={
                                         dinLivssituasjonSpørsmålSpråkId[
-                                            søknad.søker.harSamboerNå.id
+                                            søknad.søker.utvidet.spørsmål.harSamboerNå.id
                                         ]
                                     }
                                 />
                             }
-                            søknadsvar={søknad.søker.harSamboerNå.svar}
+                            søknadsvar={søknad.søker.utvidet.spørsmål.harSamboerNå.svar}
                         />
-                        {søknad.søker.nåværendeSamboer && (
-                            <SamboerOppsummering samboer={søknad.søker.nåværendeSamboer} />
+                        {søknad.søker.utvidet.nåværendeSamboer && (
+                            <SamboerOppsummering samboer={søknad.søker.utvidet.nåværendeSamboer} />
                         )}
                     </StyledOppsummeringsFeltGruppe>
 

--- a/src/frontend/context/AppContext.ts
+++ b/src/frontend/context/AppContext.ts
@@ -103,12 +103,18 @@ const [AppProvider, useApp] = createUseContext(() => {
                             adresse: ressurs.data.adresse,
                             sivilstand: ressurs.data.sivilstand,
                             adressebeskyttelse: ressurs.data.adressebeskyttelse,
-                            harSamboerNå: {
-                                ...søknad.søker.harSamboerNå,
-                                id:
-                                    ressurs.data.sivilstand.type === ESivilstand.GIFT
-                                        ? DinLivssituasjonSpørsmålId.harSamboerNåGift
-                                        : DinLivssituasjonSpørsmålId.harSamboerNå,
+                            utvidet: {
+                                ...søknad.søker.utvidet,
+                                spørsmål: {
+                                    ...søknad.søker.utvidet.spørsmål,
+                                    harSamboerNå: {
+                                        ...søknad.søker.utvidet.spørsmål.harSamboerNå,
+                                        id:
+                                            ressurs.data.sivilstand.type === ESivilstand.GIFT
+                                                ? DinLivssituasjonSpørsmålId.harSamboerNåGift
+                                                : DinLivssituasjonSpørsmålId.harSamboerNå,
+                                    },
+                                },
                             },
                         },
                     });
@@ -190,12 +196,18 @@ const [AppProvider, useApp] = createUseContext(() => {
                 adresse: søker.adresse,
                 sivilstand: søker.sivilstand,
                 adressebeskyttelse: søker.adressebeskyttelse,
-                harSamboerNå: {
-                    id:
-                        søker.sivilstand.type === ESivilstand.GIFT
-                            ? DinLivssituasjonSpørsmålId.harSamboerNåGift
-                            : DinLivssituasjonSpørsmålId.harSamboerNå,
-                    svar: null,
+                utvidet: {
+                    ...søker.utvidet,
+                    spørsmål: {
+                        ...søker.utvidet.spørsmål,
+                        harSamboerNå: {
+                            id:
+                                søker.sivilstand.type === ESivilstand.GIFT
+                                    ? DinLivssituasjonSpørsmålId.harSamboerNåGift
+                                    : DinLivssituasjonSpørsmålId.harSamboerNå,
+                            svar: null,
+                        },
+                    },
                 },
             },
         });

--- a/src/frontend/hooks/useSendInnSkjemaTest/test-data/testdata1.ts
+++ b/src/frontend/hooks/useSendInnSkjemaTest/test-data/testdata1.ts
@@ -325,11 +325,6 @@ export const testdata1: TilKontraktTestData = {
             pensjonsperioderNorge: [],
             pensjonsperioderUtland: [],
             andreUtbetalingsperioder: [],
-            harSamboerNå: {
-                id: 'har-samboer-nå-og-gift',
-                svar: 'NEI',
-            },
-            nåværendeSamboer: null,
             utvidet: {
                 spørsmål: {
                     årsak: {
@@ -348,8 +343,13 @@ export const testdata1: TilKontraktTestData = {
                         id: 'separert-enke-skilt-dato',
                         svar: '',
                     },
+                    harSamboerNå: {
+                        id: 'har-samboer-nå-og-gift',
+                        svar: 'NEI',
+                    },
                 },
                 tidligereSamboere: [],
+                nåværendeSamboer: null,
             },
         },
         erNoenAvBarnaFosterbarn: {

--- a/src/frontend/hooks/useSendInnSkjemaTest/test-data/testdata2.ts
+++ b/src/frontend/hooks/useSendInnSkjemaTest/test-data/testdata2.ts
@@ -527,28 +527,6 @@ export const testdata2: TilKontraktTestData = {
                     },
                 },
             ],
-            harSamboerNå: {
-                id: 'har-samboer-nå-og-gift',
-                svar: 'JA',
-            },
-            nåværendeSamboer: {
-                navn: {
-                    id: 'utvidet-nåværende-samboer-navn',
-                    svar: 'asdasfafsasdasdas',
-                },
-                ident: {
-                    id: 'utvidet-nåværende-samboer-fnr',
-                    svar: '05039103410',
-                },
-                fødselsdato: {
-                    id: 'utvidet-nåværende-samboer-fødselsdato',
-                    svar: '',
-                },
-                samboerFraDato: {
-                    id: 'utvidet-nåværende-samboer-samboerFraDato',
-                    svar: '2022-01-01',
-                },
-            },
             utvidet: {
                 spørsmål: {
                     årsak: {
@@ -567,8 +545,30 @@ export const testdata2: TilKontraktTestData = {
                         id: 'separert-enke-skilt-dato',
                         svar: '',
                     },
+                    harSamboerNå: {
+                        id: 'har-samboer-nå-og-gift',
+                        svar: 'JA',
+                    },
                 },
                 tidligereSamboere: [],
+                nåværendeSamboer: {
+                    navn: {
+                        id: 'utvidet-nåværende-samboer-navn',
+                        svar: 'asdasfafsasdasdas',
+                    },
+                    ident: {
+                        id: 'utvidet-nåværende-samboer-fnr',
+                        svar: '05039103410',
+                    },
+                    fødselsdato: {
+                        id: 'utvidet-nåværende-samboer-fødselsdato',
+                        svar: '',
+                    },
+                    samboerFraDato: {
+                        id: 'utvidet-nåværende-samboer-samboerFraDato',
+                        svar: '2022-01-01',
+                    },
+                },
             },
         },
         erNoenAvBarnaFosterbarn: {
@@ -1017,14 +1017,6 @@ export const testdata2: TilKontraktTestData = {
                     },
                     verdi: { nb: 'JA', nn: 'JA', en: 'JA' },
                 },
-                harSamboerNå: {
-                    label: {
-                        en: 'Are you currently living with a cohabiting partner that is not your spouse?',
-                        nb: 'Har du en annen samboer enn din ektefelle nå?',
-                        nn: 'Har du ein anna sambuar enn din ektefelle no?',
-                    },
-                    verdi: { nb: 'JA', nn: 'JA', en: 'JA' },
-                },
                 arbeidsland: {
                     label: { en: 'ukjent-spørsmål', nb: 'ukjent-spørsmål', nn: 'ukjent-spørsmål' },
                     verdi: { nb: 'Belgia', nn: 'Belgia', en: 'Belgium' },
@@ -1032,6 +1024,14 @@ export const testdata2: TilKontraktTestData = {
                 pensjonsland: {
                     label: { en: 'ukjent-spørsmål', nb: 'ukjent-spørsmål', nn: 'ukjent-spørsmål' },
                     verdi: { nb: 'Belgia', nn: 'Belgia', en: 'Belgium' },
+                },
+                harSamboerNå: {
+                    label: {
+                        en: 'Are you currently living with a cohabiting partner that is not your spouse?',
+                        nb: 'Har du en annen samboer enn din ektefelle nå?',
+                        nn: 'Har du ein anna sambuar enn din ektefelle no?',
+                    },
+                    verdi: { nb: 'JA', nn: 'JA', en: 'JA' },
                 },
             },
             tidligereSamboere: [],

--- a/src/frontend/hooks/useSendInnSkjemaTest/test-data/testdata3.ts
+++ b/src/frontend/hooks/useSendInnSkjemaTest/test-data/testdata3.ts
@@ -502,28 +502,6 @@ export const testdata3: TilKontraktTestData = {
             pensjonsperioderNorge: [],
             pensjonsperioderUtland: [],
             andreUtbetalingsperioder: [],
-            harSamboerNå: {
-                id: 'har-samboer-nå-og-gift',
-                svar: 'JA',
-            },
-            nåværendeSamboer: {
-                navn: {
-                    id: 'utvidet-nåværende-samboer-navn',
-                    svar: 'asdasfafsasdasdas',
-                },
-                ident: {
-                    id: 'utvidet-nåværende-samboer-fnr',
-                    svar: 'UKJENT',
-                },
-                fødselsdato: {
-                    id: 'utvidet-nåværende-samboer-fødselsdato',
-                    svar: 'UKJENT',
-                },
-                samboerFraDato: {
-                    id: 'utvidet-nåværende-samboer-samboerFraDato',
-                    svar: '2022-01-01',
-                },
-            },
             utvidet: {
                 spørsmål: {
                     årsak: {
@@ -542,8 +520,30 @@ export const testdata3: TilKontraktTestData = {
                         id: 'separert-enke-skilt-dato',
                         svar: '',
                     },
+                    harSamboerNå: {
+                        id: 'har-samboer-nå-og-gift',
+                        svar: 'JA',
+                    },
                 },
                 tidligereSamboere: [],
+                nåværendeSamboer: {
+                    navn: {
+                        id: 'utvidet-nåværende-samboer-navn',
+                        svar: 'asdasfafsasdasdas',
+                    },
+                    ident: {
+                        id: 'utvidet-nåværende-samboer-fnr',
+                        svar: 'UKJENT',
+                    },
+                    fødselsdato: {
+                        id: 'utvidet-nåværende-samboer-fødselsdato',
+                        svar: 'UKJENT',
+                    },
+                    samboerFraDato: {
+                        id: 'utvidet-nåværende-samboer-samboerFraDato',
+                        svar: '2022-01-01',
+                    },
+                },
             },
         },
         erNoenAvBarnaFosterbarn: {
@@ -992,14 +992,6 @@ export const testdata3: TilKontraktTestData = {
                     },
                     verdi: { nb: 'JA', nn: 'JA', en: 'JA' },
                 },
-                harSamboerNå: {
-                    label: {
-                        en: 'Are you currently living with a cohabiting partner that is not your spouse?',
-                        nb: 'Har du en annen samboer enn din ektefelle nå?',
-                        nn: 'Har du ein anna sambuar enn din ektefelle no?',
-                    },
-                    verdi: { nb: 'JA', nn: 'JA', en: 'JA' },
-                },
                 arbeidsland: {
                     label: { en: 'ukjent-spørsmål', nb: 'ukjent-spørsmål', nn: 'ukjent-spørsmål' },
                     verdi: { nb: 'Brunei', nn: 'Brunei', en: 'Brunei Darussalam' },
@@ -1007,6 +999,14 @@ export const testdata3: TilKontraktTestData = {
                 pensjonsland: {
                     label: { en: 'ukjent-spørsmål', nb: 'ukjent-spørsmål', nn: 'ukjent-spørsmål' },
                     verdi: { nb: 'Bahamas', nn: 'Bahamas', en: 'Bahamas' },
+                },
+                harSamboerNå: {
+                    label: {
+                        en: 'Are you currently living with a cohabiting partner that is not your spouse?',
+                        nb: 'Har du en annen samboer enn din ektefelle nå?',
+                        nn: 'Har du ein anna sambuar enn din ektefelle no?',
+                    },
+                    verdi: { nb: 'JA', nn: 'JA', en: 'JA' },
                 },
             },
             tidligereSamboere: [],

--- a/src/frontend/hooks/useSendInnSkjemaTest/test-data/testdata4.ts
+++ b/src/frontend/hooks/useSendInnSkjemaTest/test-data/testdata4.ts
@@ -431,28 +431,6 @@ export const testdata4: TilKontraktTestData = {
             pensjonsperioderNorge: [],
             pensjonsperioderUtland: [],
             andreUtbetalingsperioder: [],
-            harSamboerNå: {
-                id: 'har-samboer-nå-og-gift',
-                svar: 'JA',
-            },
-            nåværendeSamboer: {
-                navn: {
-                    id: 'utvidet-nåværende-samboer-navn',
-                    svar: 'twethsetjdtykdrtsh',
-                },
-                ident: {
-                    id: 'utvidet-nåværende-samboer-fnr',
-                    svar: 'UKJENT',
-                },
-                fødselsdato: {
-                    id: 'utvidet-nåværende-samboer-fødselsdato',
-                    svar: '1997-01-09',
-                },
-                samboerFraDato: {
-                    id: 'utvidet-nåværende-samboer-samboerFraDato',
-                    svar: '2022-01-06',
-                },
-            },
             utvidet: {
                 spørsmål: {
                     årsak: {
@@ -470,6 +448,10 @@ export const testdata4: TilKontraktTestData = {
                     separertEnkeSkiltDato: {
                         id: 'separert-enke-skilt-dato',
                         svar: '2022-01-01',
+                    },
+                    harSamboerNå: {
+                        id: 'har-samboer-nå-og-gift',
+                        svar: 'JA',
                     },
                 },
                 tidligereSamboere: [
@@ -496,6 +478,24 @@ export const testdata4: TilKontraktTestData = {
                         },
                     },
                 ],
+                nåværendeSamboer: {
+                    navn: {
+                        id: 'utvidet-nåværende-samboer-navn',
+                        svar: 'twethsetjdtykdrtsh',
+                    },
+                    ident: {
+                        id: 'utvidet-nåværende-samboer-fnr',
+                        svar: 'UKJENT',
+                    },
+                    fødselsdato: {
+                        id: 'utvidet-nåværende-samboer-fødselsdato',
+                        svar: '1997-01-09',
+                    },
+                    samboerFraDato: {
+                        id: 'utvidet-nåværende-samboer-samboerFraDato',
+                        svar: '2022-01-06',
+                    },
+                },
             },
         },
         erNoenAvBarnaFosterbarn: {
@@ -697,14 +697,6 @@ export const testdata4: TilKontraktTestData = {
                     },
                     verdi: { nb: 'JA', nn: 'JA', en: 'JA' },
                 },
-                harSamboerNå: {
-                    label: {
-                        en: 'Are you currently living with a cohabiting partner that is not your spouse?',
-                        nb: 'Har du en annen samboer enn din ektefelle nå?',
-                        nn: 'Har du ein anna sambuar enn din ektefelle no?',
-                    },
-                    verdi: { nb: 'JA', nn: 'JA', en: 'JA' },
-                },
                 arbeidsland: {
                     label: { en: 'ukjent-spørsmål', nb: 'ukjent-spørsmål', nn: 'ukjent-spørsmål' },
                     verdi: { nb: 'Argentina', nn: 'Argentina', en: 'Argentina' },
@@ -744,6 +736,14 @@ export const testdata4: TilKontraktTestData = {
                         nn: 'Frå kva dato er du separert, skilt eller enke/enkemann?',
                     },
                     verdi: { nb: '2022-01-01', nn: '2022-01-01', en: '2022-01-01' },
+                },
+                harSamboerNå: {
+                    label: {
+                        en: 'Are you currently living with a cohabiting partner that is not your spouse?',
+                        nb: 'Har du en annen samboer enn din ektefelle nå?',
+                        nn: 'Har du ein anna sambuar enn din ektefelle no?',
+                    },
+                    verdi: { nb: 'JA', nn: 'JA', en: 'JA' },
                 },
             },
             tidligereSamboere: [

--- a/src/frontend/hooks/useSendInnSkjemaTest/test-data/testdata5.ts
+++ b/src/frontend/hooks/useSendInnSkjemaTest/test-data/testdata5.ts
@@ -517,11 +517,6 @@ export const testdata5: TilKontraktTestData = {
             pensjonsperioderNorge: [],
             pensjonsperioderUtland: [],
             andreUtbetalingsperioder: [],
-            harSamboerNå: {
-                id: 'har-samboer-nå-og-gift',
-                svar: 'NEI',
-            },
-            nåværendeSamboer: null,
             utvidet: {
                 spørsmål: {
                     årsak: {
@@ -539,6 +534,10 @@ export const testdata5: TilKontraktTestData = {
                     separertEnkeSkiltDato: {
                         id: 'separert-enke-skilt-dato',
                         svar: '',
+                    },
+                    harSamboerNå: {
+                        id: 'har-samboer-nå-og-gift',
+                        svar: 'NEI',
                     },
                 },
                 tidligereSamboere: [
@@ -565,6 +564,7 @@ export const testdata5: TilKontraktTestData = {
                         },
                     },
                 ],
+                nåværendeSamboer: null,
             },
         },
         erNoenAvBarnaFosterbarn: {
@@ -702,14 +702,6 @@ export const testdata5: TilKontraktTestData = {
                     },
                     verdi: { nb: 'JA', nn: 'JA', en: 'JA' },
                 },
-                harSamboerNå: {
-                    label: {
-                        en: 'Are you currently living with a cohabiting partner that is not your spouse?',
-                        nb: 'Har du en annen samboer enn din ektefelle nå?',
-                        nn: 'Har du ein anna sambuar enn din ektefelle no?',
-                    },
-                    verdi: { nb: 'NEI', nn: 'NEI', en: 'NEI' },
-                },
                 pensjonsland: {
                     label: { en: 'ukjent-spørsmål', nb: 'ukjent-spørsmål', nn: 'ukjent-spørsmål' },
                     verdi: { nb: 'Benin', nn: 'Benin', en: 'Benin' },
@@ -731,6 +723,14 @@ export const testdata5: TilKontraktTestData = {
                         en: 'Are you separated or divorced without this having been registered in the Norwegian National Registry (folkeregisteret)?',
                         nb: 'Er du separert, skilt eller enke/enkemann uten at dette er registrert i folkeregisteret i Norge?',
                         nn: 'Er du separert, skilt eller enke/enkemann utan at dette er registrert i folkeregisteret i Noreg?',
+                    },
+                    verdi: { nb: 'NEI', nn: 'NEI', en: 'NEI' },
+                },
+                harSamboerNå: {
+                    label: {
+                        en: 'Are you currently living with a cohabiting partner that is not your spouse?',
+                        nb: 'Har du en annen samboer enn din ektefelle nå?',
+                        nn: 'Har du ein anna sambuar enn din ektefelle no?',
                     },
                     verdi: { nb: 'NEI', nn: 'NEI', en: 'NEI' },
                 },

--- a/src/frontend/typer/person.ts
+++ b/src/frontend/typer/person.ts
@@ -59,8 +59,6 @@ export interface ISøker extends Omit<ISøkerRespons, 'barn'> {
     arbeidsperioderUtland: IArbeidsperiode[];
     mottarUtenlandspensjon: ISøknadSpørsmål<ESvar | null>;
     pensjonsperioderUtland: IPensjonsperiode[];
-    harSamboerNå: ISøknadSpørsmål<ESvar | null>;
-    nåværendeSamboer: ISamboer | null;
 
     // Steg: EØS-steg
     arbeidINorge: ISøknadSpørsmål<ESvar | null>;
@@ -78,8 +76,10 @@ export interface ISøker extends Omit<ISøkerRespons, 'barn'> {
             separertEnkeSkilt: ISøknadSpørsmål<ESvar | null>;
             separertEnkeSkiltUtland: ISøknadSpørsmål<ESvar | null>;
             separertEnkeSkiltDato: ISøknadSpørsmål<ISODateString>;
+            harSamboerNå: ISøknadSpørsmål<ESvar | null>;
         };
         tidligereSamboere: ITidligereSamboer[];
+        nåværendeSamboer: ISamboer | null;
     };
 }
 

--- a/src/frontend/typer/søknad.ts
+++ b/src/frontend/typer/søknad.ts
@@ -159,11 +159,6 @@ export const initialStateSøknad = (kombinerSøknaderToggle: boolean = false): I
                 svar: null,
             },
             andreUtbetalingsperioder: [],
-            harSamboerNå: {
-                id: DinLivssituasjonSpørsmålId.harSamboerNå,
-                svar: null,
-            },
-            nåværendeSamboer: null,
             adresseISøkeperiode: { id: EøsSøkerSpørsmålId.adresseISøkeperiode, svar: '' },
             idNummer: [],
             utvidet: {
@@ -184,8 +179,13 @@ export const initialStateSøknad = (kombinerSøknaderToggle: boolean = false): I
                         id: DinLivssituasjonSpørsmålId.separertEnkeSkiltDato,
                         svar: '',
                     },
+                    harSamboerNå: {
+                        id: DinLivssituasjonSpørsmålId.harSamboerNå,
+                        svar: null,
+                    },
                 },
                 tidligereSamboere: [],
+                nåværendeSamboer: null,
             },
         },
         erNoenAvBarnaFosterbarn: {

--- a/src/frontend/utils/mappingTilKontrakt/søknadV8.ts
+++ b/src/frontend/utils/mappingTilKontrakt/søknadV8.ts
@@ -66,7 +66,6 @@ export const dataISøknadKontraktFormatV8 = (
         barn,
         utvidet,
         adressebeskyttelse,
-        nåværendeSamboer,
         utenlandsperioder,
         // Nye felter under utvikling av EØS full
         andreUtbetalingsperioder,
@@ -79,7 +78,7 @@ export const dataISøknadKontraktFormatV8 = (
         // resterende felter, hvor alle må være av type ISøknadSpørsmål
         ...søkerSpørsmål
     } = søker;
-    const { spørsmål: utvidaSpørsmål, tidligereSamboere } = utvidet;
+    const { spørsmål: utvidaSpørsmål, tidligereSamboere, nåværendeSamboer } = utvidet;
     const { barnInkludertISøknaden } = søknad;
     const typetSøkerSpørsmål: ISøknadSpørsmålMap = søkerSpørsmål as unknown as ISøknadSpørsmålMap;
     const typetUtvidaSpørsmål: ISøknadSpørsmålMap = utvidaSpørsmål as unknown as ISøknadSpørsmålMap;

--- a/src/frontend/utils/testing.tsx
+++ b/src/frontend/utils/testing.tsx
@@ -263,21 +263,27 @@ export const mekkGyldigSøker = (): ISøker => {
     return {
         ...initialStateSøknad(false).søker,
         sivilstand: { type: ESivilstand.UGIFT },
-        harSamboerNå: { id: DinLivssituasjonSpørsmålId.harSamboerNå, svar: ESvar.JA },
         utenlandsperioder: [],
-        nåværendeSamboer: {
-            navn: { id: SamboerSpørsmålId.nåværendeSamboerNavn, svar: 'Gunnar' },
-            ident: {
-                id: SamboerSpørsmålId.nåværendeSamboerFnr,
-                svar: AlternativtSvarForInput.UKJENT,
+        utvidet: {
+            ...initialStateSøknad(false).søker.utvidet,
+            spørsmål: {
+                ...initialStateSøknad(false).søker.utvidet.spørsmål,
+                harSamboerNå: { id: DinLivssituasjonSpørsmålId.harSamboerNå, svar: ESvar.JA },
             },
-            fødselsdato: {
-                id: SamboerSpørsmålId.nåværendeSamboerFødselsdato,
-                svar: AlternativtSvarForInput.UKJENT,
-            },
-            samboerFraDato: {
-                id: SamboerSpørsmålId.nåværendeSamboerFraDato,
-                svar: '2021-08-11',
+            nåværendeSamboer: {
+                navn: { id: SamboerSpørsmålId.nåværendeSamboerNavn, svar: 'Gunnar' },
+                ident: {
+                    id: SamboerSpørsmålId.nåværendeSamboerFnr,
+                    svar: AlternativtSvarForInput.UKJENT,
+                },
+                fødselsdato: {
+                    id: SamboerSpørsmålId.nåværendeSamboerFødselsdato,
+                    svar: AlternativtSvarForInput.UKJENT,
+                },
+                samboerFraDato: {
+                    id: SamboerSpørsmålId.nåværendeSamboerFraDato,
+                    svar: '2021-08-11',
+                },
             },
         },
         borPåRegistrertAdresse: {
@@ -463,6 +469,10 @@ export const mekkGyldigUtvidetSøknad = (): ISøknad => {
                         id: DinLivssituasjonSpørsmålId.separertEnkeSkiltDato,
                         svar: '2021-09-09',
                     },
+                    harSamboerNå: {
+                        id: DinLivssituasjonSpørsmålId.harSamboerNå,
+                        svar: ESvar.NEI,
+                    },
                 },
                 tidligereSamboere: [
                     {
@@ -488,6 +498,7 @@ export const mekkGyldigUtvidetSøknad = (): ISøknad => {
                         },
                     },
                 ],
+                nåværendeSamboer: null,
             },
         },
         barnInkludertISøknaden: base.barnInkludertISøknaden.map(barn => ({

--- a/src/shared-utils/modellversjon.ts
+++ b/src/shared-utils/modellversjon.ts
@@ -1,6 +1,6 @@
 import { ApiRessurs, RessursStatus } from '@navikt/familie-typer';
 
-export const modellVersjon = 49;
+export const modellVersjon = 50;
 
 export const modellVersjonHeaderName = 'Soknad-Modell-Versjon';
 


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fjerne spørsmål om samboer dersom man søker ordinær barnetrygd.

Har fjernet spørsmålet fra steget "Livssituasjonen din" og satt skjemafeltet til "skjult" dersom søknadstype er ordinær for å hindre validering på feltet i skjema-hooket.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Før:
![image](https://github.com/navikt/familie-ba-soknad/assets/70642183/6dc60c9a-5696-4409-90ae-501de2a1c1ed)

Etter:
![image](https://github.com/navikt/familie-ba-soknad/assets/70642183/786341cb-19da-4b5b-8801-afdfd97abe7f)
