### PR TITLE
Legger til månedsvelger i barnetrygdsperiode

### DIFF
--- a/src/frontend/components/Felleskomponenter/Arbeidsperiode/ArbeidsperiodeModal.tsx
+++ b/src/frontend/components/Felleskomponenter/Arbeidsperiode/ArbeidsperiodeModal.tsx
@@ -10,7 +10,7 @@ import { PersonType } from '../../../typer/personType';
 import { IArbeidsperiodeTekstinnhold } from '../../../typer/sanity/modaler/arbeidsperiode';
 import { dagensDato, gårsdagensDato, sisteDagDenneMåneden } from '../../../utils/dato';
 import { trimWhiteSpace, visFeiloppsummering } from '../../../utils/hjelpefunksjoner';
-import { minTilDatoForUtbetalingEllerArbeidsperiode } from '../../../utils/perioder';
+import { minTilDatoForPeriode } from '../../../utils/perioder';
 import { svarForSpørsmålMedUkjent } from '../../../utils/spørsmål';
 import Datovelger from '../Datovelger/Datovelger';
 import { LandDropdown } from '../Dropdowns/LandDropdown';
@@ -167,7 +167,7 @@ export const ArbeidsperiodeModal: React.FC<ArbeidsperiodeModalProps> = ({
                                         }
                                     />
                                 }
