### PR TITLE
Legger til sanity tekster i velg barn

### DIFF
--- a/src/frontend/components/Felleskomponenter/SkjemaCheckbox/SkjemaCheckboxForSanity.tsx
+++ b/src/frontend/components/Felleskomponenter/SkjemaCheckbox/SkjemaCheckboxForSanity.tsx
@@ -1,0 +1,40 @@
+import React, { ReactNode } from 'react';
+
+import { Checkbox, ErrorMessage } from '@navikt/ds-react';
+import { ESvar } from '@navikt/familie-form-elements';
+import { Felt } from '@navikt/familie-skjema';
+
+import useFørsteRender from '../../../hooks/useFørsteRender';
+
+interface SkjemaFeltInputForSanityProps {
+    felt: Felt<ESvar>;
+    visFeilmeldinger?: boolean;
+    label: ReactNode;
+}
+
+export const SkjemaCheckboxForSanity: React.FC<SkjemaFeltInputForSanityProps> = ({
+    felt,
+    visFeilmeldinger = false,
+    label,
+}) => {
+    useFørsteRender(() => {
+        felt.validerOgSettFelt(felt.verdi);
+    });
+
+    return felt.erSynlig ? (
+        <div>
+            <Checkbox
+                id={felt.id}
+                checked={felt.verdi === ESvar.JA}
+                onChange={event =>
+                    felt.validerOgSettFelt(event.target.checked ? ESvar.JA : ESvar.NEI)
+                }
+            >
+                {label}
+            </Checkbox>
+            {visFeilmeldinger && felt.feilmelding && (
+                <ErrorMessage>{felt.feilmelding}</ErrorMessage>
+            )}
+        </div>
+    ) : null;
+};

--- a/src/frontend/components/Felleskomponenter/SkjemaFeltInput/SkjemaFeltInputForSanity.tsx
+++ b/src/frontend/components/Felleskomponenter/SkjemaFeltInput/SkjemaFeltInputForSanity.tsx
@@ -45,6 +45,7 @@ export const SkjemaFeltInputForSanity: React.FC<SkjemaFeltInputForSanityProps> =
             autoComplete={autoComplete}
             disabled={disabled}
             $fullbredde={fullbredde}
+            data-testid={felt.id}
         />
     ) : null;
 };

--- a/src/frontend/components/Felleskomponenter/SkjemaFeltInput/SkjemaFeltInputForSanity.tsx
+++ b/src/frontend/components/Felleskomponenter/SkjemaFeltInput/SkjemaFeltInputForSanity.tsx
@@ -1,0 +1,50 @@
+import React, { ReactNode } from 'react';
+
+import styled from 'styled-components';
+
+import { TextField } from '@navikt/ds-react';
+import { Felt } from '@navikt/familie-skjema';
+
+interface SkjemaFeltInputForSanityProps {
+    // eslint-disable-next-line
+    felt: Felt<any>;
+    visFeilmeldinger: boolean;
+    label: ReactNode;
+    språkValues?: Record<string, ReactNode>;
+    description?: ReactNode;
+    autoComplete?: 'on' | 'off';
+    disabled?: boolean;
+    fullbredde?: boolean;
+}
+
+const StyledTextField = styled(TextField)<{ $fullbredde: boolean }>`
+    width: ${props => (props.$fullbredde ? '100%' : 'fit-content')};
+`;
+
+/**
+ * Henter input props fra felt, og fra props. Props overstyrer felt.
+ */
+export const SkjemaFeltInputForSanity: React.FC<SkjemaFeltInputForSanityProps> = props => {
+    const {
+        felt,
+        label,
+        visFeilmeldinger,
+        description,
+        autoComplete = 'off',
+        disabled,
+        fullbredde = true,
+    } = props;
+    const navInputPropsFraFeltHook = felt.hentNavInputProps(visFeilmeldinger);
+
+    return felt.erSynlig ? (
+        <StyledTextField
+            label={label}
+            description={description}
+            {...navInputPropsFraFeltHook}
+            maxLength={500}
+            autoComplete={autoComplete}
+            disabled={disabled}
+            $fullbredde={fullbredde}
+        />
+    ) : null;
+};

--- a/src/frontend/components/Felleskomponenter/SøkerMåBrukePDF.tsx
+++ b/src/frontend/components/Felleskomponenter/SøkerMåBrukePDF.tsx
@@ -1,44 +1,25 @@
-import React, { FC } from 'react';
+import React, { FC, ReactNode } from 'react';
 
-import styled from 'styled-components';
+import { Alert, Box } from '@navikt/ds-react';
 
-import { Alert, BodyShort, Label } from '@navikt/ds-react';
+import { useApp } from '../../context/AppContext';
 
-import EksternLenke from './EksternLenke/EksternLenke';
-import Informasjonsbolk from './Informasjonsbolk/Informasjonsbolk';
-import SpråkTekst from './SpråkTekst/SpråkTekst';
+import TekstBlock from './Sanity/TekstBlock';
 
