### PR TITLE
Endrer spørsmål-feilmeldinger til å kunne ta i bruk tekster fra Sanity

### DIFF
--- a/src/frontend/components/SøknadsSteg/OmDeg/useOmdeg.tsx
+++ b/src/frontend/components/SøknadsSteg/OmDeg/useOmdeg.tsx
@@ -9,6 +9,7 @@ import useJaNeiSpmFelt from '../../../hooks/useJaNeiSpmFelt';
 import { AlternativtSvarForInput } from '../../../typer/common';
 import { IUtenlandsperiode } from '../../../typer/perioder';
 import { IIdNummer } from '../../../typer/person';
+import { ESanitySteg } from '../../../typer/sanity/sanity';
 import { IOmDegFeltTyper } from '../../../typer/skjema';
 import { nullstilteEøsFelterForBarn } from '../../../utils/barn';
 import { nullstilteEøsFelterForSøker } from '../../../utils/søker';
@@ -16,6 +17,8 @@ import { flyttetPermanentFraNorge } from '../../../utils/utenlandsopphold';
 import SpråkTekst from '../../Felleskomponenter/SpråkTekst/SpråkTekst';
 import { UtenlandsoppholdSpørsmålId } from '../../Felleskomponenter/UtenlandsoppholdModal/spørsmål';
 import { idNummerLandMedPeriodeType, PeriodeType } from '../EøsSteg/idnummerUtils';
