### PR TITLE
Henter og viser kontoinformasjon

### DIFF
--- a/src/frontend/components/Kontoinformasjon/Kontoinformasjon.tsx
+++ b/src/frontend/components/Kontoinformasjon/Kontoinformasjon.tsx
@@ -13,7 +13,7 @@ const Kontoinformasjon: React.FC = () => {
     const kvitteringstekster = tekster()[ESanitySteg.KVITTERING];
 
     return (
-        <VStack gap="4">
+        <VStack gap="6">
             {kontoinformasjon.status === RessursStatus.SUKSESS && (
                 <>
                     <Heading level="3" size="xsmall">
@@ -42,7 +42,6 @@ const Kontoinformasjon: React.FC = () => {
                         {plainTekst(kvitteringstekster.manglerKontonummerTittel)}
                     </Heading>
                     <TekstBlock block={kvitteringstekster.finnerIngenKontonummerBeskrivelse} />
-                    <TekstBlock block={kvitteringstekster.registrerKontonummerLenke} />
                 </>
             )}
         </VStack>

--- a/src/frontend/components/Kontoinformasjon/Kontoinformasjon.tsx
+++ b/src/frontend/components/Kontoinformasjon/Kontoinformasjon.tsx
@@ -16,7 +16,7 @@ const Kontoinformasjon: React.FC = () => {
         <VStack gap="4">
             {kontoinformasjon.status === RessursStatus.SUKSESS && (
                 <>
-                    <Heading level="3" size="small">
+                    <Heading level="3" size="xsmall">
                         {plainTekst(kvitteringstekster.kontonummerTittel)}
                     </Heading>
                     <Label as="p">{kontoinformasjon.data.kontonummer}</Label>
@@ -38,7 +38,7 @@ const Kontoinformasjon: React.FC = () => {
                     <Alert variant="warning">
                         <TekstBlock block={kvitteringstekster.finnerIngenKontonummerAdvarsel} />
                     </Alert>
-                    <Heading level="3" size="small">
+                    <Heading level="3" size="xsmall">
                         {plainTekst(kvitteringstekster.manglerKontonummerTittel)}
                     </Heading>
                     <TekstBlock block={kvitteringstekster.finnerIngenKontonummerBeskrivelse} />

--- a/src/frontend/components/Kontoinformasjon/Kontoinformasjon.tsx
+++ b/src/frontend/components/Kontoinformasjon/Kontoinformasjon.tsx
@@ -4,7 +4,7 @@ import { Alert, Heading, Label, Loader, VStack } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useApp } from '../../context/AppContext';
-import { ESanitySteg } from '../../typer/sanity/sanity';
+import { ESanitySteg, Typografi } from '../../typer/sanity/sanity';
 import TekstBlock from '../Felleskomponenter/Sanity/TekstBlock';
 
 const Kontoinformasjon: React.FC = () => {
@@ -20,7 +20,10 @@ const Kontoinformasjon: React.FC = () => {
                         {plainTekst(kvitteringstekster.kontonummerTittel)}
                     </Heading>
                     <Label as="p">{kontoinformasjon.data.kontonummer}</Label>
-                    <TekstBlock block={kvitteringstekster.redigerKontonummerLenke} />
+                    <TekstBlock
+                        typografi={Typografi.BodyLong}
+                        block={kvitteringstekster.redigerKontonummerLenke}
+                    />
                 </>
             )}
 
@@ -41,7 +44,10 @@ const Kontoinformasjon: React.FC = () => {
                     <Heading level="3" size="xsmall">
                         {plainTekst(kvitteringstekster.manglerKontonummerTittel)}
                     </Heading>
-                    <TekstBlock block={kvitteringstekster.finnerIngenKontonummerBeskrivelse} />
+                    <TekstBlock
+                        typografi={Typografi.BodyLong}
+                        block={kvitteringstekster.finnerIngenKontonummerBeskrivelse}
+                    />
                 </>
             )}
         </VStack>

--- a/src/frontend/components/Kontoinformasjon/Kontoinformasjon.tsx
+++ b/src/frontend/components/Kontoinformasjon/Kontoinformasjon.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import { Alert, Heading, Label, Loader, VStack } from '@navikt/ds-react';
+import { RessursStatus } from '@navikt/familie-typer';
+
+import { useApp } from '../../context/AppContext';
+import { ESanitySteg } from '../../typer/sanity/sanity';
+import TekstBlock from '../Felleskomponenter/Sanity/TekstBlock';
+
+const Kontoinformasjon: React.FC = () => {
+    const { kontoinformasjon, tekster, plainTekst } = useApp();
+
+    const kvitteringstekster = tekster()[ESanitySteg.KVITTERING];
+
+    return (
+        <VStack gap="4">
+            {kontoinformasjon.status === RessursStatus.SUKSESS && (
+                <>
+                    <Heading level="3" size="small">
+                        {plainTekst(kvitteringstekster.kontonummerTittel)}
+                    </Heading>
+                    <Label as="p">{kontoinformasjon.data.kontonummer}</Label>
+                    <TekstBlock block={kvitteringstekster.redigerKontonummerLenke} />
+                </>
+            )}
+
+            {kontoinformasjon.status === RessursStatus.HENTER && (
+                <>
+                    <Heading level="3" size="xsmall">
+                        {plainTekst(kvitteringstekster.kontonummerTittel)}
+                    </Heading>
+                    <Loader title={plainTekst(kvitteringstekster.henterKontonummer)} />
+                </>
+            )}
+
+            {kontoinformasjon.status === RessursStatus.FEILET && (
+                <>
+                    <Alert variant="warning">
+                        <TekstBlock block={kvitteringstekster.finnerIngenKontonummerAdvarsel} />
+                    </Alert>
+                    <Heading level="3" size="small">
+                        {plainTekst(kvitteringstekster.manglerKontonummerTittel)}
+                    </Heading>
+                    <TekstBlock block={kvitteringstekster.finnerIngenKontonummerBeskrivelse} />
+                    <TekstBlock block={kvitteringstekster.registrerKontonummerLenke} />
+                </>
+            )}
+        </VStack>
+    );
+};
+
+export default Kontoinformasjon;

--- a/src/frontend/components/SøknadsSteg/Kvittering/Kvittering.tsx
+++ b/src/frontend/components/SøknadsSteg/Kvittering/Kvittering.tsx
@@ -54,7 +54,7 @@ const Kvittering: React.FC = () => {
 
     return (
         <Steg tittel={<SpråkTekst id={'kvittering.sidetittel'} />}>
-            <KomponentGruppe>
+            <KomponentGruppe inline>
                 <Alert variant={'success'}>
                     <SpråkTekst
                         id={'kvittering.mottatt'}

--- a/src/frontend/components/SøknadsSteg/Kvittering/Kvittering.tsx
+++ b/src/frontend/components/SøknadsSteg/Kvittering/Kvittering.tsx
@@ -6,6 +6,7 @@ import { Alert, BodyLong } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useApp } from '../../../context/AppContext';
+import { useFeatureToggles } from '../../../context/FeatureToggleContext';
 import { useSteg } from '../../../context/StegContext';
 import { RouteEnum } from '../../../typer/routes';
 import { setUserProperty, UserProperty } from '../../../utils/amplitude';
@@ -15,6 +16,7 @@ import Informasjonsbolk from '../../Felleskomponenter/Informasjonsbolk/Informasj
 import KomponentGruppe from '../../Felleskomponenter/KomponentGruppe/KomponentGruppe';
 import SpråkTekst from '../../Felleskomponenter/SpråkTekst/SpråkTekst';
 import Steg from '../../Felleskomponenter/Steg/Steg';
+import Kontoinformasjon from '../../Kontoinformasjon/Kontoinformasjon';
 
 import { KontonummerInfo } from './KontonummerInfo';
 
@@ -28,6 +30,7 @@ const Kvittering: React.FC = () => {
     } = useApp();
     const { barnInkludertISøknaden, erEøs } = søknad;
     const { hentStegNummer } = useSteg();
+    const { toggles } = useFeatureToggles();
 
     const innsendtDato: Date =
         innsendingStatus.status === RessursStatus.SUKSESS
@@ -84,7 +87,9 @@ const Kvittering: React.FC = () => {
                 </BodyLong>
             </KomponentGruppe>
 
-            {varEøsSøknad && (
+            {toggles.VIS_KONTONUMMER && <Kontoinformasjon />}
+
+            {!toggles.VIS_KONTONUMMER && varEøsSøknad && (
                 <KomponentGruppe>
                     <KontonummerInfo />
                 </KomponentGruppe>

--- a/src/frontend/components/SøknadsSteg/Kvittering/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/Kvittering/innholdTyper.ts
@@ -2,4 +2,11 @@ import { LocaleRecordBlock } from '../../../typer/sanity/sanity';
 
 export type IKvitteringTekstinnhold = {
     kvitteringTittel: LocaleRecordBlock;
+    manglerKontonummerTittel: LocaleRecordBlock;
+    kontonummerTittel: LocaleRecordBlock;
+    redigerKontonummerLenke: LocaleRecordBlock;
+    registrerKontonummerLenke: LocaleRecordBlock;
+    henterKontonummer: LocaleRecordBlock;
+    finnerIngenKontonummerAdvarsel: LocaleRecordBlock;
+    finnerIngenKontonummerBeskrivelse: LocaleRecordBlock;
 };

--- a/src/frontend/components/SøknadsSteg/Kvittering/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/Kvittering/innholdTyper.ts
@@ -5,7 +5,6 @@ export type IKvitteringTekstinnhold = {
     manglerKontonummerTittel: LocaleRecordBlock;
     kontonummerTittel: LocaleRecordBlock;
     redigerKontonummerLenke: LocaleRecordBlock;
-    registrerKontonummerLenke: LocaleRecordBlock;
     henterKontonummer: LocaleRecordBlock;
     finnerIngenKontonummerAdvarsel: LocaleRecordBlock;
     finnerIngenKontonummerBeskrivelse: LocaleRecordBlock;

--- a/src/frontend/context/AppContext.ts
+++ b/src/frontend/context/AppContext.ts
@@ -5,15 +5,18 @@ import { Alpha3Code, getName } from 'i18n-iso-countries';
 import { useIntl } from 'react-intl';
 
 import {
+    byggFeiletRessurs,
     byggHenterRessurs,
     byggTomRessurs,
     hentDataFraRessurs,
+    Ressurs,
     RessursStatus,
 } from '@navikt/familie-typer';
 
 import Miljø, { basePath } from '../../shared-utils/Miljø';
 import { DinLivssituasjonSpørsmålId } from '../components/SøknadsSteg/DinLivssituasjon/spørsmål';
 import { LocaleType } from '../typer/common';
+import { IKontoinformasjon } from '../typer/kontoinformasjon';
 import { ESivilstand, ESøknadstype } from '../typer/kontrakt/generelle';
 import { IKvittering } from '../typer/kvittering';
 import { IMellomlagretBarnetrygd } from '../typer/mellomlager';
@@ -40,6 +43,7 @@ const [AppProvider, useApp] = createUseContext(() => {
     const { innloggetStatus } = useInnloggetContext();
     const [sluttbruker, settSluttbruker] = useState(byggTomRessurs<ISøkerRespons>());
     const [eøsLand, settEøsLand] = useState(byggTomRessurs<Map<Alpha3Code, string>>());
+    const [kontoinformasjon, settKontoinformasjon] = useState(byggTomRessurs<IKontoinformasjon>());
     const [søknad, settSøknad] = useState<ISøknad>(initialStateSøknad());
     const [innsendingStatus, settInnsendingStatus] = useState(byggTomRessurs<IKvittering>());
     const [sisteUtfylteStegIndex, settSisteUtfylteStegIndex] = useState<number>(-1);
@@ -87,6 +91,7 @@ const [AppProvider, useApp] = createUseContext(() => {
                 settSluttbruker(ressurs);
 
                 hentOgSettMellomlagretData();
+                hentOgSettKontoinformasjon();
                 ressurs.status === RessursStatus.SUKSESS &&
                     settSøknad({
                         ...søknad,
@@ -173,6 +178,21 @@ const [AppProvider, useApp] = createUseContext(() => {
             påvirkerSystemLaster: false,
         });
         settMellomlagretVerdi(undefined);
+    };
+
+    const hentOgSettKontoinformasjon = () => {
+        preferredAxios
+            .get(`${Miljø().soknadApiProxyUrl}/kontoregister/hent-kontonr`, {
+                withCredentials: true,
+            })
+            .then((response: { data?: Ressurs<IKontoinformasjon> }) => {
+                if (response.data) {
+                    settKontoinformasjon(response.data);
+                }
+            })
+            .catch(() => {
+                settKontoinformasjon(byggFeiletRessurs('Request mot kontoregisteret feilet'));
+            });
     };
 
     const nullstillSøknadsobjekt = () => {
@@ -360,6 +380,7 @@ const [AppProvider, useApp] = createUseContext(() => {
         tekster,
         plainTekst,
         flettefeltTilTekst,
+        kontoinformasjon,
     };
 });
 

--- a/src/frontend/typer/feature-toggles.ts
+++ b/src/frontend/typer/feature-toggles.ts
@@ -6,12 +6,14 @@ export enum EFeatureToggle {
     // EKSEMPEL = 'EKSEMPEL',
     NYE_MODAL_TEKSTER = 'NYE_MODAL_TEKSTER',
     NYE_VEDLEGGSTEKSTER = 'NYE_VEDLEGGSTEKSTER',
+    VIS_KONTONUMMER = 'VIS_KONTONUMMER',
 }
 
 export const ToggleKeys: Record<EFeatureToggle, string> = {
     // [EFeatureToggle.EKSEMPEL]: 'familie-ba-soknad.eksempel',
     [EFeatureToggle.NYE_MODAL_TEKSTER]: 'familie-ba-soknad.nye-modal-tekster',
     [EFeatureToggle.NYE_VEDLEGGSTEKSTER]: 'familie-ba-soknad.nye-vedleggstekster',
+    [EFeatureToggle.VIS_KONTONUMMER]: 'familie-ba-soknad.vis-kontonummer',
 };
 
 export type EAllFeatureToggles = Record<EFeatureToggle, boolean>;

--- a/src/frontend/typer/kontoinformasjon.ts
+++ b/src/frontend/typer/kontoinformasjon.ts
@@ -1,0 +1,3 @@
+export interface IKontoinformasjon {
+    kontonummer: string;
+}


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20794

### 💰 Hva forsøker du å løse i denne PR'en
Henter og viser kontonummer fra baks-soknad-api (som igjen henter det fra Kontoregisteret Person).

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Har lagt fetchingen der jeg ser mye annen fetching skjer, i `AppContext`. Si ifra hvis dette blir feil sted å legge det.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
Skal skrive tester etter hvert, men siden denne oppgaven har ligget så lenge så prioriterer jeg nå å få ut en PR på det.

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [X] Nei
  
### 👀 Screen shots
Happy case - med kontonummer:
<img width="805" alt="image" src="https://github.com/user-attachments/assets/fb6cebe4-ed5c-4418-b46b-202d6c1b1435">

Uten kontonummer:
<img width="761" alt="image" src="https://github.com/user-attachments/assets/38833816-df0e-4202-9535-d316189d3a21">

Dette slettes - før ble det vist informasjon om kontonummer når det var en EØS-søknad:
<img width="731" alt="image" src="https://github.com/user-attachments/assets/8ea1235a-af93-4dd0-b1f0-787d0c4af129">
