### PR TITLE
Bruker samme heading på alle sider uavhengig av søknadstypen

### DIFF
--- a/src/frontend/components/Felleskomponenter/Banner/Banner.tsx
+++ b/src/frontend/components/Felleskomponenter/Banner/Banner.tsx
@@ -5,6 +5,9 @@ import styled from 'styled-components';
 import { Heading } from '@navikt/ds-react';
 import { APurple200, APurple400 } from '@navikt/ds-tokens/dist/tokens';
 
+import { useApp } from '../../../context/AppContext';
+import { useFeatureToggles } from '../../../context/FeatureToggleContext';
+import { ESanitySteg } from '../../../typer/sanity/sanity';
 import SpråkTekst from '../SpråkTekst/SpråkTekst';
 
 const Section = styled.section`
@@ -18,10 +21,16 @@ const Section = styled.section`
 `;
 
 const Banner: React.FC<{ språkTekstId: string }> = ({ språkTekstId }) => {
+    const { toggles } = useFeatureToggles();
+    const { tekster, plainTekst } = useApp();
     return (
         <Section>
             <Heading size="large">
-                <SpråkTekst id={språkTekstId} />
+                {toggles.KOMBINER_SOKNADER ? (
+                    plainTekst(tekster()[ESanitySteg.FORSIDE].soeknadstittelBarnetrygd)
+                ) : (
+                    <SpråkTekst id={språkTekstId} />
+                )}
             </Heading>
         </Section>
     );


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Tidligere hadde vi ulik heading avhengig av om man søkte utvidet eller ordinær. Nå får man samme heading uansett.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**


### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  