### PR TITLE
Ikke be om meklingsattest for barn over 16

### DIFF
--- a/src/frontend/components/SøknadsSteg/OmBarnet/OmBarnet.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/OmBarnet.tsx
@@ -24,7 +24,7 @@ import AndreForelder from './AndreForelder';
 import { OmBarnetHeader } from './OmBarnetHeader';
 import Oppfølgningsspørsmål from './Oppfølgningsspørsmål';
 import { OmBarnetSpørsmålsId, omBarnetSpørsmålSpråkId } from './spørsmål';
-import { useOmBarnet } from './useOmBarnet';
+import { barnErUnder16År, useOmBarnet } from './useOmBarnet';
 
 const EksternLenkeContainer = styled.div`
     margin-bottom: 4rem;
@@ -198,7 +198,9 @@ const OmBarnet: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
                         dokumentasjonsbehov: Dokumentasjonsbehov.AVTALE_DELT_BOSTED,
                     },
                     {
-                        skalVises: skjema.felter.borMedAndreForelderCheckbox.erSynlig,
+                        skalVises:
+                            skjema.felter.borMedAndreForelderCheckbox.erSynlig &&
+                            barnErUnder16År(barn),
                         dokumentasjonsbehov: Dokumentasjonsbehov.MEKLINGSATTEST,
                     },
                 ]}

--- a/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.tsx
@@ -61,7 +61,7 @@ import { idNummerLand } from '../EøsSteg/idnummerUtils';
 
 import { OmBarnetSpørsmålsId } from './spørsmål';
 
-const barnErUnder16År = (barnet: IBarnMedISøknad): boolean => Number(barnet.alder) < 16;
+export const barnErUnder16År = (barnet: IBarnMedISøknad): boolean => Number(barnet.alder) < 16;
 
 export const useOmBarnet = (
     barnetsUuid: BarnetsId
@@ -520,7 +520,6 @@ export const useOmBarnet = (
         feltId: OmBarnetSpørsmålsId.søkerBorMedAndreForelder,
         skalFeltetVises: avhengigheter => {
             return (
-                barnErUnder16År(gjeldendeBarn) &&
                 gjeldendeBarn[barnDataKeySpørsmål.andreForelderErDød].svar === ESvar.NEI &&
                 avhengigheter &&
                 avhengigheter.søkerHarBoddMedAndreForelder &&

--- a/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.tsx
@@ -61,6 +61,8 @@ import { idNummerLand } from '../EøsSteg/idnummerUtils';
 
 import { OmBarnetSpørsmålsId } from './spørsmål';
 
+const barnErUnder16År = (barnet: IBarnMedISøknad): boolean => Number(barnet.alder) < 16;
+
 export const useOmBarnet = (
     barnetsUuid: BarnetsId
 ): {
@@ -518,6 +520,7 @@ export const useOmBarnet = (
         feltId: OmBarnetSpørsmålsId.søkerBorMedAndreForelder,
         skalFeltetVises: avhengigheter => {
             return (
+                barnErUnder16År(gjeldendeBarn) &&
                 gjeldendeBarn[barnDataKeySpørsmål.andreForelderErDød].svar === ESvar.NEI &&
                 avhengigheter &&
                 avhengigheter.søkerHarBoddMedAndreForelder &&
@@ -917,8 +920,9 @@ export const useOmBarnet = (
                     case Dokumentasjonsbehov.MEKLINGSATTEST:
                         return genererOppdatertDokumentasjon(
                             dok,
-                            gjeldendeBarn[barnDataKeySpørsmål.andreForelderErDød].svar ===
-                                ESvar.NEI &&
+                            barnErUnder16År(gjeldendeBarn) &&
+                                gjeldendeBarn[barnDataKeySpørsmål.andreForelderErDød].svar ===
+                                    ESvar.NEI &&
                                 søkerHarBoddMedAndreForelder.verdi === ESvar.JA &&
                                 borMedAndreForelderCheckbox.verdi === ESvar.NEI,
                             gjeldendeBarn.id


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: NAV-22388
Dersom man søker utvidet barnetrygd for barn over 16 år skal vi ikke be om meklingsattest. Kun for barn under 16 år. 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
For barn med ubestemt fødselsdato i PDL og barn som søker selv har lagt til manuelt i søknaden, beregner vi ikke alder og vil fremdeles be om meklingsattest.

Fint om dere ser over om jeg har vært for naiv i løsningen min 😇 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
Har testet manuelt

  
### 👀 Screen shots
Gitt barn født 01.01.08 (16 år) ber vi ikke om meklingsattest hverken i infoboks eller på dokumentasjonssiden:
<img width="623" alt="Screenshot 2024-09-11 at 13 02 56" src="https://github.com/user-attachments/assets/9a442d1b-d10e-4627-be47-bd877e89f884">
<img width="589" alt="Screenshot 2024-09-11 at 13 02 40" src="https://github.com/user-attachments/assets/54c732ac-ec43-415c-a259-b09a1e0fe626">