-interface Props {
-    advarselTekstId: string;
-    utfyllendeAdvarselInfoId?: string;
+interface SøkerMåBrukePDFProps {
+    advarselTekst: ReactNode;
 }
 
-const LenkeContainer = styled.div`
-    margin: 1.75rem 0;
-`;
+export const SøkerMåBrukePDF: FC<SøkerMåBrukePDFProps> = ({ advarselTekst }) => {
+    const { tekster } = useApp();
+    const { brukPDFKontantstoette } = tekster().FELLES.kanIkkeBrukeSoeknad;
 
-export const SøkerMåBrukePDF: FC<Props> = ({ advarselTekstId, utfyllendeAdvarselInfoId }) => {
     return (
-        <Informasjonsbolk aria-live={'polite'}>
-            <Alert variant={'warning'} inline>
-                <SpråkTekst id={advarselTekstId} />
-            </Alert>
-            {utfyllendeAdvarselInfoId && (
-                <Informasjonsbolk>
-                    <Label as="p">
-                        <SpråkTekst id={utfyllendeAdvarselInfoId} />
-                    </Label>
-                </Informasjonsbolk>
-            )}
-            <LenkeContainer>
-                <EksternLenke
-                    lenkeSpråkId={'felles.bruk-pdfskjema.lenke'}
-                    lenkeTekstSpråkId={'felles.bruk-pdfskjema.lenketekst'}
-                />
-            </LenkeContainer>
-            <BodyShort>
-                <SpråkTekst id={'felles.sende-skjema.info'} />
-            </BodyShort>
-        </Informasjonsbolk>
+        <Alert variant={'warning'}>
+            {advarselTekst}
+            <Box marginBlock="3 0">
+                <TekstBlock block={brukPDFKontantstoette} />
+            </Box>
+        </Alert>
     );
 };

--- a/src/frontend/components/Felleskomponenter/SøkerMåBrukePDF.tsx
+++ b/src/frontend/components/Felleskomponenter/SøkerMåBrukePDF.tsx
@@ -15,7 +15,7 @@ export const SøkerMåBrukePDF: FC<SøkerMåBrukePDFProps> = ({ advarselTekst })
     const { brukPDFKontantstoette } = tekster().FELLES.kanIkkeBrukeSoeknad;
 
     return (
-        <Alert variant={'warning'}>
+        <Alert variant={'warning'} data-testid="søker-må-bruke-pdf">
             {advarselTekst}
             <Box marginBlock="3 0">
                 <TekstBlock block={brukPDFKontantstoette} />

--- a/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/Barnekort.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/Barnekort.tsx
@@ -123,6 +123,7 @@ const Barnekort: React.FC<IBarnekortProps> = ({
                     checked={erMedISøknad}
                     aria-label={`${plainTekst(soekOmYtelseForBarnetSjekkboks)} ${barn.navn}`}
                     onChange={() => velgBarnCallback(barn, erMedISøknad)}
+                    data-testid={`søk-om-barnetrygd-for-barn-${barn.ident}`}
                 >
                     <TekstBlock block={soekOmYtelseForBarnetSjekkboks} />
                 </Checkbox>
@@ -132,6 +133,7 @@ const Barnekort: React.FC<IBarnekortProps> = ({
                         variant="tertiary"
                         onClick={() => fjernBarnCallback(barn.id)}
                         icon={<TrashFillIcon aria-hidden />}
+                        data-testid="fjern-barn-knapp"
                     >
                         <TekstBlock block={knappetekst} />
                     </Button>

--- a/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/Barnekort.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/Barnekort.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { useIntl } from 'react-intl';
 import styled from 'styled-components';
 
 import { TrashFillIcon } from '@navikt/aksel-icons';
@@ -19,6 +18,7 @@ import { IBarn } from '../../../../typer/person';
 import { ESanitySteg } from '../../../../typer/sanity/sanity';
 import { hentBostedSpråkId } from '../../../../utils/språk';
 import { formaterFnr, uppercaseFørsteBokstav } from '../../../../utils/visning';
+import TekstBlock from '../../../Felleskomponenter/Sanity/TekstBlock';
 import SpråkTekst from '../../../Felleskomponenter/SpråkTekst/SpråkTekst';
 import { TilfeldigBarnIkon } from '../../../Felleskomponenter/TilfeldigBarnIkon/TilfeldigBarnIkon';
 
@@ -57,10 +57,19 @@ const Barnekort: React.FC<IBarnekortProps> = ({
     fjernBarnCallback,
 }) => {
     const { plainTekst, tekster } = useApp();
-    const { formatMessage } = useIntl();
     const {
         søknad: { barnRegistrertManuelt },
     } = useApp();
+
+    const teksterForSteg = tekster().VELG_BARN;
+    const {
+        alderLabel,
+        aar,
+        registrertBostedLabel,
+        soekOmYtelseForBarnetSjekkboks,
+        foedselsnummerLabel,
+        navnErstatterForAdressesperre,
+    } = teksterForSteg;
 
     const erMedISøknad = !!barnSomSkalVæreMed.find(barnMedISøknad => barnMedISøknad.id === barn.id);
 
@@ -71,6 +80,8 @@ const Barnekort: React.FC<IBarnekortProps> = ({
     const fødselsnummerTekst = !barn.adressebeskyttelse
         ? formaterFnr(barn.ident)
         : uppercaseFørsteBokstav(plainTekst(tekster()[ESanitySteg.FELLES].frittståendeOrd.skjult));
+
+    const knappetekst = tekster()[ESanitySteg.FELLES].modaler.leggTilBarn.fjernKnapp;
 
     return (
         <BarnekortContainer>
@@ -84,25 +95,25 @@ const Barnekort: React.FC<IBarnekortProps> = ({
                 </Bleed>
                 <Heading level="3" size="medium">
                     {barn.adressebeskyttelse ? (
-                        <SpråkTekst id={'hvilkebarn.barn.anonym'} />
+                        <TekstBlock block={navnErstatterForAdressesperre} />
                     ) : (
                         barn.navn
                     )}
                 </Heading>
                 <HGrid gap="6" columns={{ sm: 1, md: '2fr 1fr 3fr' }}>
                     <BarnekortInfo
-                        labelId={'hvilkebarn.barn.fødselsnummer'}
+                        label={<TekstBlock block={foedselsnummerLabel} />}
                         verdi={fødselsnummerTekst}
                     />
                     {barn.alder && ( // Barn med undefined fødselsdato i pdl eller som søker har lagt inn selv har alder -null-
                         <BarnekortInfo
-                            labelId={'hvilkebarn.barn.alder'}
-                            verdi={<SpråkTekst id={'felles.år'} values={{ alder: barn.alder }} />}
+                            label={<TekstBlock block={alderLabel} />}
+                            verdi={`${barn.alder} ${plainTekst(aar)}`}
                         />
                     )}
                     {!erRegistrertManuelt && (
                         <BarnekortInfo
-                            labelId={'hvilkebarn.barn.bosted'}
+                            label={<TekstBlock block={registrertBostedLabel} />}
                             verdi={<SpråkTekst id={hentBostedSpråkId(barn)} />}
                         />
                     )}
@@ -110,14 +121,10 @@ const Barnekort: React.FC<IBarnekortProps> = ({
                 <Divider />
                 <Checkbox
                     checked={erMedISøknad}
-                    aria-label={
-                        formatMessage({ id: 'hvilkebarn.barn.søk-om.spm' }) + ` (${barn.navn})`
-                    }
+                    aria-label={`${plainTekst(soekOmYtelseForBarnetSjekkboks)} ${barn.navn}`}
                     onChange={() => velgBarnCallback(barn, erMedISøknad)}
                 >
-                    {formatMessage({
-                        id: 'hvilkebarn.barn.søk-om.spm',
-                    })}
+                    <TekstBlock block={soekOmYtelseForBarnetSjekkboks} />
                 </Checkbox>
                 {erRegistrertManuelt && (
                     <Button
@@ -126,7 +133,7 @@ const Barnekort: React.FC<IBarnekortProps> = ({
                         onClick={() => fjernBarnCallback(barn.id)}
                         icon={<TrashFillIcon aria-hidden />}
                     >
-                        <SpråkTekst id={'hvilkebarn.fjern-barn.knapp'} />
+                        <TekstBlock block={knappetekst} />
                     </Button>
                 )}
             </VStack>

--- a/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/BarnekortInfo.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/BarnekortInfo.tsx
@@ -2,17 +2,13 @@ import React, { ReactNode } from 'react';
 
 import { Box, Label, BodyShort } from '@navikt/ds-react';
 
-import SpråkTekst from '../../../Felleskomponenter/SpråkTekst/SpråkTekst';
-
-export const BarnekortInfo: React.FC<{ labelId: string; verdi: ReactNode }> = ({
-    labelId,
+export const BarnekortInfo: React.FC<{ label: ReactNode; verdi: ReactNode }> = ({
+    label,
     verdi,
 }) => {
     return (
         <Box>
-            <Label as="p">
-                <SpråkTekst id={labelId} />
-            </Label>
+            <Label as="p">{label}</Label>
             <BodyShort>{verdi}</BodyShort>
         </Box>
     );

--- a/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/LeggTilBarnModal.test.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/LeggTilBarnModal.test.tsx
@@ -1,26 +1,40 @@
 import React from 'react';
 
-import { act, render } from '@testing-library/react';
+import { act, render, within } from '@testing-library/react';
 
-import { silenceConsoleErrors, TestProvidere } from '../../../../utils/testing';
+import { ESvar } from '@navikt/familie-form-elements';
+
+import { silenceConsoleErrors, spyOnUseApp, TestProvidere } from '../../../../utils/testing';
 
 import LeggTilBarnModal from './LeggTilBarnModal';
 
-describe('LeggTilBarnModal', function () {
+describe('LeggTilBarnModal', () => {
     test('Test at advarsel om fnr vises hvis man huker av for at barnet ikke har fått fnr enda', () => {
         silenceConsoleErrors();
+        spyOnUseApp({});
 
-        const { getByText } = render(
+        const { getByTestId } = render(
             <TestProvidere>
                 <LeggTilBarnModal erÅpen={true} lukkModal={jest.fn()} />
             </TestProvidere>
         );
-        const erFødtJa = getByText(/felles.svaralternativ.ja/);
-        act(() => erFødtJa.click());
-        const harIkkFnrCheckbox = getByText(/hvilkebarn.leggtilbarn.ikke-fått-fnr.spm/);
+
+        const erFødtSpørsmål = getByTestId('legg-til-barn-er-født');
+
+        const erFødtJaKnapp = within(erFødtSpørsmål)
+            .getAllByRole('radio')
+            .find(radio => radio.getAttribute('value') === ESvar.JA);
+        expect(erFødtJaKnapp).toBeDefined();
+        act(() => erFødtJaKnapp!.click());
+
+        const fødselsnummerEllerDNummerContainer = getByTestId(
+            'fødselsnummer-eller-d-nummer-container'
+        );
+
+        const harIkkFnrCheckbox = within(fødselsnummerEllerDNummerContainer).getByRole('checkbox');
         act(() => harIkkFnrCheckbox.click());
 
-        const advarsel = getByText(/hvilkebarn.leggtilbarn.ikke-fått-fnr.alert/);
+        const advarsel = getByTestId('søker-må-bruke-pdf');
         expect(advarsel).toBeInTheDocument();
     });
 });

--- a/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/LeggTilBarnModal.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/LeggTilBarnModal.tsx
@@ -93,7 +93,7 @@ const LeggTilBarnModal: React.FC<{
                             />
                         </KomponentGruppe>
                     </Fieldset>
-                    <div aria-live="polite">
+                    <div aria-live="polite" data-testid="fødselsnummer-eller-d-nummer-container">
                         <SkjemaFeltInputForSanity
                             felt={skjema.felter.ident}
                             visFeilmeldinger={skjema.visFeilmeldinger}

--- a/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/LeggTilBarnModal.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/LeggTilBarnModal.tsx
@@ -4,16 +4,17 @@ import { Alert, Fieldset } from '@navikt/ds-react';
 import { ESvar } from '@navikt/familie-form-elements';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 
+import { useApp } from '../../../../context/AppContext';
+import { Typografi } from '../../../../typer/sanity/sanity';
 import { visFeiloppsummering } from '../../../../utils/hjelpefunksjoner';
-import JaNeiSpm from '../../../Felleskomponenter/JaNeiSpm/JaNeiSpm';
+import JaNeiSpmForSanity from '../../../Felleskomponenter/JaNeiSpm/JaNeiSpmForSanity';
 import KomponentGruppe from '../../../Felleskomponenter/KomponentGruppe/KomponentGruppe';
-import { SkjemaCheckbox } from '../../../Felleskomponenter/SkjemaCheckbox/SkjemaCheckbox';
+import TekstBlock from '../../../Felleskomponenter/Sanity/TekstBlock';
+import { SkjemaCheckboxForSanity } from '../../../Felleskomponenter/SkjemaCheckbox/SkjemaCheckboxForSanity';
 import { SkjemaFeiloppsummering } from '../../../Felleskomponenter/SkjemaFeiloppsummering/SkjemaFeiloppsummering';
-import { SkjemaFeltInput } from '../../../Felleskomponenter/SkjemaFeltInput/SkjemaFeltInput';
+import { SkjemaFeltInputForSanity } from '../../../Felleskomponenter/SkjemaFeltInput/SkjemaFeltInputForSanity';
 import SkjemaModal from '../../../Felleskomponenter/SkjemaModal/SkjemaModal';
-import SpråkTekst from '../../../Felleskomponenter/SpråkTekst/SpråkTekst';
 import { SøkerMåBrukePDF } from '../../../Felleskomponenter/SøkerMåBrukePDF';
-import { VelgBarnSpørsmålId, velgBarnSpørsmålSpråkId } from '../spørsmål';
 
 import { useLeggTilBarn } from './useLeggTilBarn';
 
@@ -23,6 +24,18 @@ const LeggTilBarnModal: React.FC<{
 }> = ({ erÅpen, lukkModal }) => {
     const { skjema, nullstillSkjema, valideringErOk, leggTilBarn, validerFelterOgVisFeilmelding } =
         useLeggTilBarn();
+    const { tekster } = useApp();
+
+    const teksterForLeggTilBarnModal = tekster().FELLES.modaler.leggTilBarn;
+    const {
+        erBarnetFoedt,
+        ikkeFoedtAlert,
+        barnetsNavnSubtittel,
+        fornavn,
+        etternavn,
+        foedselsnummerEllerDNummer,
+        foedselsnummerAlert,
+    } = teksterForLeggTilBarnModal;
 
     const submitOgLukk = () => {
         if (!validerFelterOgVisFeilmelding()) {
@@ -43,78 +56,60 @@ const LeggTilBarnModal: React.FC<{
             onAvbrytCallback={nullstillSkjema}
         >
             <KomponentGruppe>
-                <JaNeiSpm
+                <JaNeiSpmForSanity
                     skjema={skjema}
                     felt={skjema.felter.erFødt}
-                    spørsmålTekstId={velgBarnSpørsmålSpråkId[VelgBarnSpørsmålId.leggTilBarnErFødt]}
+                    spørsmålDokument={erBarnetFoedt}
                 />
                 {skjema.felter.erFødt.verdi === ESvar.NEI && (
                     <Alert variant={'warning'} inline>
-                        <SpråkTekst id={'hvilkebarn.leggtilbarn.barn-ikke-født.alert'} />
+                        <TekstBlock block={ikkeFoedtAlert} typografi={Typografi.BodyShort} />
                     </Alert>
                 )}
             </KomponentGruppe>
             {skjema.felter.erFødt.valideringsstatus === Valideringsstatus.OK && (
                 <>
                     <Fieldset
-                        legend={
-                            <SpråkTekst
-                                id={velgBarnSpørsmålSpråkId[VelgBarnSpørsmålId.barnetsNavn]}
-                            />
-                        }
+                        legend={<TekstBlock block={barnetsNavnSubtittel} />}
                         aria-live="polite"
                     >
                         <KomponentGruppe aria-live="polite">
-                            <SkjemaFeltInput
+                            <SkjemaFeltInputForSanity
                                 felt={skjema.felter.fornavn}
                                 visFeilmeldinger={skjema.visFeilmeldinger}
-                                labelSpråkTekstId={
-                                    velgBarnSpørsmålSpråkId[VelgBarnSpørsmålId.leggTilBarnFornavn]
-                                }
+                                label={<TekstBlock block={fornavn.sporsmal} />}
                                 disabled={skjema.felter.navnetErUbestemt.verdi === ESvar.JA}
                             />
-                            <SkjemaFeltInput
+                            <SkjemaFeltInputForSanity
                                 felt={skjema.felter.etternavn}
                                 visFeilmeldinger={skjema.visFeilmeldinger}
-                                labelSpråkTekstId={
-                                    velgBarnSpørsmålSpråkId[VelgBarnSpørsmålId.leggTilBarnEtternavn]
-                                }
+                                label={<TekstBlock block={etternavn.sporsmal} />}
                                 disabled={skjema.felter.navnetErUbestemt.verdi === ESvar.JA}
                             />
-                            <SkjemaCheckbox
+                            <SkjemaCheckboxForSanity
                                 felt={skjema.felter.navnetErUbestemt}
                                 visFeilmeldinger={skjema.visFeilmeldinger}
-                                labelSpråkTekstId={
-                                    velgBarnSpørsmålSpråkId[
-                                        VelgBarnSpørsmålId.leggTilBarnNavnIkkeBestemt
-                                    ]
-                                }
+                                label={<TekstBlock block={etternavn.checkboxLabel} />}
                             />
                         </KomponentGruppe>
                     </Fieldset>
                     <div aria-live="polite">
-                        <SkjemaFeltInput
+                        <SkjemaFeltInputForSanity
                             felt={skjema.felter.ident}
                             visFeilmeldinger={skjema.visFeilmeldinger}
-                            labelSpråkTekstId={
-                                velgBarnSpørsmålSpråkId[VelgBarnSpørsmålId.leggTilBarnFnr]
-                            }
+                            label={<TekstBlock block={foedselsnummerEllerDNummer.sporsmal} />}
                             disabled={skjema.felter.ikkeFåttIdentChecked.verdi === ESvar.JA}
                         />
-                        <SkjemaCheckbox
+                        <SkjemaCheckboxForSanity
                             felt={skjema.felter.ikkeFåttIdentChecked}
                             visFeilmeldinger={skjema.visFeilmeldinger}
-                            labelSpråkTekstId={
-                                velgBarnSpørsmålSpråkId[VelgBarnSpørsmålId.leggTilBarnIkkeFåttFnr]
-                            }
+                            label={<TekstBlock block={foedselsnummerEllerDNummer.checkboxLabel} />}
                         />
-                        {skjema.felter.ikkeFåttIdentChecked.verdi === ESvar.JA && (
-                            <SøkerMåBrukePDF
-                                advarselTekstId={'hvilkebarn.leggtilbarn.ikke-fått-fnr.alert'}
-                            />
-                        )}
                     </div>
                 </>
+            )}
+            {skjema.felter.ikkeFåttIdentChecked.verdi === ESvar.JA && (
+                <SøkerMåBrukePDF advarselTekst={<TekstBlock block={foedselsnummerAlert} />} />
             )}
             {visFeiloppsummering(skjema) && <SkjemaFeiloppsummering skjema={skjema} />}
         </SkjemaModal>

--- a/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/NyttBarnKort.test.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/NyttBarnKort.test.tsx
@@ -33,7 +33,7 @@ describe('NyttBarnKort', () => {
         jest.spyOn(fnrvalidator, 'idnr').mockReturnValue({ status: 'valid', type: 'fnr' });
         const åpen: number[] = [];
 
-        const { getByRole, getByText, getByTestId, rerender } = render(
+        const { getByRole, getByTestId, rerender } = render(
             <TestProvidere>
                 <NyttBarnKort
                     onLeggTilBarn={() => {
@@ -80,25 +80,15 @@ describe('NyttBarnKort', () => {
         const erFødt = getByTestId('legg-til-barn-er-født');
         expect(erFødt).toBeInTheDocument();
 
-        // Språktekst-id for Ja er 'ja'
-        // const jaKnapp = getByText('felles.svaralternativ.ja');
-        // act(() => jaKnapp.click());
-
         const jaKnapp = within(erFødt)
             .getAllByRole('radio')
             .find(radio => radio.getAttribute('value') === ESvar.JA);
         expect(jaKnapp).toBeDefined();
         act(() => jaKnapp!.click());
 
-        const fornavnLabel = getByText('hvilkebarn.leggtilbarn.fornavn.spm');
-        const etternavnLabel = getByText('hvilkebarn.leggtilbarn.etternavn.spm');
-        const idnrLabel = getByText('felles.fødsels-eller-dnummer.label');
-        expect(fornavnLabel).toBeInTheDocument();
-        expect(etternavnLabel).toBeInTheDocument();
-        expect(idnrLabel).toBeInTheDocument();
-        const fornavnInput = fornavnLabel.nextElementSibling || new Element();
-        const etternavnInput = etternavnLabel.nextElementSibling || new Element();
-        const idnrInput = idnrLabel.nextElementSibling || new Element();
+        const fornavnInput = getByTestId('legg-til-barn-fornavn');
+        const etternavnInput = getByTestId('legg-til-barn-etternavn');
+        const idnrInput = getByTestId('legg-til-barn-fnr');
 
         act(() => {
             fireEvent.input(fornavnInput, { target: { value: 'Sirius' } });

--- a/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/NyttBarnKort.test.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/NyttBarnKort.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, waitFor, within } from '@testing-library/react';
 
+import { ESvar } from '@navikt/familie-form-elements';
 import * as fnrvalidator from '@navikt/fnrvalidator';
 
 import {
@@ -76,12 +77,18 @@ describe('NyttBarnKort', () => {
         expect(leggTilKnappIModal).toBeInTheDocument();
         expect(leggTilKnappIModal).toHaveClass('navds-button--secondary');
 
-        const erFødt = getByText('hvilkebarn.leggtilbarn.barnfødt.spm');
+        const erFødt = getByTestId('legg-til-barn-er-født');
         expect(erFødt).toBeInTheDocument();
 
         // Språktekst-id for Ja er 'ja'
-        const jaKnapp = getByText('felles.svaralternativ.ja');
-        act(() => jaKnapp.click());
+        // const jaKnapp = getByText('felles.svaralternativ.ja');
+        // act(() => jaKnapp.click());
+
+        const jaKnapp = within(erFødt)
+            .getAllByRole('radio')
+            .find(radio => radio.getAttribute('value') === ESvar.JA);
+        expect(jaKnapp).toBeDefined();
+        act(() => jaKnapp!.click());
 
         const fornavnLabel = getByText('hvilkebarn.leggtilbarn.fornavn.spm');
         const etternavnLabel = getByText('hvilkebarn.leggtilbarn.etternavn.spm');

--- a/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/NyttBarnKort.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/NyttBarnKort.tsx
@@ -3,17 +3,16 @@ import React from 'react';
 import { BodyShort, Button } from '@navikt/ds-react';
 
 import { useApp } from '../../../../context/AppContext';
-import { ILeggTilBarnTekstinnhold } from '../../../../typer/sanity/modaler/leggTilBarn';
-import { ESanitySteg } from '../../../../typer/sanity/sanity';
 import { BarnekortContainer } from '../Barnekort/BarnekortContainer';
-import { IVelgBarnTekstinnhold } from '../innholdTyper';
 
 export const NyttBarnKort: React.FC<{ onLeggTilBarn: () => void }> = ({ onLeggTilBarn }) => {
     const { tekster, plainTekst } = useApp();
-    const teksterForSteg: IVelgBarnTekstinnhold = tekster()[ESanitySteg.VELG_BARN];
-    const teksterForLeggTilBarnModal: ILeggTilBarnTekstinnhold =
-        tekster()[ESanitySteg.FELLES].modaler.leggTilBarn;
+
+    const teksterForSteg = tekster().VELG_BARN;
     const { soekeForUregistrerteBarn } = teksterForSteg;
+
+    const teksterForLeggTilBarnModal = tekster().FELLES.modaler.leggTilBarn;
+    const { leggTilKnapp } = teksterForLeggTilBarnModal;
 
     return (
         <BarnekortContainer>
@@ -24,7 +23,7 @@ export const NyttBarnKort: React.FC<{ onLeggTilBarn: () => void }> = ({ onLeggTi
                 data-testid="leggTilBarnKnapp"
                 onClick={() => onLeggTilBarn()}
             >
-                {plainTekst(teksterForLeggTilBarnModal.leggTilKnapp)}
+                {plainTekst(leggTilKnapp)}
             </Button>
         </BarnekortContainer>
     );

--- a/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/NyttBarnKort.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/NyttBarnKort.tsx
@@ -20,7 +20,7 @@ export const NyttBarnKort: React.FC<{ onLeggTilBarn: () => void }> = ({ onLeggTi
             <Button
                 type="button"
                 variant="secondary"
-                data-testid="leggTilBarnKnapp"
+                data-testid="legg-til-barn-knapp"
                 onClick={() => onLeggTilBarn()}
             >
                 {plainTekst(leggTilKnapp)}

--- a/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.test.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.test.tsx
@@ -88,14 +88,13 @@ describe('VelgBarn', () => {
             søknad.barnInkludertISøknaden = nySøknad.barnInkludertISøknaden;
         });
 
-        const { getByText, getByTestId } = render(
+        const { getByTestId } = render(
             <TestProvidere mocketNettleserHistorikk={['/velg-barn']}>
                 <VelgBarn />
             </TestProvidere>
         );
 
-        const fjernBarnKnapp = getByText(/hvilkebarn.fjern-barn.knapp/);
-
+        const fjernBarnKnapp = getByTestId('fjern-barn-knapp');
         act(() => fjernBarnKnapp.click());
 
         const gåVidere = getByTestId('neste-steg');
@@ -172,32 +171,29 @@ describe('VelgBarn', () => {
             søknad.barnInkludertISøknaden = nySøknad.barnInkludertISøknaden;
         });
 
-        const { getByText, getByTestId } = render(
+        const { getByTestId, getAllByRole } = render(
             <TestProvidere mocketNettleserHistorikk={['/velg-barn']}>
                 <VelgBarn />
             </TestProvidere>
         );
 
-        const fjernBarnKnapp = getByText(/hvilkebarn.fjern-barn.knapp/);
+        const fjernBarnKnapp = getByTestId('fjern-barn-knapp');
         act(() => fjernBarnKnapp.click());
 
-        const leggTilBarnKnapp = getByTestId('leggTilBarnKnapp');
+        const leggTilBarnKnapp = getByTestId('legg-til-barn-knapp');
         act(() => leggTilBarnKnapp.click());
 
         const leggTilKnappIModal = getByTestId('hvilkebarn.leggtilbarn.kort.knapp');
 
-        const jaKnapp = getByText('felles.svaralternativ.ja');
-        act(() => jaKnapp.click());
+        const jaKnapp = getAllByRole('radio').find(
+            radio => radio.getAttribute('value') === ESvar.JA
+        );
+        expect(jaKnapp).toBeDefined();
+        act(() => jaKnapp!.click());
 
-        const fornavnLabel = getByText('hvilkebarn.leggtilbarn.fornavn.spm');
-        const etternavnLabel = getByText('hvilkebarn.leggtilbarn.etternavn.spm');
-        const idnrLabel = getByText('felles.fødsels-eller-dnummer.label');
-        expect(fornavnLabel).toBeInTheDocument();
-        expect(etternavnLabel).toBeInTheDocument();
-        expect(idnrLabel).toBeInTheDocument();
-        const fornavnInput = fornavnLabel.nextElementSibling || new Element();
-        const etternavnInput = etternavnLabel.nextElementSibling || new Element();
-        const idnrInput = idnrLabel.nextElementSibling || new Element();
+        const fornavnInput = getByTestId('legg-til-barn-fornavn');
+        const etternavnInput = getByTestId('legg-til-barn-etternavn');
+        const idnrInput = getByTestId('legg-til-barn-fnr');
 
         act(() => {
             fireEvent.input(fornavnInput, { target: { value: manueltRegistrert.navn } });
@@ -229,13 +225,13 @@ describe('VelgBarn', () => {
         };
         spyOnUseApp(søknad);
 
-        const { getByLabelText } = render(
+        const { getByTestId } = render(
             <TestProvidere mocketNettleserHistorikk={['/velg-barn']}>
                 <VelgBarn />
             </TestProvidere>
         );
-        const checkbox: HTMLInputElement = getByLabelText(
-            /hvilkebarn.barn.søk-om.spm/
+        const checkbox: HTMLInputElement = getByTestId(
+            'søk-om-barnetrygd-for-barn-12345'
         ) as HTMLInputElement;
         act(() => checkbox.click());
 

--- a/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.tsx
@@ -2,14 +2,13 @@ import React from 'react';
 
 import { useApp } from '../../../context/AppContext';
 import { ESanitySteg } from '../../../typer/sanity/sanity';
+import TekstBlock from '../../Felleskomponenter/Sanity/TekstBlock';
 import useModal from '../../Felleskomponenter/SkjemaModal/useModal';
-import SpråkTekst from '../../Felleskomponenter/SpråkTekst/SpråkTekst';
 import Steg from '../../Felleskomponenter/Steg/Steg';
 
 import Barnekort from './Barnekort/Barnekort';
 import LeggTilBarnModal from './LeggTilBarn/LeggTilBarnModal';
 import { NyttBarnKort } from './LeggTilBarn/NyttBarnKort';
-import { VelgBarnSpørsmålId, velgBarnSpørsmålSpråkId } from './spørsmål';
 import { useVelgBarn } from './useVelgBarn';
 
 const VelgBarn: React.FC = () => {
@@ -30,12 +29,12 @@ const VelgBarn: React.FC = () => {
     const barn = barnFraRespons.concat(barnManueltLagtTil);
 
     const stegTekster = tekster()[ESanitySteg.VELG_BARN];
-    const { velgBarnGuide } = stegTekster;
+    const { velgBarnTittel, velgBarnGuide } = stegTekster;
 
     return (
         <>
             <Steg
-                tittel={<SpråkTekst id={velgBarnSpørsmålSpråkId[VelgBarnSpørsmålId.velgBarn]} />}
+                tittel={<TekstBlock block={velgBarnTittel} />}
                 guide={velgBarnGuide}
                 skjema={{
                     validerFelterOgVisFeilmelding,

--- a/src/frontend/components/SøknadsSteg/VelgBarn/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/innholdTyper.ts
@@ -4,4 +4,10 @@ export interface IVelgBarnTekstinnhold {
     velgBarnTittel: LocaleRecordBlock;
     velgBarnGuide: LocaleRecordBlock;
     soekeForUregistrerteBarn: LocaleRecordBlock;
+    alderLabel: LocaleRecordBlock;
+    aar: LocaleRecordBlock;
+    registrertBostedLabel: LocaleRecordBlock;
+    soekOmYtelseForBarnetSjekkboks: LocaleRecordBlock;
+    foedselsnummerLabel: LocaleRecordBlock;
+    navnErstatterForAdressesperre: LocaleRecordBlock;
 }

--- a/src/frontend/typer/sanity/modaler/leggTilBarn.ts
+++ b/src/frontend/typer/sanity/modaler/leggTilBarn.ts
@@ -1,6 +1,13 @@
-import { LocaleRecordBlock } from '../sanity';
+import { ISanitySpørsmålDokument, LocaleRecordBlock } from '../sanity';
 
 export interface ILeggTilBarnTekstinnhold {
     leggTilKnapp: LocaleRecordBlock;
     fjernKnapp: LocaleRecordBlock;
+    erBarnetFoedt: ISanitySpørsmålDokument;
+    ikkeFoedtAlert: LocaleRecordBlock;
+    barnetsNavnSubtittel: LocaleRecordBlock;
+    fornavn: ISanitySpørsmålDokument;
+    etternavn: ISanitySpørsmålDokument;
+    foedselsnummerEllerDNummer: ISanitySpørsmålDokument;
+    foedselsnummerAlert: LocaleRecordBlock;
 }

--- a/src/frontend/typer/sanity/modaler/leggTilBarn.ts
+++ b/src/frontend/typer/sanity/modaler/leggTilBarn.ts
@@ -2,4 +2,5 @@ import { LocaleRecordBlock } from '../sanity';
 
 export interface ILeggTilBarnTekstinnhold {
     leggTilKnapp: LocaleRecordBlock;
+    fjernKnapp: LocaleRecordBlock;
 }

--- a/src/frontend/typer/sanity/sanity.ts
+++ b/src/frontend/typer/sanity/sanity.ts
@@ -53,6 +53,7 @@ export enum Typografi {
 export const frittståendeOrdPrefix = 'FRITTSTAENDEORD';
 export const modalPrefix = 'MODAL';
 export const navigasjonPrefix = 'NAVIGASJON';
+export const kanIkkeBrukeSoeknadPrefix = 'KAN_IKKE_BRUKE_SOKNAD';
 
 export interface ISanitySpørsmålDokument extends SanityDokument {
     sporsmal: LocaleRecordBlock;

--- a/src/frontend/typer/sanity/tekstInnhold.ts
+++ b/src/frontend/typer/sanity/tekstInnhold.ts
@@ -61,6 +61,7 @@ export interface IFellesTekstInnhold {
     frittståendeOrd: IFrittståendeOrdTekstinnhold;
     modaler: IModalerTekstinnhold;
     navigasjon: INavigasjonTekstinnhold;
+    kanIkkeBrukeSoeknad: IKanIkkeBrukeSoeknadTekstinnhold;
 }
 
 export interface IFrittståendeOrdTekstinnhold {
@@ -153,4 +154,8 @@ export interface IForsideTekstinnhold {
     utvidetBarnetrygdAlert: LocaleRecordBlock;
     soekerDuUtvidet: ISanitySpørsmålDokument;
     mellomlagretAlert: LocaleRecordBlock;
+}
+
+export interface IKanIkkeBrukeSoeknadTekstinnhold {
+    brukPDFKontantstoette: LocaleRecordBlock;
 }

--- a/src/frontend/utils/sanity.ts
+++ b/src/frontend/utils/sanity.ts
@@ -21,6 +21,7 @@ import {
     ESanitySteg,
     FlettefeltVerdier,
     frittståendeOrdPrefix,
+    kanIkkeBrukeSoeknadPrefix,
     LocaleRecordBlock,
     LocaleRecordString,
     modalPrefix,
@@ -30,6 +31,7 @@ import {
 import {
     IFellesTekstInnhold,
     IFrittståendeOrdTekstinnhold,
+    IKanIkkeBrukeSoeknadTekstinnhold,
     IModalerTekstinnhold,
     INavigasjonTekstinnhold,
     ITekstinnhold,
@@ -163,6 +165,9 @@ export const transformerTilTekstinnhold = (alleDokumenter: SanityDokument[]): IT
         navigasjon: struktrerInnholdForFelles(
             dokumenterFiltrertPåPrefix(fellesDokumenter, navigasjonPrefix)
         ) as INavigasjonTekstinnhold,
+        kanIkkeBrukeSoeknad: struktrerInnholdForFelles(
+            dokumenterFiltrertPåPrefix(fellesDokumenter, kanIkkeBrukeSoeknadPrefix)
+        ) as IKanIkkeBrukeSoeknadTekstinnhold,
     };
     return tekstInnhold as ITekstinnhold;
 };


### PR DESCRIPTION
Favro: [NAV-22907](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22907)

### 💰 Hva forsøker du å løse i denne PR'en
- Bytter fra bruk av lokale tekster til Sanity i "Velg barn" steget.
- Endrer tester til å ta i bruk testid fremfor å søke etter tekster.
- Legger til Sanity komponenter for `SkjemaCheckboxForSanity` `SkjemaFeltInputForSanity`.
- Forbedrer `SøkerMåBrukePdf` komponenten til å ha likt tekstinnhold som i KS og endrer bruk av `Alert`.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Tester er endret, men ingen nye er lagt til ettersom ny funksjonalitet ikke er lagt til.

### 🤷‍♀ ️Hvor er det lurt å starte?
- Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
- Hovedsaklig ikke visuelle endringer ettersom oppgaven går ut på å endre hvordan tekster hentes.

#### `SøkerMåBrukePdf` Alert komponent
##### Før
![image](https://github.com/user-attachments/assets/bbc69743-161a-4765-a185-1477e105c706)

##### Etter
![image](https://github.com/user-attachments/assets/b27def89-2a61-457a-b53c-0dc8486893d3)