### PR TITLE
Fikser visning av alert for allNødvendigDokumentasjonErLastetOpp

### DIFF
--- a/src/frontend/components/SøknadsSteg/Kvittering/Kvittering.tsx
+++ b/src/frontend/components/SøknadsSteg/Kvittering/Kvittering.tsx
@@ -38,13 +38,13 @@ const Kvittering: React.FC = () => {
     const klokkeslett = format(innsendtDato, 'HH:mm');
     const dato = format(innsendtDato, 'dd.MM.yy');
 
-    const alleRelevanteVedleggErSendtInn = useRef(
-        søknad.dokumentasjon.filter(
+    const allNødvendigDokumentasjonErLastetOpp = useRef(
+        !søknad.dokumentasjon.find(
             dokumentasjon =>
                 dokumentasjon.dokumentasjonsbehov !== Dokumentasjonsbehov.ANNEN_DOKUMENTASJON &&
                 erDokumentasjonRelevant(dokumentasjon) &&
-                !dokumentasjon.harSendtInn
-        ).length === 0
+                !(dokumentasjon.harSendtInn || dokumentasjon.opplastedeVedlegg.length > 0)
+        )
     );
 
     useEffect(() => {
@@ -69,7 +69,7 @@ const Kvittering: React.FC = () => {
                 })}
             </Alert>
             <VStack gap="6">
-                {alleRelevanteVedleggErSendtInn.current ? (
+                {allNødvendigDokumentasjonErLastetOpp.current ? (
                     <TekstBlock
                         block={kvitteringTekster.trengerIkkeEttersendeVedlegg}
                         typografi={Typografi.BodyLong}


### PR DESCRIPTION
Favro: [NAV-24095](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24095)

Samme oppgave er gjort i KS: https://github.com/navikt/familie-ks-soknad/pull/751

### 💰 Hva forsøker du å løse i denne PR'en
- Endrer `allNødvendigDokumentasjonErLastetOpp` til å også sjekke for antall opplastede vedlegg, ikke bare om dokumentasjon er sendt inn fra før.
- Endrer variabel navn fra `alleRelevanteVedleggErSendtInn` til `allNødvendigDokumentasjonErLastetOpp`.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Ikke nødvendig.

### 🤷‍♀ ️Hvor er det lurt å starte?
- Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Før ble varsel vist, selv når all dokumentasjon var gitt.
![image](https://github.com/user-attachments/assets/f4a172ce-26b1-4998-bf58-80df91c89459)

Etter blir varsel kun vist når ikke all dokumentasjon er gitt.
![image](https://github.com/user-attachments/assets/c5fb9ca8-6dbe-4e0a-b60a-b4e8cedfee25)