### PR TITLE
Gjør ident nullable for barn

### DIFF
--- a/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/Barnekort.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/Barnekort.tsx
@@ -69,9 +69,12 @@ const Barnekort: React.FC<IBarnekortProps> = ({
         manueltRegistrertBarn => manueltRegistrertBarn.id === barn.id
     );
 
-    const fødselsnummerTekst = !barn.adressebeskyttelse
-        ? formaterFnr(barn.ident)
-        : uppercaseFørsteBokstav(plainTekst(tekster()[ESanitySteg.FELLES].frittståendeOrd.skjult));
+    const fødselsnummerTekst =
+        !barn.adressebeskyttelse && barn.ident
+            ? formaterFnr(barn.ident)
+            : uppercaseFørsteBokstav(
+                  plainTekst(tekster()[ESanitySteg.FELLES].frittståendeOrd.skjult)
+              );
 
     return (
         <BarnekortContainer>

--- a/src/frontend/context/AppContext.ts
+++ b/src/frontend/context/AppContext.ts
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 
 import createUseContext from 'constate';
 import { Alpha3Code, getName } from 'i18n-iso-countries';
-import { useIntl } from 'react-intl';
 
 import {
     byggHenterRessurs,
@@ -35,7 +34,6 @@ import { useSpråk } from './SpråkContext';
 
 const [AppProvider, useApp] = createUseContext(() => {
     const { valgtLocale } = useSpråk();
-    const intl = useIntl();
     const { axiosRequest, lasterRessurser } = useLastRessurserContext();
     const { innloggetStatus } = useInnloggetContext();
     const [sluttbruker, settSluttbruker] = useState(byggTomRessurs<ISøkerRespons>());
@@ -94,7 +92,7 @@ const [AppProvider, useApp] = createUseContext(() => {
                             ...søknad.søker,
                             navn: ressurs.data.navn,
                             statsborgerskap: ressurs.data.statsborgerskap,
-                            barn: mapBarnResponsTilBarn(ressurs.data.barn, intl),
+                            barn: mapBarnResponsTilBarn(ressurs.data.barn),
                             ident: ressurs.data.ident,
                             adresse: ressurs.data.adresse,
                             sivilstand: ressurs.data.sivilstand,

--- a/src/frontend/context/AppContext.ts
+++ b/src/frontend/context/AppContext.ts
@@ -315,6 +315,14 @@ const [AppProvider, useApp] = createUseContext(() => {
 
     const plainTekst = plainTekstHof(flettefeltTilTekst, valgtLocale);
 
+    const tilRestLocaleRecord = (sanityTekst, flettefelter): Record<LocaleType, string> => {
+        return {
+            [LocaleType.en]: plainTekst(sanityTekst, flettefelter, LocaleType.en),
+            [LocaleType.nn]: plainTekst(sanityTekst, flettefelter, LocaleType.nn),
+            [LocaleType.nb]: plainTekst(sanityTekst, flettefelter, LocaleType.nb),
+        };
+    };
+
     return {
         axiosRequest,
         sluttbruker,
@@ -344,6 +352,7 @@ const [AppProvider, useApp] = createUseContext(() => {
         settEøsLand,
         tekster,
         plainTekst,
+        tilRestLocaleRecord,
         flettefeltTilTekst,
     };
 });

--- a/src/frontend/hooks/useSendInnSkjema.tsx
+++ b/src/frontend/hooks/useSendInnSkjema.tsx
@@ -16,10 +16,16 @@ export const useSendInnSkjema = (): {
     const { axiosRequest, søknad, settInnsendingStatus, settSisteModellVersjon } = useApp();
     const { soknadApiProxyUrl } = Miljø();
     const { valgtLocale } = useSpråk();
+    const { tekster, tilRestLocaleRecord } = useApp();
     const sendInnSkjemaV8 = async (): Promise<[boolean, ISøknadKontraktV8]> => {
         settInnsendingStatus({ status: RessursStatus.HENTER });
 
-        const formatert: ISøknadKontraktV8 = dataISøknadKontraktFormatV8(valgtLocale, søknad);
+        const formatert: ISøknadKontraktV8 = dataISøknadKontraktFormatV8(
+            valgtLocale,
+            søknad,
+            tekster(),
+            tilRestLocaleRecord
+        );
 
         const res = await sendInn<ISøknadKontraktV8>(
             formatert,

--- a/src/frontend/typer/kontrakt/generelle.ts
+++ b/src/frontend/typer/kontrakt/generelle.ts
@@ -1,4 +1,5 @@
 import { ISODateString, LocaleType } from '../common';
+import { FlettefeltVerdier, LocaleRecordBlock, LocaleRecordString } from '../sanity/sanity';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export type SpørsmålMap = Record<string, ISøknadsfelt<any>>;
@@ -12,6 +13,11 @@ export interface ISøknadsfelt<T> {
     label: Record<LocaleType, string>;
     verdi: Record<LocaleType, T>;
 }
+
+export type TilRestLocaleRecord = (
+    sanityTekst: LocaleRecordString | LocaleRecordBlock,
+    flettefelter?: FlettefeltVerdier
+) => Record<LocaleType, string>;
 
 export interface IKontraktTidligereSamboer extends IKontraktNåværendeSamboer {
     samboerTilDato: ISøknadsfelt<ISODateString>;

--- a/src/frontend/typer/person.ts
+++ b/src/frontend/typer/person.ts
@@ -13,30 +13,31 @@ import {
 import { ISøknadSpørsmål } from './spørsmål';
 import { Årsak } from './utvidet';
 
-export interface IPerson {
-    ident: string;
-    adressebeskyttelse: boolean;
-}
-
-export interface IBarnRespons extends IPerson {
+export interface IBarnRespons {
     navn: string | null;
     borMedSøker: boolean;
     fødselsdato: string | undefined;
+    ident?: string;
+    adressebeskyttelse: boolean;
 }
 
-export interface ISøkerRespons extends IPerson {
+export interface ISøkerRespons {
     navn: string;
     barn: IBarnRespons[];
     statsborgerskap: { landkode: Alpha3Code }[];
     adresse: IAdresse | null;
     sivilstand: { type: ESivilstand };
+    ident: string;
+    adressebeskyttelse: boolean;
 }
 
-export interface IBarn extends IPerson {
+export interface IBarn {
     id: BarnetsId;
     navn: string;
     borMedSøker: boolean | undefined;
     alder: string | null;
+    ident?: string;
+    adressebeskyttelse: boolean;
 }
 
 export interface IIdNummer {

--- a/src/frontend/utils/barn.ts
+++ b/src/frontend/utils/barn.ts
@@ -1,5 +1,4 @@
 import { Alpha3Code } from 'i18n-iso-countries';
-import { IntlShape } from 'react-intl';
 
 import { ESvar } from '@navikt/familie-form-elements';
 
@@ -12,8 +11,6 @@ import { tomString } from '../typer/common';
 import { IEøsBarnetrygdsperiode, IUtenlandsperiode } from '../typer/perioder';
 import { IBarn, IBarnRespons, IIdNummer } from '../typer/person';
 import { ISøknad } from '../typer/søknad';
-
-import { formaterFnr } from './visning';
 
 export const genererInitiellAndreForelder = (
     andreForelder: IAndreForelder | null,
@@ -255,10 +252,10 @@ export const hentUid = () => {
     });
 };
 
-export const mapBarnResponsTilBarn = (barn: IBarnRespons[], intl): IBarn[] => {
+export const mapBarnResponsTilBarn = (barn: IBarnRespons[]): IBarn[] => {
     return barn.map(barnRespons => ({
         id: hentUid(),
-        navn: barnetsNavnValue(barnRespons, intl),
+        navn: barnetsNavnValue(barnRespons),
         ident: barnRespons.ident,
         alder: barnRespons.fødselsdato ? hentAlder(barnRespons.fødselsdato) : null,
         borMedSøker: barnRespons.borMedSøker,
@@ -266,13 +263,8 @@ export const mapBarnResponsTilBarn = (barn: IBarnRespons[], intl): IBarn[] => {
     }));
 };
 
-export const barnetsNavnValue = (barn: IBarnRespons, intl: IntlShape): string => {
-    return barn.navn
-        ? barn.navn
-        : intl.formatMessage(
-              { id: 'felles.anonym.barn.fnr' },
-              { fødselsnummer: formaterFnr(barn.ident) }
-          );
+export const barnetsNavnValue = (barn: IBarnRespons): string => {
+    return barn.navn ? barn.navn : 'Barn';
 };
 
 export const skalSkjuleAndreForelderFelt = (barn: IBarnMedISøknad) => {

--- a/src/frontend/utils/mappingTilKontrakt/barnV8.ts
+++ b/src/frontend/utils/mappingTilKontrakt/barnV8.ts
@@ -8,10 +8,11 @@ import {
 } from '../../components/SøknadsSteg/OmBarnet/spørsmål';
 import { barnDataKeySpørsmål, IBarnMedISøknad } from '../../typer/barn';
 import { LocaleType } from '../../typer/common';
-import { ERegistrertBostedType } from '../../typer/kontrakt/generelle';
+import { ERegistrertBostedType, TilRestLocaleRecord } from '../../typer/kontrakt/generelle';
 import { ISøknadIKontraktBarnV8 } from '../../typer/kontrakt/v8';
 import { ISøker } from '../../typer/person';
 import { PersonType } from '../../typer/personType';
+import { ITekstinnhold } from '../../typer/sanity/tekstInnhold';
 import { ISøknadSpørsmålMap } from '../../typer/spørsmål';
 import { hentTekster } from '../språk';
 
@@ -31,7 +32,9 @@ import { utenlandsperiodeTilISøknadsfelt } from './utenlandsperiode';
 export const barnISøknadsFormatV8 = (
     barn: IBarnMedISøknad,
     søker: ISøker,
-    valgtSpråk: LocaleType
+    valgtSpråk: LocaleType,
+    tekster: ITekstinnhold,
+    tilRestLocaleRecord: TilRestLocaleRecord
 ): ISøknadIKontraktBarnV8 => {
     /* eslint-disable @typescript-eslint/no-unused-vars */
     const {
@@ -55,6 +58,7 @@ export const barnISøknadsFormatV8 = (
         ...barnSpørsmål
     } = barn;
     const typetBarnSpørsmål = barnSpørsmål as unknown as ISøknadSpørsmålMap;
+    const fellesTekster = tekster.FELLES;
 
     const registertBostedVerdi = (): ERegistrertBostedType => {
         /**
@@ -86,7 +90,9 @@ export const barnISøknadsFormatV8 = (
         navn: søknadsfeltBarn('pdf.barn.navn.label', sammeVerdiAlleSpråk(navn), barn),
         ident: søknadsfeltBarn(
             'pdf.barn.ident.label',
-            ident ? sammeVerdiAlleSpråk(ident) : hentTekster('pdf.barn.ikke-oppgitt'),
+            ident
+                ? sammeVerdiAlleSpråk(ident)
+                : tilRestLocaleRecord(fellesTekster.frittståendeOrd.skjult),
             barn
         ),
         registrertBostedType: søknadsfeltBarn(

--- a/src/frontend/utils/mappingTilKontrakt/søknadV8.ts
+++ b/src/frontend/utils/mappingTilKontrakt/søknadV8.ts
@@ -7,10 +7,11 @@ import {
 import { OmBarnaDineSpørsmålId } from '../../components/SøknadsSteg/OmBarnaDine/spørsmål';
 import { IBarnMedISøknad } from '../../typer/barn';
 import { LocaleType } from '../../typer/common';
-import { ESivilstand } from '../../typer/kontrakt/generelle';
+import { ESivilstand, TilRestLocaleRecord } from '../../typer/kontrakt/generelle';
 import { ISøknadKontraktV8 } from '../../typer/kontrakt/v8';
 import { ISøker } from '../../typer/person';
 import { PersonType } from '../../typer/personType';
+import { ITekstinnhold } from '../../typer/sanity/tekstInnhold';
 import { ISøknadSpørsmålMap } from '../../typer/spørsmål';
 import { ISøknad } from '../../typer/søknad';
 import { erDokumentasjonRelevant } from '../dokumentasjon';
@@ -52,7 +53,9 @@ const antallEøsSteg = (søker: ISøker, barnInkludertISøknaden: IBarnMedISøkn
 
 export const dataISøknadKontraktFormatV8 = (
     valgtSpråk: LocaleType,
-    søknad: ISøknad
+    søknad: ISøknad,
+    tekster: ITekstinnhold,
+    tilRestLocaleRecord: TilRestLocaleRecord
 ): ISøknadKontraktV8 => {
     const { søker } = søknad;
     // Raskeste måte å få tak i alle spørsmål minus de andre feltene på søker
@@ -163,7 +166,9 @@ export const dataISøknadKontraktFormatV8 = (
                 })
             ),
         },
-        barn: barnInkludertISøknaden.map(barn => barnISøknadsFormatV8(barn, søker, valgtSpråk)),
+        barn: barnInkludertISøknaden.map(barn =>
+            barnISøknadsFormatV8(barn, søker, valgtSpråk, tekster, tilRestLocaleRecord)
+        ),
         spørsmål: {
             erNoenAvBarnaFosterbarn: søknadsfelt(
                 språktekstIdFraSpørsmålId(OmBarnaDineSpørsmålId.erNoenAvBarnaFosterbarn),


### PR DESCRIPTION
Favro: [NAV-21626](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21626)

### 💰 Hva forsøker du å løse i denne PR'en
Når vi henter personopplysninger for søker vil ikke barnets ident/fnr være satt dersom barnet har adressebeskyttelse. Må derfor oppdatere ident-feltet for barn i respons-objektet til personopplysninger til å være nullable.

Har lagt inn nødvendige relaterte kodeendringer.

Relatert PR i `familie-baks-soknad-api`: https://github.com/navikt/familie-baks-soknad-api/pull/266

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
 