+
+import { IOmDegTekstinnhold } from './innholdTyper';
 
 export const useOmdeg = (): {
     skjema: ISkjema<IOmDegFeltTyper, string>;
@@ -27,22 +30,25 @@ export const useOmdeg = (): {
     fjernUtenlandsperiode: (periode: IUtenlandsperiode) => void;
     utenlandsperioder: IUtenlandsperiode[];
 } => {
-    const { søknad, settSøknad } = useApp();
+    const { søknad, settSøknad, tekster } = useApp();
     const { erEøsLand } = useEøs();
     const søker = søknad.søker;
     const [utenlandsperioder, settUtenlandsperioder] = useState<IUtenlandsperiode[]>(
         søker.utenlandsperioder
     );
     const { skalTriggeEøsForSøker, søkerTriggerEøs, settSøkerTriggerEøs } = useEøs();
+    const teksterForSteg: IOmDegTekstinnhold = tekster()[ESanitySteg.OM_DEG];
 
     const borPåRegistrertAdresse = useJaNeiSpmFelt({
         søknadsfelt: søker.borPåRegistrertAdresse,
+        feilmelding: teksterForSteg.borPaaRegistrertAdresse.feilmelding,
         feilmeldingSpråkId: 'omdeg.borpådenneadressen.feilmelding',
         skalSkjules: !søker.adresse || søker.adressebeskyttelse,
     });
 
     const værtINorgeITolvMåneder = useJaNeiSpmFelt({
         søknadsfelt: søker.værtINorgeITolvMåneder,
+        feilmelding: teksterForSteg.vaertINorgeITolvMaaneder.feilmelding,
         feilmeldingSpråkId: 'omdeg.oppholdtsammenhengende.feilmelding',
     });
 
@@ -64,6 +70,7 @@ export const useOmdeg = (): {
 
     const planleggerÅBoINorgeTolvMnd = useJaNeiSpmFelt({
         søknadsfelt: søker.planleggerÅBoINorgeTolvMnd,
+        feilmelding: teksterForSteg.planleggerAaBoINorgeTolvMnd.feilmelding,
         feilmeldingSpråkId: 'omdeg.planlagt-opphold-sammenhengende.feilmelding',
         avhengigheter: {
             værtINorgeITolvMåneder: { hovedSpørsmål: værtINorgeITolvMåneder },

--- a/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummering.test.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummering.test.tsx
@@ -51,7 +51,7 @@ describe('Oppsummering', () => {
         });
         spyOnUseApp(søknad);
 
-        const { getByText, findByTestId } = render(
+        const { container, findByTestId } = render(
             <TestProvidere mocketNettleserHistorikk={['/oppsummering']}>
                 <Oppsummering />
                 <LesUtLocation />
@@ -60,12 +60,12 @@ describe('Oppsummering', () => {
         const gåVidere = await findByTestId('neste-steg');
         await act(() => gåVidere.click());
 
-        const feilmelding = getByText('omdeg.oppholdtsammenhengende.feilmelding');
+        const feilOppsummering = container.getElementsByClassName('navds-error-summary')[0];
 
         const location = await findByTestId('location');
         expect(JSON.parse(location.innerHTML).hash).toEqual('#omdeg-feil');
 
-        expect(feilmelding).toBeInTheDocument();
+        expect(feilOppsummering).toBeInTheDocument();
     }, 10000);
 
     it('går til dokumentasjon med gyldig søknad', async () => {

--- a/src/frontend/hooks/useJaNeiSpmFelt.tsx
+++ b/src/frontend/hooks/useJaNeiSpmFelt.tsx
@@ -6,6 +6,8 @@ import { ESvar } from '@navikt/familie-form-elements';
 import { feil, Felt, FeltState, ok, useFelt, Valideringsstatus } from '@navikt/familie-skjema';
 
 import SpråkTekst from '../components/Felleskomponenter/SpråkTekst/SpråkTekst';
+import { useApp } from '../context/AppContext';
+import { FlettefeltVerdier, LocaleRecordBlock } from '../typer/sanity/sanity';
 import { ISøknadSpørsmål } from '../typer/spørsmål';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -40,20 +42,25 @@ export const erRelevanteAvhengigheterValidert = (avhengigheter: { [key: string]:
 
 const useJaNeiSpmFelt = ({
     søknadsfelt,
+    feilmelding,
     feilmeldingSpråkId,
     avhengigheter,
     nullstillVedAvhengighetEndring = false,
     skalSkjules = false,
+    flettefelter,
     feilmeldingSpråkVerdier,
 }: {
     søknadsfelt?: ISøknadSpørsmål<ESvar | null>;
+    feilmelding?: LocaleRecordBlock;
     feilmeldingSpråkId: string;
     avhengigheter?: { [key: string]: FeltGruppe | undefined };
     nullstillVedAvhengighetEndring?: boolean;
     skalSkjules?: boolean;
+    flettefelter?: FlettefeltVerdier;
     feilmeldingSpråkVerdier?: { [key: string]: ReactNode };
 }) => {
     const [harBlittVist, settHarBlittVist] = useState<boolean>(!avhengigheter);
+    const { plainTekst } = useApp();
 
     return useFelt<ESvar | null>({
         feltId: søknadsfelt ? søknadsfelt.id : uuidv4(),
@@ -64,7 +71,11 @@ const useJaNeiSpmFelt = ({
                 ? ok(felt)
                 : feil(
                       felt,
-                      <SpråkTekst id={feilmeldingSpråkId} values={feilmeldingSpråkVerdier} />
+                      feilmelding ? (
+                          plainTekst(feilmelding, { ...flettefelter })
+                      ) : (
+                          <SpråkTekst id={feilmeldingSpråkId} values={feilmeldingSpråkVerdier} />
+                      )
                   );
         },
         skalFeltetVises: (avhengigheter: { [key: string]: FeltGruppe }) => {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
- Endrer spørsmål-feilmeldinger til å kunne ta i bruk tekster fra Sanity (likt som i KS).
- Legger til Sanity feilmeldinger for spørsmål i "Om deg" steget.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Ikke nødvendig ut fra hva jeg kan se.
- Tester er ikke fjernet eller lagt til, men `Oppsummering.test.tsx` > `stopper fra å gå videre hvis søknaden har mangler` er endret ettersom den tidligere var basert på tekstinnhold som ikke er tilgjengelig fra Sanity (ettersom Sanity-teskter mockes).

### 🤷‍♀ ️Hvor er det lurt å starte?
- Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen visuelle endringer.