### PR TITLE
Fjerner custom CSS for dekoratøren sin footer, det setter feil bredde på footeren

### DIFF
--- a/src/frontend/Theme.ts
+++ b/src/frontend/Theme.ts
@@ -51,9 +51,4 @@ export const GlobalStyle = createGlobalStyle`
       padding-bottom: 12.75rem;
     }
   }
-
-  footer {
-    position: absolute;
-    bottom: 0;
-  }
 `;

--- a/src/frontend/Theme.ts
+++ b/src/frontend/Theme.ts
@@ -37,18 +37,4 @@ export const GlobalStyle = createGlobalStyle`
   position: relative;
   min-height: 100vh;
 }
-
-  #familie-ba-soknad-content-wrapper {
-    padding-bottom: 5.5rem;
-  }
-  @media screen and (max-width: 950px) {
-    #familie-ba-soknad-content-wrapper {
-      padding-bottom: 6.875rem;
-    }
-  }
-  @media screen and (max-width: 768px) {
-    #familie-ba-soknad-content-wrapper {
-      padding-bottom: 12.75rem;
-    }
-  }
 `;


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fjerner custom CSS som tukler med CSSen til dekoratørens footer. 


### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [X] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
Fiks på det visuelle uttrykket som vises fra dekoratøren krever ikke tester.

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
  
### 👀 Screen shots
#### Footeren så før slik ut:

Desktop:
<img width="1900" alt="image" src="https://github.com/navikt/familie-ba-soknad/assets/3233286/5077e70c-3cfd-407e-9413-c807b6cce9b7">

Mobil:
<img width="552" alt="image" src="https://github.com/navikt/familie-ba-soknad/assets/3233286/842efae1-3673-4052-a74c-d9c420c32254">

#### Nå ser den slik ut:
Desktop:
<img width="1969" alt="image" src="https://github.com/navikt/familie-ba-soknad/assets/3233286/449b70a5-ba7f-47be-a501-f6b84370354d">

Mobil:
<img width="553" alt="image" src="https://github.com/navikt/familie-ba-soknad/assets/3233286/3704e751-9ee4-4098-b67f-5726fdb341d3">
