### PR TITLE
Begrenser antall opplastede vedlegg til 25

### DIFF
--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg.tsx
@@ -117,14 +117,16 @@ const LastOppVedlegg: React.FC<Props> = ({ dokumentasjon, vedleggNr, oppdaterDok
                 />
             )}
             {!dokumentasjon.harSendtInn && (
-                <Filopplaster
-                    oppdaterDokumentasjon={oppdaterDokumentasjon}
-                    dokumentasjon={dokumentasjon}
-                    tillatteFiltyper={{
-                        'image/*': [EFiltyper.PNG, EFiltyper.JPG, EFiltyper.JPEG],
-                        'application/pdf': [EFiltyper.PDF],
-                    }}
-                />
+                <div data-testid={'dokumentopplaster'}>
+                    <Filopplaster
+                        oppdaterDokumentasjon={oppdaterDokumentasjon}
+                        dokumentasjon={dokumentasjon}
+                        tillatteFiltyper={{
+                            'image/*': [EFiltyper.PNG, EFiltyper.JPG, EFiltyper.JPEG],
+                            'application/pdf': [EFiltyper.PDF],
+                        }}
+                    />
+                </div>
             )}
             <br />
             {dokumentasjon.dokumentasjonsbehov !== Dokumentasjonsbehov.ANNEN_DOKUMENTASJON && (

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg.tsx
@@ -117,17 +117,14 @@ const LastOppVedlegg: React.FC<Props> = ({ dokumentasjon, vedleggNr, oppdaterDok
                 />
             )}
             {!dokumentasjon.harSendtInn && (
-                <div data-testid={'dokumentopplaster'}>
-                    <Filopplaster
-                        oppdaterDokumentasjon={oppdaterDokumentasjon}
-                        dokumentasjon={dokumentasjon}
-                        maxFilstørrelse={1024 * 1024 * 10}
-                        tillatteFiltyper={{
-                            'image/*': [EFiltyper.PNG, EFiltyper.JPG, EFiltyper.JPEG],
-                            'application/pdf': [EFiltyper.PDF],
-                        }}
-                    />
-                </div>
+                <Filopplaster
+                    oppdaterDokumentasjon={oppdaterDokumentasjon}
+                    dokumentasjon={dokumentasjon}
+                    tillatteFiltyper={{
+                        'image/*': [EFiltyper.PNG, EFiltyper.JPG, EFiltyper.JPEG],
+                        'application/pdf': [EFiltyper.PDF],
+                    }}
+                />
             )}
             <br />
             {dokumentasjon.dokumentasjonsbehov !== Dokumentasjonsbehov.ANNEN_DOKUMENTASJON && (

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/Filopplaster.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/Filopplaster.tsx
@@ -22,7 +22,6 @@ interface Props {
     ) => void;
     dokumentasjon: IDokumentasjon;
     tillatteFiltyper: { [key: string]: string[] };
-    maxFilstørrelse: number;
 }
 
 interface FilopplastningBoksProps {
@@ -67,10 +66,8 @@ const Filopplaster: React.FC<Props> = ({
     oppdaterDokumentasjon,
     dokumentasjon,
     tillatteFiltyper,
-    maxFilstørrelse,
 }) => {
     const { onDrop, harFeil, feilmeldinger, slettVedlegg } = useFilopplaster(
-        maxFilstørrelse,
         dokumentasjon,
         oppdaterDokumentasjon
     );

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/Filopplaster.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/Filopplaster.tsx
@@ -7,6 +7,7 @@ import { UploadIcon } from '@navikt/aksel-icons';
 import { BodyShort } from '@navikt/ds-react';
 import { ABlue500, ABorderDefault } from '@navikt/ds-tokens/dist/tokens';
 
+import { useApp } from '../../../../context/AppContext';
 import { IDokumentasjon, IVedlegg } from '../../../../typer/dokumentasjon';
 import { Dokumentasjonsbehov } from '../../../../typer/kontrakt/dokumentasjon';
 import SpråkTekst from '../../../Felleskomponenter/SpråkTekst/SpråkTekst';
@@ -76,6 +77,8 @@ const Filopplaster: React.FC<Props> = ({
         accept: tillatteFiltyper,
     });
 
+    const { plainTekst } = useApp();
+
     return (
         <>
             <FilopplastningBoks type={'button'} {...getRootProps()} $harFeil={harFeil}>
@@ -99,7 +102,7 @@ const Filopplaster: React.FC<Props> = ({
                 <StyledFeilmeldingList>
                     {Array.from(feilmeldinger).map(([key, value], index) => (
                         <li key={index}>
-                            <SpråkTekst id={key} />
+                            {plainTekst(key)}
                             {
                                 <StyledFeilmeldingList>
                                     {value.map((fil, index) => (

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/innholdTyper.ts
@@ -1,27 +1,17 @@
-import { BeskrivelseSanityApiNavn, TittelSanityApiNavn } from '../../../typer/dokumentasjon';
-import { LocaleRecordBlock } from '../../../typer/sanity/sanity';
+import { LocaleRecordBlock, LocaleRecordString } from '../../../typer/sanity/sanity';
 
 export type IDokumentasjonTekstinnhold = {
     dokumentasjonTittel: LocaleRecordBlock;
     dokumentasjonGuide: LocaleRecordBlock;
     sendtInnTidligere: LocaleRecordBlock;
     vedleggXavY: LocaleRecordBlock;
-} & {
-    [TittelSanityApiNavn.bekreftelsePaaAdopsjonTittel]: LocaleRecordBlock;
-    [TittelSanityApiNavn.annenDokumentasjon]: LocaleRecordBlock;
-    [TittelSanityApiNavn.avtaleOmDeltBostedTittel]: LocaleRecordBlock;
-    [TittelSanityApiNavn.bekreftelseFraBarnevernetTittel]: LocaleRecordBlock;
-    [TittelSanityApiNavn.bekreftelsePaaAtBarnBorSammenMedDegTittel]: LocaleRecordBlock;
-    [TittelSanityApiNavn.meklingsattestTittel]: LocaleRecordBlock;
-    [TittelSanityApiNavn.dokumentasjonPaaSeparasjonSkilsmisseEllerDoedsfallTittel]: LocaleRecordBlock;
-    [TittelSanityApiNavn.vedtakOmOppholdstillatelseTittel]: LocaleRecordBlock;
-} & {
-    [BeskrivelseSanityApiNavn.dokumentasjonPaaSeparasjonSkilsmisseEllerDoedsfall]: LocaleRecordBlock;
-    [BeskrivelseSanityApiNavn.vedtakOmOppholdstillatelse]: LocaleRecordBlock;
-    [BeskrivelseSanityApiNavn.bekreftelsePaaAdopsjonBarnetrygd]: LocaleRecordBlock;
-    [BeskrivelseSanityApiNavn.bekreftelsePaaAtBarnBorSammenMedDeg]: LocaleRecordBlock;
-    [BeskrivelseSanityApiNavn.avtaleOmDeltBosted]: LocaleRecordBlock;
-    [BeskrivelseSanityApiNavn.meklingsattest]: LocaleRecordBlock;
-    [BeskrivelseSanityApiNavn.bekreftelseFraBarnevernetBarnetrygd]: LocaleRecordBlock;
-    [BeskrivelseSanityApiNavn.lastOppSenereISoknad]: LocaleRecordBlock;
+    dokumentasjonPaaSeparasjonSkilsmisseEllerDoedsfall: LocaleRecordBlock;
+    vedtakOmOppholdstillatelse: LocaleRecordBlock;
+    bekreftelsePaaAdopsjonBarnetrygd: LocaleRecordBlock;
+    bekreftelsePaaAtBarnBorSammenMedDeg: LocaleRecordBlock;
+    avtaleOmDeltBosted: LocaleRecordBlock;
+    meklingsattest: LocaleRecordBlock;
+    bekreftelseFraBarnevernetBarnetrygd: LocaleRecordBlock;
+    lastOppSenereISoknad: LocaleRecordBlock;
+    forMange: LocaleRecordString;
 };

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/innholdTyper.ts
@@ -1,3 +1,4 @@
+import { BeskrivelseSanityApiNavn, TittelSanityApiNavn } from '../../../typer/dokumentasjon';
 import { LocaleRecordBlock, LocaleRecordString } from '../../../typer/sanity/sanity';
 
 export type IDokumentasjonTekstinnhold = {
@@ -5,14 +6,25 @@ export type IDokumentasjonTekstinnhold = {
     dokumentasjonGuide: LocaleRecordBlock;
     sendtInnTidligere: LocaleRecordBlock;
     vedleggXavY: LocaleRecordBlock;
-    dokumentasjonPaaSeparasjonSkilsmisseEllerDoedsfall: LocaleRecordBlock;
-    vedtakOmOppholdstillatelse: LocaleRecordBlock;
-    bekreftelsePaaAdopsjonBarnetrygd: LocaleRecordBlock;
-    bekreftelsePaaAtBarnBorSammenMedDeg: LocaleRecordBlock;
-    avtaleOmDeltBosted: LocaleRecordBlock;
-    meklingsattest: LocaleRecordBlock;
-    bekreftelseFraBarnevernetBarnetrygd: LocaleRecordBlock;
-    lastOppSenereISoknad: LocaleRecordBlock;
+} & {
+    [TittelSanityApiNavn.bekreftelsePaaAdopsjonTittel]: LocaleRecordBlock;
+    [TittelSanityApiNavn.annenDokumentasjon]: LocaleRecordBlock;
+    [TittelSanityApiNavn.avtaleOmDeltBostedTittel]: LocaleRecordBlock;
+    [TittelSanityApiNavn.bekreftelseFraBarnevernetTittel]: LocaleRecordBlock;
+    [TittelSanityApiNavn.bekreftelsePaaAtBarnBorSammenMedDegTittel]: LocaleRecordBlock;
+    [TittelSanityApiNavn.meklingsattestTittel]: LocaleRecordBlock;
+    [TittelSanityApiNavn.dokumentasjonPaaSeparasjonSkilsmisseEllerDoedsfallTittel]: LocaleRecordBlock;
+    [TittelSanityApiNavn.vedtakOmOppholdstillatelseTittel]: LocaleRecordBlock;
+} & {
+    [BeskrivelseSanityApiNavn.dokumentasjonPaaSeparasjonSkilsmisseEllerDoedsfall]: LocaleRecordBlock;
+    [BeskrivelseSanityApiNavn.vedtakOmOppholdstillatelse]: LocaleRecordBlock;
+    [BeskrivelseSanityApiNavn.bekreftelsePaaAdopsjonBarnetrygd]: LocaleRecordBlock;
+    [BeskrivelseSanityApiNavn.bekreftelsePaaAtBarnBorSammenMedDeg]: LocaleRecordBlock;
+    [BeskrivelseSanityApiNavn.avtaleOmDeltBosted]: LocaleRecordBlock;
+    [BeskrivelseSanityApiNavn.meklingsattest]: LocaleRecordBlock;
+    [BeskrivelseSanityApiNavn.bekreftelseFraBarnevernetBarnetrygd]: LocaleRecordBlock;
+    [BeskrivelseSanityApiNavn.lastOppSenereISoknad]: LocaleRecordBlock;
+} & {
     forMange: LocaleRecordString;
     feilFiltype: LocaleRecordString;
     forStor: LocaleRecordString;

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/innholdTyper.ts
@@ -14,4 +14,8 @@ export type IDokumentasjonTekstinnhold = {
     bekreftelseFraBarnevernetBarnetrygd: LocaleRecordBlock;
     lastOppSenereISoknad: LocaleRecordBlock;
     forMange: LocaleRecordString;
+    feilFiltype: LocaleRecordString;
+    forStor: LocaleRecordString;
+    bildetForLite: LocaleRecordString;
+    noeGikkFeil: LocaleRecordString;
 };


### PR DESCRIPTION
Favro: [NAV-22223](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22223)

### 💰 Hva forsøker du å løse i denne PR'en
Begrenser antall opplastede vedlegg til 25.

Dersom man forsøker å laste opp flere enn 25 vedlegg totalt i søknaden viser vi en feilmelding til bruker.

Bytter også ut alle lokale språktekster relatert til feilmeldinger ved opplasting med tekster fra Sanity.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
![image](https://github.com/user-attachments/assets/7c1c6fb4-00ce-4272-9482-75411cf2ecef)
