### PR TITLE
Fjerner alle info tegn ved hjelpetekster i spørsmål

### DIFF
--- a/src/frontend/components/SøknadsSteg/OmBarnaDine/OmBarnaDine.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnaDine/OmBarnaDine.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { useNavigate } from 'react-router-dom';
 
-import { Alert } from '@navikt/ds-react';
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { useApp } from '../../../context/AppContext';
@@ -72,11 +71,7 @@ const OmBarnaDine: React.FC = () => {
                             OmBarnaDineSpørsmålId.oppholderBarnSegIInstitusjon
                         ]
                     }
-                    tilleggsinfo={
-                        <Alert variant={'info'} inline>
-                            <SpråkTekst id={'ombarna.institusjon.info'} />
-                        </Alert>
-                    }
+                    tilleggsinfoTekstId={'ombarna.institusjon.info'}
                 />
 
                 <HvilkeBarnCheckboxGruppe
@@ -104,11 +99,7 @@ const OmBarnaDine: React.FC = () => {
                                 OmBarnaDineSpørsmålId.erBarnAdoptertFraUtland
                             ]
                         }
-                        tilleggsinfo={
-                            <Alert variant={'info'} inline>
-                                <SpråkTekst id={'ombarna.adoptert.info'} />
-                            </Alert>
-                        }
+                        tilleggsinfoTekstId={'ombarna.adoptert.info'}
                     />
                     <HvilkeBarnCheckboxGruppe
                         legendSpråkId={
@@ -165,11 +156,7 @@ const OmBarnaDine: React.FC = () => {
                                 OmBarnaDineSpørsmålId.barnOppholdtSegTolvMndSammenhengendeINorge
                             ]
                         }
-                        tilleggsinfo={
-                            <Alert variant={'info'} inline>
-                                <SpråkTekst id={'felles.korteopphold.info'} />
-                            </Alert>
-                        }
+                        tilleggsinfoTekstId={'felles.korteopphold.info'}
                     />
                     <HvilkeBarnCheckboxGruppe
                         legendSpråkId={

--- a/src/frontend/components/SøknadsSteg/OmDeg/OmDeg.test.tsx
+++ b/src/frontend/components/SøknadsSteg/OmDeg/OmDeg.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { mockDeep } from 'jest-mock-extended';
 
 import { ESvar } from '@navikt/familie-form-elements';
@@ -46,11 +46,11 @@ describe('OmDeg', () => {
         spyOnUseApp({ søker: søkerMedSvarSomViserAlleTekster });
         søkerMedSvarSomViserAlleTekster.adresse = null;
         søkerMedSvarSomViserAlleTekster.adressebeskyttelse = false;
-        const { findAllByTestId } = render(<TestKomponentMedEkteTekster />);
+        render(<TestKomponentMedEkteTekster />);
 
-        // Vent på effect i AppContext så vi ikke får advarsel om act
-        await findAllByTestId(/alertstripe/);
-        expect(console.error).toHaveBeenCalledTimes(0);
+        await waitFor(() => {
+            expect(console.error).toHaveBeenCalledTimes(0);
+        });
     });
 
     test('Alle tekster finnes når man svarer at man ikke bor på registrert adresse', () => {
@@ -104,16 +104,16 @@ describe('OmDeg', () => {
                 statsborgerskap: [{ landkode: 'NOR' }],
             }),
         });
-        const { queryByText, findAllByTestId } = render(<TestKomponent />);
-        // Lar async useEffect i AppContext bli ferdig
-        await findAllByTestId('alertstripe');
+        const { queryByText } = render(<TestKomponent />);
 
-        expect(
-            queryByText(omDegSpørsmålSpråkId[OmDegSpørsmålId.borPåRegistrertAdresse])
-        ).not.toBeInTheDocument();
-        expect(
-            queryByText(omDegSpørsmålSpråkId[OmDegSpørsmålId.værtINorgeITolvMåneder])
-        ).toBeInTheDocument();
+        await waitFor(() => {
+            expect(
+                queryByText(omDegSpørsmålSpråkId[OmDegSpørsmålId.borPåRegistrertAdresse])
+            ).not.toBeInTheDocument();
+            expect(
+                queryByText(omDegSpørsmålSpråkId[OmDegSpørsmålId.værtINorgeITolvMåneder])
+            ).toBeInTheDocument();
+        });
     });
 
     test('Søker med adresse får opp to spørsmål med en gang', async () => {
@@ -140,16 +140,16 @@ describe('OmDeg', () => {
                 statsborgerskap: [{ landkode: 'NOR' }],
             }),
         });
-        const { queryByText, findAllByTestId } = render(<TestKomponent />);
-        // Lar async useEffect i AppContext bli ferdig
-        await findAllByTestId('alertstripe');
+        const { queryByText } = render(<TestKomponent />);
 
-        expect(
-            queryByText(omDegSpørsmålSpråkId[OmDegSpørsmålId.borPåRegistrertAdresse])
-        ).not.toBeInTheDocument();
+        await waitFor(() => {
+            expect(
+                queryByText(omDegSpørsmålSpråkId[OmDegSpørsmålId.borPåRegistrertAdresse])
+            ).not.toBeInTheDocument();
 
-        expect(
-            queryByText(omDegSpørsmålSpråkId['søker-vært-i-norge-sammenhengende-tolv-måneder'])
-        ).toBeInTheDocument();
+            expect(
+                queryByText(omDegSpørsmålSpråkId['søker-vært-i-norge-sammenhengende-tolv-måneder'])
+            ).toBeInTheDocument();
+        });
     });
 });

--- a/src/frontend/components/SøknadsSteg/OmDeg/OmDeg.tsx
+++ b/src/frontend/components/SøknadsSteg/OmDeg/OmDeg.tsx
@@ -84,11 +84,7 @@ const OmDeg: React.FC = () => {
                         spørsmålTekstId={
                             omDegSpørsmålSpråkId[OmDegSpørsmålId.værtINorgeITolvMåneder]
                         }
-                        tilleggsinfo={
-                            <Alert variant={'info'} inline data-testid={'alertstripe'}>
-                                <SpråkTekst id={'felles.korteopphold.info'} />
-                            </Alert>
-                        }
+                        tilleggsinfoTekstId={'felles.korteopphold.info'}
                     />
                     {skjema.felter.værtINorgeITolvMåneder.verdi === ESvar.NEI && (
                         <PerioderContainer>


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18710

### 💰 Hva forsøker du å løse i denne PR'en
- Bytter ut Alert komponent som tilleggsinfo for JaNeiSpm med tekstId for å fjerne info-ikon forran hjelpetekst.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Jeg har ikke skrevet tester, men endrer tester for `omDeg.test.tsx` ettersom 'alertstripe' ikke lengre tas i bruk.

### 🤷‍♀ ️Hvor er det lurt å starte?
- Gjør applikasjonen og se på hjelpetekstene under spørsmål i "Om deg" og "Barna dine".

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots

#### Før
![image](https://github.com/navikt/familie-ba-soknad/assets/89088327/6ad741e1-944c-40f3-9b05-8357455d2de6)

#### Etter
![image](https://github.com/navikt/familie-ba-soknad/assets/89088327/82673214-c785-463d-b00f-4be4cf97f335)