### PR TITLE
Legg alltid til dokumentasjonsbeskrivelse for utvidet, den filtreres bort ved behov

### DIFF
--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg.tsx
@@ -85,7 +85,7 @@ const LastOppVedlegg: React.FC<Props> = ({ dokumentasjon, vedleggNr, oppdaterDok
         <SpråkTekst id={dokumentasjon.tittelSpråkId} values={{ barn: formatertListeMedBarn() }} />
     );
 
-    const skalViseAnnenDokumentasjonsBeskrivelse = () => {
+    const skalViseDokumentasjonsBeskrivelse = () => {
         return (
             dokumentasjon.dokumentasjonsbehov !== Dokumentasjonsbehov.ANNEN_DOKUMENTASJON ||
             (søknad.søknadstype === ESøknadstype.UTVIDET &&
@@ -110,7 +110,7 @@ const LastOppVedlegg: React.FC<Props> = ({ dokumentasjon, vedleggNr, oppdaterDok
                 )}
                 {dokTittel}
             </Heading>
-            {dokumentasjon.beskrivelseSpråkId && skalViseAnnenDokumentasjonsBeskrivelse() && (
+            {dokumentasjon.beskrivelseSpråkId && skalViseDokumentasjonsBeskrivelse() && (
                 <>
                     <SpråkTekst
                         id={dokumentasjon.beskrivelseSpråkId}

--- a/src/frontend/typer/søknad.ts
+++ b/src/frontend/typer/søknad.ts
@@ -95,9 +95,7 @@ export const initialStateSøknad = (kombinerSøknaderToggle: boolean = false): I
             genererInitiellDokumentasjon(
                 Dokumentasjonsbehov.ANNEN_DOKUMENTASJON,
                 dokumentasjonsbehovTilSpråkId(Dokumentasjonsbehov.ANNEN_DOKUMENTASJON),
-                !kombinerSøknaderToggle && hentSøknadstype() === ESøknadstype.UTVIDET
-                    ? 'dokumentasjon.annendokumentasjon.utvidet.informasjon'
-                    : null
+                'dokumentasjon.annendokumentasjon.utvidet.informasjon'
             ),
         ],
         søker: {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Favro: [vi har kombinert søknad for utvidet og ordinær](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18565)

Tidligere la vi til dokumentasjonsbeskrivelse for utvidet i dokumentasjonsbehovet dersom `/utvidet` var i URLen. Men nå som vi har kombinert søknads-URL-ene har vi ikke lengre tilgang på søknadstype der vi oppretter initielt objekt for dokumentasjonsbehov. Etter å ha sett litt på logikken ser vi at vi senere i flyten, i `LastOppVedlegg.tsx`, der vi rendrer ut dokumentasjonsbehovene, filtrerer vekk dokumentasjon for utvidet dersom brukeren søker ordinær. Dermed kan vi trygt legge til dokumentasjonsbehovet for utvidet i det initielle dokumentasjonsbehovobjektet

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
