### PR TITLE
Legger til persontype barn

### DIFF
--- a/src/frontend/components/Felleskomponenter/Arbeidsperiode/Arbeidsperiode.tsx
+++ b/src/frontend/components/Felleskomponenter/Arbeidsperiode/Arbeidsperiode.tsx
@@ -106,6 +106,7 @@ export const Arbeidsperiode: React.FC<Props> = ({
                             gjelderUtlandet={gjelderUtlandet}
                             personType={personType}
                             erDød={personType === PersonType.AndreForelder && erDød}
+                            barn={personType !== PersonType.Søker ? barn : undefined}
                         />
                     ))}
                     {!toggles.NYE_MODAL_TEKSTER && registrerteArbeidsperioder.verdi.length > 0 && (

--- a/src/frontend/components/Felleskomponenter/Arbeidsperiode/ArbeidsperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/Arbeidsperiode/ArbeidsperiodeOppsummering.tsx
@@ -6,7 +6,7 @@ import { ESvar } from '@navikt/familie-form-elements';
 
 import { useSpråk } from '../../../context/SpråkContext';
 import { IArbeidsperiode } from '../../../typer/perioder';
-import { PersonType } from '../../../typer/personType';
+import { PeriodePersonTypeMedBarnProps, PersonType } from '../../../typer/personType';
 import { formaterDato } from '../../../utils/dato';
 import { landkodeTilSpråk } from '../../../utils/språk';
 import { formaterDatoMedUkjent } from '../../../utils/visning';
@@ -27,12 +27,7 @@ interface Props {
     gjelderUtlandet: boolean;
 }
 
-type ArbeidperiodeOppsummeringPersonTypeProps =
-    | { personType: PersonType.Søker; erDød?: boolean }
-    | { personType: PersonType.Omsorgsperson; erDød?: boolean }
-    | { personType: PersonType.AndreForelder; erDød: boolean };
-
-type ArbeidsperiodeOppsummeringProps = Props & ArbeidperiodeOppsummeringPersonTypeProps;
+type ArbeidsperiodeOppsummeringProps = Props & PeriodePersonTypeMedBarnProps;
 
 export const ArbeidsperiodeOppsummering: React.FC<ArbeidsperiodeOppsummeringProps> = ({
     arbeidsperiode,

--- a/src/frontend/components/Felleskomponenter/Pensjonsmodal/PensjonsperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/Pensjonsmodal/PensjonsperiodeOppsummering.tsx
@@ -3,9 +3,8 @@ import React from 'react';
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { useSpråk } from '../../../context/SpråkContext';
-import { IBarnMedISøknad } from '../../../typer/barn';
 import { IPensjonsperiode } from '../../../typer/perioder';
-import { PersonType } from '../../../typer/personType';
+import { PeriodePersonTypeMedBarnProps, PersonType } from '../../../typer/personType';
 import { formaterDato } from '../../../utils/dato';
 import { landkodeTilSpråk } from '../../../utils/språk';
 import { OppsummeringFelt } from '../../SøknadsSteg/Oppsummering/OppsummeringFelt';
@@ -25,12 +24,7 @@ interface Props {
     gjelderUtlandet: boolean;
 }
 
-type PensjonsperiodeOppsummeringPersonTypeProps =
-    | { personType: PersonType.Søker; erDød?: boolean; barn?: IBarnMedISøknad | undefined }
-    | { personType: PersonType.Omsorgsperson; erDød?: boolean; barn: IBarnMedISøknad | undefined }
-    | { personType: PersonType.AndreForelder; erDød: boolean; barn: IBarnMedISøknad | undefined };
-
-type PensjonsperiodeOppsummeringProps = Props & PensjonsperiodeOppsummeringPersonTypeProps;
+type PensjonsperiodeOppsummeringProps = Props & PeriodePersonTypeMedBarnProps;
 
 export const PensjonsperiodeOppsummering: React.FC<PensjonsperiodeOppsummeringProps> = ({
     pensjonsperiode,

--- a/src/frontend/components/Felleskomponenter/UtbetalingerModal/UtbetalingsperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/UtbetalingerModal/UtbetalingsperiodeOppsummering.tsx
@@ -3,9 +3,8 @@ import React from 'react';
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { useSpråk } from '../../../context/SpråkContext';
-import { IBarnMedISøknad } from '../../../typer/barn';
 import { IUtbetalingsperiode } from '../../../typer/perioder';
-import { PersonType } from '../../../typer/personType';
+import { PeriodePersonTypeMedBarnProps, PersonType } from '../../../typer/personType';
 import { formaterDato } from '../../../utils/dato';
 import { landkodeTilSpråk } from '../../../utils/språk';
 import { formaterDatoMedUkjent } from '../../../utils/visning';
@@ -22,12 +21,7 @@ interface Props {
     fjernPeriodeCallback?: (utbetalingsperiode: IUtbetalingsperiode) => void;
 }
 
-type UtbetalingsperiodeOppsummeringPersonTypeProps =
-    | { personType: PersonType.Søker; erDød?: boolean; barn?: IBarnMedISøknad | undefined }
-    | { personType: PersonType.Omsorgsperson; erDød?: boolean; barn: IBarnMedISøknad | undefined }
-    | { personType: PersonType.AndreForelder; erDød: boolean; barn: IBarnMedISøknad | undefined };
-
-type UtbetalingsperiodeOppsummeringProps = Props & UtbetalingsperiodeOppsummeringPersonTypeProps;
+type UtbetalingsperiodeOppsummeringProps = Props & PeriodePersonTypeMedBarnProps;
 
 export const UtbetalingsperiodeOppsummering: React.FC<UtbetalingsperiodeOppsummeringProps> = ({
     utbetalingsperiode,

--- a/src/frontend/components/SøknadsSteg/OmBarnet/Oppfølgningsspørsmål.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/Oppfølgningsspørsmål.tsx
@@ -83,7 +83,7 @@ const Oppfølgningsspørsmål: React.FC<{
     const antallPerioder = utenlandsperioder.length;
     const leggTilPeriodeTekster = hentLeggTilPeriodeTekster(
         'utenlandsopphold',
-        PersonType.Søker,
+        PersonType.Barn,
         antallPerioder
     );
 

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsAndreForelderOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsAndreForelderOppsummering.tsx
@@ -90,6 +90,7 @@ const EøsAndreForelderOppsummering: React.FC<{
                         personType={PersonType.AndreForelder}
                         erDød={andreForelderErDød}
                         gjelderUtlandet={false}
+                        barn={barn}
                     />
                 ))}
                 {jaNeiSpmOppsummering(andreForelderDataKeySpørsmål.pensjonNorge)}

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsOmsorgspersonOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsOmsorgspersonOppsummering.tsx
@@ -94,6 +94,7 @@ const EøsOmsorgspersonOppsummering: React.FC<{
                     nummer={index + 1}
                     personType={PersonType.Omsorgsperson}
                     gjelderUtlandet={true}
+                    barn={barn}
                 />
             ))}
             {omsorgsperson.arbeidNorge.svar && (
@@ -114,6 +115,7 @@ const EøsOmsorgspersonOppsummering: React.FC<{
                     nummer={index + 1}
                     personType={PersonType.Omsorgsperson}
                     gjelderUtlandet={false}
+                    barn={barn}
                 />
             ))}
             {omsorgsperson.pensjonUtland.svar && (

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnet/AndreForelderOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnet/AndreForelderOppsummering.tsx
@@ -129,6 +129,7 @@ const AndreForelderOppsummering: React.FC<{
                             gjelderUtlandet={true}
                             personType={PersonType.AndreForelder}
                             erDød={barn[barnDataKeySpørsmål.andreForelderErDød].svar === ESvar.JA}
+                            barn={barn}
                         />
                     ))}
 

--- a/src/frontend/typer/personType.ts
+++ b/src/frontend/typer/personType.ts
@@ -4,12 +4,14 @@ export enum PersonType {
     AndreForelder = 'andreForelder',
     Omsorgsperson = 'omsorgsperson',
     Søker = 'søker',
+    Barn = 'barn',
 }
 
 export type PeriodePersonTypeMedBarnProps =
-    | { personType: PersonType.Søker; barn?: never; erDød?: never }
-    | { personType: PersonType.Omsorgsperson; barn: IBarnMedISøknad; erDød?: never }
-    | { personType: PersonType.AndreForelder; barn: IBarnMedISøknad; erDød: boolean };
+    | { personType: PersonType.Søker; erDød?: boolean; barn?: IBarnMedISøknad | undefined }
+    | { personType: PersonType.Omsorgsperson; erDød?: boolean; barn: IBarnMedISøknad | undefined }
+    | { personType: PersonType.AndreForelder; erDød?: boolean; barn: IBarnMedISøknad | undefined }
+    | { personType: PersonType.Barn; erDød?: boolean; barn?: IBarnMedISøknad | undefined };
 
 export type PeriodePersonTypeProps =
     | { personType: PersonType.Søker; erDød?: never }

--- a/src/frontend/typer/sanity/tekstInnhold.ts
+++ b/src/frontend/typer/sanity/tekstInnhold.ts
@@ -24,6 +24,7 @@ export enum SanityPersonType {
     ANDRE_FORELDER = 'ANDRE_FORELDER',
     SOKER = 'SOKER',
     OMSORGSPERSON = 'OMSORGSPERSON',
+    BARN = 'BARN',
 }
 
 export enum SanityModalPrefix {

--- a/src/frontend/utils/mappingTilKontrakt/andreUtbetalingsperioder.ts
+++ b/src/frontend/utils/mappingTilKontrakt/andreUtbetalingsperioder.ts
@@ -29,7 +29,7 @@ export const tilIAndreUtbetalingsperioderIKontraktFormat = ({
     PeriodePersonTypeMedBarnProps): ISøknadsfelt<IUtbetalingsperiodeIKontraktFormatV8> => {
     const { fårUtbetalingNå, utbetalingLand, utbetalingFraDato, utbetalingTilDato } = periode;
     const periodenErAvsluttet =
-        fårUtbetalingNå?.svar === ESvar.NEI || (personType === PersonType.AndreForelder && erDød);
+        fårUtbetalingNå?.svar === ESvar.NEI || (personType === PersonType.AndreForelder && !!erDød);
 
     const hentUtbetalingsperiodeSpråkId = utbetalingsperiodeModalSpørsmålSpråkIder(
         personType,

--- a/src/frontend/utils/mappingTilKontrakt/pensjonsperioder.ts
+++ b/src/frontend/utils/mappingTilKontrakt/pensjonsperioder.ts
@@ -31,7 +31,7 @@ export const tilIPensjonsperiodeIKontraktFormat = ({
     const { mottarPensjonNå, pensjonsland, pensjonFra, pensjonTil } = periode;
 
     const periodenErAvsluttet =
-        mottarPensjonNå?.svar === ESvar.NEI || (personType === PersonType.AndreForelder && erDød);
+        mottarPensjonNå?.svar === ESvar.NEI || (personType === PersonType.AndreForelder && !!erDød);
 
     const hentPensjonsperiodeSpråkId = pensjonsperiodeModalSpørsmålSpråkId(
         personType,

--- a/src/frontend/utils/sanity.ts
+++ b/src/frontend/utils/sanity.ts
@@ -122,7 +122,7 @@ const strukturertInnholdForModaler = (dokumenter: SanityDokument[]): IModalerTek
         },
         utenlandsopphold: {
             søker: utenlandsopphold(SanityPersonType.SOKER),
-            barn: utenlandsopphold(SanityPersonType.OMSORGSPERSON),
+            barn: utenlandsopphold(SanityPersonType.BARN),
             andreForelder: utenlandsopphold(SanityPersonType.ANDRE_FORELDER),
         },
     };


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21853

### 💰 Hva forsøker du å løse i denne PR'en
- Legger til PersonType.Barn
- Fikser tekst for utenlandsopphold i OmBarnet/Oppfølgningsspørsmål slik at den bruker Barn istedenfor Barn

### 🔎️ Er det noe spesielt du ønsker å fremheve?
- Når Barn ble lagt til som PersonType skapet det en del TypeScript feil fordi enkelte props ble satt ma nuelt (´ArbeidperiodeOppsummeringPersonTypeProps´, ´UtbetalingsperiodeOppsummeringPersonTypeProps´, ´PeriodePersonTypeMedBarnProps´). Jeg endret derfor en del av koden til å bli lik som det har blitt gjort i KS ved bruk av ´PeriodePersonTypeMedBarnProps´.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Ikke nødvendig

### 🤷‍♀ ️Hvor er det lurt å starte?
- Gå gjennom søknaden og ta i bruk komponenter hvor endringer har skjedd i koden for å sikre at alt fortsatt fungerer som det skal. Mesteparten av endringene ble gjort i periode relaterte komponenter.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
#### Før - Henter tekst for utenlandsopphold for søker. Dette er feil ettersom utenlandsoppholdet gjelder barnet.
![image](https://github.com/user-attachments/assets/dbe71c43-4095-44b2-b030-27713a3ce246)

#### Etter - Bruker placeholder tekst som ligger bak feature-toggle. Dette blir endret senere.
![image](https://github.com/user-attachments/assets/16174d44-5b8b-4c98-914a-14af84876a4b)