### PR TITLE
Bytter til bruk av Sanity tekster for OmDegOppsummering

### DIFF
--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmDegOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmDegOppsummering.tsx
@@ -14,13 +14,7 @@ import { genererAdresseVisning } from '../../../../utils/adresse';
 import { landkodeTilSpråk } from '../../../../utils/språk';
 import { jaNeiSvarTilSpråkId } from '../../../../utils/spørsmål';
 import TekstBlock from '../../../Felleskomponenter/Sanity/TekstBlock';
-import SpråkTekst from '../../../Felleskomponenter/SpråkTekst/SpråkTekst';
 import { UtenlandsperiodeOppsummering } from '../../../Felleskomponenter/UtenlandsoppholdModal/UtenlandsperiodeOppsummering';
-import {
-    omDegPersonopplysningerSpråkId,
-    OmDegSpørsmålId,
-    omDegSpørsmålSpråkId,
-} from '../../OmDeg/spørsmål';
 import { useOmdeg } from '../../OmDeg/useOmdeg';
 import { OppsummeringFelt } from '../OppsummeringFelt';
 import Oppsummeringsbolk from '../Oppsummeringsbolk';
@@ -42,6 +36,7 @@ const OmDegOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
         <Oppsummeringsbolk
             steg={hentRouteObjektForRouteEnum(RouteEnum.OmDeg)}
             tittel={'omdeg.sidetittel'}
+            tittelForSanity={omDegTekster.omDegTittel}
             skjemaHook={omDegHook}
             settFeilAnchors={settFeilAnchors}
         >
@@ -59,11 +54,11 @@ const OmDegOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
                 }
             />
             <OppsummeringFelt
-                tittel={<SpråkTekst id={'felles.fødsels-eller-dnummer.label'} />}
+                tittel={plainTekst(omDegTekster.ident)}
                 søknadsvar={søknad.søker.ident}
             />
             <OppsummeringFelt
