### PR TITLE
Fjerner filtrering av ytelse når tekster hentes fra Sanity

### DIFF
--- a/src/frontend/context/SanityContext.ts
+++ b/src/frontend/context/SanityContext.ts
@@ -31,7 +31,7 @@ const [SanityProvider, useSanity] = createUseContext(() => {
         settTeksterRessurs(byggHenterRessurs());
 
         sanityKlient
-            .fetch<SanityDokument[]>('*["BARNETRYGD" in ytelse]')
+            .fetch<SanityDokument[]>('*')
             .then(dokumenter => {
                 fjernRessursSomLaster(ressursId);
                 settTeksterRessurs({


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21906

### 💰 Hva forsøker du å løse i denne PR'en
- Fjerner filtrering av ytelse når tekster hentes fra Sanity slik at alle tekster hentes, uavhengig om hva slags avhukinger som er gjort.