-                                tidligsteValgbareMåned={minTilDatoForUtbetalingEllerArbeidsperiode(
+                                tidligsteValgbareMåned={minTilDatoForPeriode(
                                     periodenErAvsluttet,
                                     skjema.felter.fraDatoArbeidsperiode.verdi
                                 )}
@@ -214,7 +214,7 @@ export const ArbeidsperiodeModal: React.FC<ArbeidsperiodeModalProps> = ({
                                         }
                                     />
                                 }
-                                avgrensMinDato={minTilDatoForUtbetalingEllerArbeidsperiode(
+                                avgrensMinDato={minTilDatoForPeriode(
                                     periodenErAvsluttet,
                                     skjema.felter.fraDatoArbeidsperiode.verdi
                                 )}

--- a/src/frontend/components/Felleskomponenter/Arbeidsperiode/useArbeidsperiodeSkjema.tsx
+++ b/src/frontend/components/Felleskomponenter/Arbeidsperiode/useArbeidsperiodeSkjema.tsx
@@ -20,7 +20,7 @@ import {
     sisteDagDenneMåneden,
     stringTilDate,
 } from '../../../utils/dato';
-import { minTilDatoForUtbetalingEllerArbeidsperiode } from '../../../utils/perioder';
+import { minTilDatoForPeriode } from '../../../utils/perioder';
 
 import { arbeidslandFeilmelding } from './arbeidsperiodeSpråkUtils';
 import { ArbeidsperiodeSpørsmålsId } from './spørsmål';
@@ -115,7 +115,7 @@ export const useArbeidsperiodeSkjema = (
         sluttdatoAvgrensning: periodenErAvsluttet
             ? tilArbeidsperiodeSluttdatoAvgrensning
             : undefined,
-        startdatoAvgrensning: minTilDatoForUtbetalingEllerArbeidsperiode(
+        startdatoAvgrensning: minTilDatoForPeriode(
             periodenErAvsluttet,
             fraDatoArbeidsperiode.verdi
         ),

--- a/src/frontend/components/Felleskomponenter/Barnetrygdperiode/BarnetrygdperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/Barnetrygdperiode/BarnetrygdperiodeOppsummering.tsx
@@ -3,13 +3,16 @@ import React from 'react';
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { useApp } from '../../../context/AppContext';
+import { useFeatureToggles } from '../../../context/FeatureToggleContext';
 import { useSpråk } from '../../../context/SpråkContext';
 import { HeadingLevel } from '../../../typer/common';
+import { EFeatureToggle } from '../../../typer/feature-toggles';
 import { IEøsBarnetrygdsperiode } from '../../../typer/perioder';
 import { PersonType } from '../../../typer/personType';
 import { IBarnetrygdsperiodeTekstinnhold } from '../../../typer/sanity/modaler/barnetrygdperiode';
-import { formaterDato } from '../../../utils/dato';
+import { formaterDato, formaterDatostringKunMåned } from '../../../utils/dato';
 import { landkodeTilSpråk } from '../../../utils/språk';
+import { uppercaseFørsteBokstav } from '../../../utils/visning';
 import { OppsummeringFelt } from '../../SøknadsSteg/Oppsummering/OppsummeringFelt';
 import PeriodeOppsummering from '../PeriodeOppsummering/PeriodeOppsummering';
 import TekstBlock from '../Sanity/TekstBlock';
@@ -38,6 +41,7 @@ export const BarnetrygdsperiodeOppsummering: React.FC<Props> = ({
     personType,
     headingLevel = '3',
 }) => {
+    const { toggles } = useFeatureToggles();
     const {
         mottarEøsBarnetrygdNå,
         barnetrygdsland,
@@ -97,12 +101,27 @@ export const BarnetrygdsperiodeOppsummering: React.FC<Props> = ({
             />
             <OppsummeringFelt
                 tittel={<TekstBlock block={teksterForPersonType.startdato.sporsmal} />}
-                søknadsvar={formaterDato(fraDatoBarnetrygdperiode.svar)}
+                søknadsvar={
+                    toggles[EFeatureToggle.SPOR_OM_MANED_IKKE_DATO]
+                        ? uppercaseFørsteBokstav(
+                              formaterDatostringKunMåned(fraDatoBarnetrygdperiode.svar, valgtLocale)
+                          )
+                        : formaterDato(fraDatoBarnetrygdperiode.svar)
+                }
             />
             {tilDatoBarnetrygdperiode.svar && (
                 <OppsummeringFelt
                     tittel={<TekstBlock block={teksterForPersonType.sluttdato.sporsmal} />}
-                    søknadsvar={formaterDato(tilDatoBarnetrygdperiode.svar)}
+                    søknadsvar={
+                        toggles[EFeatureToggle.SPOR_OM_MANED_IKKE_DATO]
+                            ? uppercaseFørsteBokstav(
+                                  formaterDatostringKunMåned(
+                                      tilDatoBarnetrygdperiode.svar,
+                                      valgtLocale
+                                  )
+                              )
+                            : formaterDato(tilDatoBarnetrygdperiode.svar)
+                    }
                 />
             )}
             <OppsummeringFelt

--- a/src/frontend/components/Felleskomponenter/UtbetalingerModal/UtbetalingerModal.tsx
+++ b/src/frontend/components/Felleskomponenter/UtbetalingerModal/UtbetalingerModal.tsx
@@ -11,7 +11,7 @@ import { PersonType } from '../../../typer/personType';
 import { IAndreUtbetalingerTekstinnhold } from '../../../typer/sanity/modaler/andreUtbetalinger';
 import { dagensDato, gårsdagensDato, sisteDagDenneMåneden } from '../../../utils/dato';
 import { visFeiloppsummering } from '../../../utils/hjelpefunksjoner';
-import { minTilDatoForUtbetalingEllerArbeidsperiode } from '../../../utils/perioder';
+import { minTilDatoForPeriode } from '../../../utils/perioder';
 import { svarForSpørsmålMedUkjent } from '../../../utils/spørsmål';
 import Datovelger from '../Datovelger/Datovelger';
 import { LandDropdown } from '../Dropdowns/LandDropdown';
@@ -147,7 +147,7 @@ export const UtbetalingerModal: React.FC<UtbetalingerModalProps> = ({
                                             }
                                         />
                                     }
-                                    tidligsteValgbareMåned={minTilDatoForUtbetalingEllerArbeidsperiode(
+                                    tidligsteValgbareMåned={minTilDatoForPeriode(
                                         periodenErAvsluttet,
                                         utbetalingFraDato.verdi
                                     )}
@@ -195,7 +195,7 @@ export const UtbetalingerModal: React.FC<UtbetalingerModalProps> = ({
                                         />
                                     }
                                     avgrensMaxDato={periodenErAvsluttet ? dagensDato() : undefined}
-                                    avgrensMinDato={minTilDatoForUtbetalingEllerArbeidsperiode(
+                                    avgrensMinDato={minTilDatoForPeriode(
                                         periodenErAvsluttet,
                                         utbetalingFraDato.verdi
                                     )}

--- a/src/frontend/components/Felleskomponenter/UtbetalingerModal/useUtbetalingerSkjema.tsx
+++ b/src/frontend/components/Felleskomponenter/UtbetalingerModal/useUtbetalingerSkjema.tsx
@@ -20,7 +20,7 @@ import {
     sisteDagDenneMåneden,
     stringTilDate,
 } from '../../../utils/dato';
-import { minTilDatoForUtbetalingEllerArbeidsperiode } from '../../../utils/perioder';
+import { minTilDatoForPeriode } from '../../../utils/perioder';
 
 import { fårUtbetalingNåFeilmelding, utbetalingslandFeilmelding } from './språkUtils';
 import { UtbetalingerSpørsmålId } from './spørsmål';
@@ -95,10 +95,7 @@ export const useUtbetalingerSkjema = (personType, barn, erDød) => {
         sluttdatoAvgrensning: periodenErAvsluttet
             ? utbetalingTilDatoSluttdatoAvgrensning
             : undefined,
-        startdatoAvgrensning: minTilDatoForUtbetalingEllerArbeidsperiode(
-            periodenErAvsluttet,
-            utbetalingFraDato.verdi
-        ),
+        startdatoAvgrensning: minTilDatoForPeriode(periodenErAvsluttet, utbetalingFraDato.verdi),
         customStartdatoFeilmelding:
             erSammeDatoSomDagensDato(stringTilDate(utbetalingFraDato.verdi)) || periodenErAvsluttet
                 ? undefined

--- a/src/frontend/utils/mappingTilKontrakt/andreForelder.ts
+++ b/src/frontend/utils/mappingTilKontrakt/andreForelder.ts
@@ -272,6 +272,7 @@ export const andreForelderTilISøknadsfelt = (
                 tekster: tekster.FELLES.modaler.barnetrygdsperiode.andreForelder,
                 erDød: forelderErDød,
                 barn,
+                toggleSpørOmMånedIkkeDato,
             })
         ),
         idNummer: idNummer.map(idnummerObj =>

--- a/src/frontend/utils/mappingTilKontrakt/barn.ts
+++ b/src/frontend/utils/mappingTilKontrakt/barn.ts
@@ -119,6 +119,7 @@ export const barnISøknadsFormat = (
                 tilRestLocaleRecord,
                 tekster: fellesTekster.modaler.barnetrygdsperiode.søker,
                 barn,
+                toggleSpørOmMånedIkkeDato,
             })
         ),
         idNummer: idNummer.map(idnummerObj =>

--- a/src/frontend/utils/mappingTilKontrakt/eøsBarnetrygdsperiode.ts
+++ b/src/frontend/utils/mappingTilKontrakt/eøsBarnetrygdsperiode.ts
@@ -1,12 +1,16 @@
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { IBarnMedISøknad } from '../../typer/barn';
+import { ISODateString } from '../../typer/common';
 import { ISøknadsfelt, TilRestLocaleRecord } from '../../typer/kontrakt/generelle';
 import { IEøsBarnetrygdsperiodeIKontraktFormat } from '../../typer/kontrakt/kontrakt';
 import { IEøsBarnetrygdsperiode } from '../../typer/perioder';
 import { PeriodePersonTypeProps, PersonType } from '../../typer/personType';
 import { IBarnetrygdsperiodeTekstinnhold } from '../../typer/sanity/modaler/barnetrygdperiode';
+import { ISøknadSpørsmål } from '../../typer/spørsmål';
+import { formaterDatostringKunMåned } from '../dato';
 import { landkodeTilSpråk } from '../språk';
+import { uppercaseFørsteBokstav } from '../visning';
 
 import { sammeVerdiAlleSpråk, verdiCallbackAlleSpråk } from './hjelpefunksjoner';
 
@@ -16,6 +20,7 @@ interface PensjonperiodeIKontraktFormatParams {
     tekster: IBarnetrygdsperiodeTekstinnhold;
     tilRestLocaleRecord: TilRestLocaleRecord;
     barn: IBarnMedISøknad;
+    toggleSpørOmMånedIkkeDato: boolean;
 }
 
 export const tilIEøsBarnetrygsperiodeIKontraktFormat = ({
@@ -26,6 +31,7 @@ export const tilIEøsBarnetrygsperiodeIKontraktFormat = ({
     barn,
     personType,
     erDød,
+    toggleSpørOmMånedIkkeDato,
 }: PensjonperiodeIKontraktFormatParams &
     PeriodePersonTypeProps): ISøknadsfelt<IEøsBarnetrygdsperiodeIKontraktFormat> => {
     const {
@@ -68,12 +74,12 @@ export const tilIEøsBarnetrygsperiodeIKontraktFormat = ({
             },
             fraDatoBarnetrygdperiode: {
                 label: tilRestLocaleRecord(tekster.startdato.sporsmal),
-                verdi: sammeVerdiAlleSpråk(fraDatoBarnetrygdperiode?.svar),
+                verdi: datoTilVerdiForKontrakt(fraDatoBarnetrygdperiode),
             },
             tilDatoBarnetrygdperiode: tilDatoBarnetrygdperiode.svar
                 ? {
                       label: tilRestLocaleRecord(tekster.sluttdato.sporsmal),
-                      verdi: sammeVerdiAlleSpråk(tilDatoBarnetrygdperiode?.svar ?? null),
+                      verdi: datoTilVerdiForKontrakt(tilDatoBarnetrygdperiode),
                   }
                 : null,
             månedligBeløp: {
@@ -84,4 +90,12 @@ export const tilIEøsBarnetrygsperiodeIKontraktFormat = ({
             },
         }),
     };
+
+    function datoTilVerdiForKontrakt(skjemaSpørsmål: ISøknadSpørsmål<ISODateString | ''>) {
+        return toggleSpørOmMånedIkkeDato
+            ? verdiCallbackAlleSpråk(locale =>
+                  uppercaseFørsteBokstav(formaterDatostringKunMåned(skjemaSpørsmål.svar, locale))
+              )
+            : sammeVerdiAlleSpråk(skjemaSpørsmål.svar);
+    }
 };

--- a/src/frontend/utils/mappingTilKontrakt/omsorgsperson.ts
+++ b/src/frontend/utils/mappingTilKontrakt/omsorgsperson.ts
@@ -203,6 +203,7 @@ export const omsorgspersonTilISøknadsfelt = (
                 tilRestLocaleRecord,
                 tekster: tekster.FELLES.modaler.barnetrygdsperiode.omsorgsperson,
                 barn: barn,
+                toggleSpørOmMånedIkkeDato,
             })
         ),
     };

--- a/src/frontend/utils/perioder.ts
+++ b/src/frontend/utils/perioder.ts
@@ -15,10 +15,7 @@ import {
     stringTilDate,
 } from './dato';
 
-export const minTilDatoForUtbetalingEllerArbeidsperiode = (
-    periodenErAvsluttet: boolean,
-    fraDato: string
-) => {
+export const minTilDatoForPeriode = (periodenErAvsluttet: boolean, fraDato: string) => {
     const gyldigFraDato = fraDato !== '' && erDatoFormatGodkjent(stringTilDate(fraDato));
     if (periodenErAvsluttet) {
         return gyldigFraDato ? dagenEtterDato(stringTilDate(fraDato)) : undefined;


### PR DESCRIPTION
Favro: [NAV-18711](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18711)

### 💰 Hva forsøker du å løse i denne PR'en
– Dette er en oppfølging av en tidligere oppgave (https://github.com/navikt/familie-ba-soknad/pull/1550), der `MånedÅrVelger`-komponenten ble introdusert og tatt i bruk flere steder. Nå tas `MånedÅrVelger` også i bruk i barnetrygdsperiode.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Ikke nødvendig.

### 🤷‍♀ ️Hvor er det lurt å starte?
- Alt i ett.
- Jeg har allerede testet endringene i preprod og generering av PDF.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
#### Før
![image](https://github.com/user-attachments/assets/26221266-5150-481c-ae8d-a0afed7e415b)

#### Etter
![image](https://github.com/user-attachments/assets/d38c0b7f-f85a-4cc3-8712-8df526f7f2c9)