-                tittel={<SpråkTekst id={omDegPersonopplysningerSpråkId.søkerStatsborgerskap} />}
+                tittel={plainTekst(omDegTekster.statsborgerskap)}
                 søknadsvar={søknad.søker.statsborgerskap
                     .map((statsborgerskap: { landkode: Alpha3Code }) =>
                         landkodeTilSpråk(statsborgerskap.landkode, valgtLocale)
@@ -71,27 +66,21 @@ const OmDegOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
                     .join(', ')}
             />
             <OppsummeringFelt
-                tittel={<SpråkTekst id={omDegPersonopplysningerSpråkId.søkerSivilstatus} />}
+                tittel={plainTekst(omDegTekster.sivilstatus)}
                 søknadsvar={søknad.søker.sivilstand.type}
             />
             <OppsummeringFelt
-                tittel={<SpråkTekst id={omDegPersonopplysningerSpråkId.søkerAdresse} />}
+                tittel={plainTekst(omDegTekster.adresse)}
                 children={genererAdresseVisning(søknad.søker, omDegTekster, plainTekst)}
             />
             {søknad.søker.borPåRegistrertAdresse.svar && (
                 <OppsummeringFelt
-                    tittel={
-                        <SpråkTekst
-                            id={omDegSpørsmålSpråkId[OmDegSpørsmålId.borPåRegistrertAdresse]}
-                        />
-                    }
+                    tittel={<TekstBlock block={omDegTekster.borPaaRegistrertAdresse.sporsmal} />}
                     søknadsvar={søknad.søker.borPåRegistrertAdresse.svar}
                 />
             )}
             <OppsummeringFelt
-                tittel={
-                    <SpråkTekst id={omDegSpørsmålSpråkId[OmDegSpørsmålId.værtINorgeITolvMåneder]} />
-                }
+                tittel={<TekstBlock block={omDegTekster.vaertINorgeITolvMaaneder.sporsmal} />}
                 søknadsvar={søknad.søker.værtINorgeITolvMåneder.svar}
             />
             {søknad.søker.utenlandsperioder.map((periode, index) => (
@@ -100,9 +89,7 @@ const OmDegOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
             {søknad.søker.planleggerÅBoINorgeTolvMnd.svar && (
                 <OppsummeringFelt
                     tittel={
-                        <SpråkTekst
-                            id={omDegSpørsmålSpråkId[OmDegSpørsmålId.planleggerÅBoINorgeTolvMnd]}
-                        />
+                        <TekstBlock block={omDegTekster.planleggerAaBoINorgeTolvMnd.sporsmal} />
                     }
                     søknadsvar={søknad.søker.planleggerÅBoINorgeTolvMnd.svar}
                 />

--- a/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummeringsbolk.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummeringsbolk.tsx
@@ -14,7 +14,6 @@ import {
     LocaleRecordString,
 } from '../../../typer/sanity/sanity';
 import { SkjemaFeltTyper } from '../../../typer/skjema';
-import { uppercaseFørsteBokstav } from '../../../utils/visning';
 import { AppLenke } from '../../Felleskomponenter/AppLenke/AppLenke';
 import { SkjemaFeiloppsummering } from '../../Felleskomponenter/SkjemaFeiloppsummering/SkjemaFeiloppsummering';
 import SpråkTekst from '../../Felleskomponenter/SpråkTekst/SpråkTekst';
@@ -86,7 +85,7 @@ const Oppsummeringsbolk: React.FC<Props> = ({
                         steg?.route !== RouteEnum.EøsForBarn &&
                         `${hentStegNummer(steg?.route ?? RouteEnum.OmDeg)}. `}
                     {tittelForSanity ? (
-                        uppercaseFørsteBokstav(plainTekst(tittelForSanity, flettefelter))
+                        plainTekst(tittelForSanity, flettefelter)
                     ) : (
                         <SpråkTekst id={tittel} values={språkValues} />
                     )}

--- a/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummeringsbolk.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummeringsbolk.tsx
@@ -8,7 +8,13 @@ import { ISkjema } from '@navikt/familie-skjema';
 import { useApp } from '../../../context/AppContext';
 import { useSteg } from '../../../context/StegContext';
 import { ISteg, RouteEnum } from '../../../typer/routes';
+import {
+    FlettefeltVerdier,
+    LocaleRecordBlock,
+    LocaleRecordString,
+} from '../../../typer/sanity/sanity';
 import { SkjemaFeltTyper } from '../../../typer/skjema';
+import { uppercaseFørsteBokstav } from '../../../utils/visning';
 import { AppLenke } from '../../Felleskomponenter/AppLenke/AppLenke';
 import { SkjemaFeiloppsummering } from '../../Felleskomponenter/SkjemaFeiloppsummering/SkjemaFeiloppsummering';
 import SpråkTekst from '../../Felleskomponenter/SpråkTekst/SpråkTekst';
@@ -22,6 +28,8 @@ interface IHookReturn {
 interface Props {
     tittel: string;
     språkValues?: { [key: string]: string };
+    tittelForSanity?: LocaleRecordBlock | LocaleRecordString;
+    flettefelter?: FlettefeltVerdier;
     steg?: ISteg;
     skjemaHook: IHookReturn;
     settFeilAnchors?: React.Dispatch<React.SetStateAction<string[]>>;
@@ -38,12 +46,14 @@ const Oppsummeringsbolk: React.FC<Props> = ({
     children,
     tittel,
     språkValues,
+    tittelForSanity,
+    flettefelter,
     steg,
     skjemaHook,
     settFeilAnchors,
 }) => {
     const { hentStegNummer } = useSteg();
-    const { søknad } = useApp();
+    const { søknad, tekster, plainTekst } = useApp();
     const { validerAlleSynligeFelter, valideringErOk, skjema } = skjemaHook;
     const [visFeil, settVisFeil] = useState(false);
 
@@ -75,12 +85,16 @@ const Oppsummeringsbolk: React.FC<Props> = ({
                     {steg?.route !== RouteEnum.OmBarnet &&
                         steg?.route !== RouteEnum.EøsForBarn &&
                         `${hentStegNummer(steg?.route ?? RouteEnum.OmDeg)}. `}
-                    <SpråkTekst id={tittel} values={språkValues} />
+                    {tittelForSanity ? (
+                        uppercaseFørsteBokstav(plainTekst(tittelForSanity, flettefelter))
+                    ) : (
+                        <SpråkTekst id={tittel} values={språkValues} />
+                    )}
                 </FormSummary.Heading>
                 {steg && !visFeil && (
                     <AppLenke steg={steg}>
                         <StyledAppLenkeTekst>
-                            <SpråkTekst id="oppsummering.endresvar.lenketekst" />
+                            {plainTekst(tekster().OPPSUMMERING.endreSvarLenkeTekst)}
                         </StyledAppLenkeTekst>
                     </AppLenke>
                 )}

--- a/src/frontend/components/SøknadsSteg/Oppsummering/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/innholdTyper.ts
@@ -1,6 +1,7 @@
-import { LocaleRecordBlock } from '../../../typer/sanity/sanity';
+import { LocaleRecordBlock, LocaleRecordString } from '../../../typer/sanity/sanity';
 
 export interface IOppsummeringTekstinnhold {
     oppsummeringTittel: LocaleRecordBlock;
     oppsummeringGuide: LocaleRecordBlock;
+    endreSvarLenkeTekst: LocaleRecordString;
 }


### PR DESCRIPTION
Favro: [NAV-23323](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23323)

### 💰 Hva forsøker du å løse i denne PR'en
- Endrer Oppsummeringsbolk til å kunne bruke Sanity tekster for tittel (+ flettefeltverdier).
- Bytter til bruk av Sanity tekster for OmDegOppsummering.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Ikke nødvendig.

### 🤷‍♀ ️Hvor er det lurt å starte?
- Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
- Ingen visuelle endringer.