### PR TITLE
Fikser hardkodet og" tekst

### DIFF
--- a/src/frontend/components/Felleskomponenter/VedleggOppsummering/vedleggOppsummering.domene.ts
+++ b/src/frontend/components/Felleskomponenter/VedleggOppsummering/vedleggOppsummering.domene.ts
@@ -1,3 +1,5 @@
+import { PlainTekst } from '../../../typer/sanity/sanity';
+import { IFrittståendeOrdTekstinnhold } from '../../../typer/sanity/tekstInnhold';
 import { slåSammen } from '../../../utils/slåSammen';
 
 import { IVedleggOppsummering } from './vedleggOppsummering.types';
@@ -12,12 +14,21 @@ export const skalVedleggOppsummeringVises = (vedlegg: IVedleggOppsummering[]): b
     return vedlegg.filter(enkeltVedlegg => enkeltVedlegg.skalVises).length > 0;
 };
 
-export const hentVedleggOppsummering = (dokumentasjoner, søknad): IVedleggOppsummering[] =>
+export const hentVedleggOppsummering = (
+    dokumentasjoner,
+    søknad,
+    plainTekst: PlainTekst,
+    frittståendeOrdTekster: IFrittståendeOrdTekstinnhold
+): IVedleggOppsummering[] =>
     dokumentasjoner.map(dokumentasjon => {
         const barnDokGjelderFor = søknad.barnInkludertISøknaden.filter(barn =>
             dokumentasjon.gjelderForBarnId.find(id => id === barn.id)
         );
-        const barnasNavn = slåSammen(barnDokGjelderFor.map(barn => barn.navn));
+        const barnasNavn = slåSammen(
+            barnDokGjelderFor.map(barn => barn.navn),
+            plainTekst,
+            frittståendeOrdTekster
+        );
 
         return {
             skalVises: true,

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/Dokumentasjon.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/Dokumentasjon.tsx
@@ -77,6 +77,7 @@ const Dokumentasjon: React.FC = () => {
     });
 
     const stegTekster = tekster()[ESanitySteg.DOKUMENTASJON];
+    const frittståendeOrdTekster = tekster()[ESanitySteg.FELLES].frittståendeOrd;
 
     const relevateDokumentasjoner = hentRelevateDokumentasjoner(søknad.dokumentasjon);
 
@@ -89,7 +90,9 @@ const Dokumentasjon: React.FC = () => {
 
     const vedleggOppsummering = hentVedleggOppsummering(
         relevateDokumentasjonerUtenAnnenDokumentasjon,
-        søknad
+        søknad,
+        plainTekst,
+        frittståendeOrdTekster
     );
 
     return (

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg.tsx
@@ -28,7 +28,10 @@ interface Props {
 
 const LastOppVedlegg: React.FC<Props> = ({ dokumentasjon, oppdaterDokumentasjon }) => {
     const { søknad, tekster, plainTekst } = useAppContext();
+
     const dokumentasjonstekster = tekster().DOKUMENTASJON;
+    const frittståendeOrdTekster = tekster().FELLES.frittståendeOrd;
+
     const settHarSendtInnTidligere = (event: React.ChangeEvent<HTMLInputElement>) => {
         const huketAv = event.target.checked;
         const vedlegg = huketAv ? [] : dokumentasjon.opplastedeVedlegg;
@@ -38,7 +41,11 @@ const LastOppVedlegg: React.FC<Props> = ({ dokumentasjon, oppdaterDokumentasjon 
     const barnDokGjelderFor = søknad.barnInkludertISøknaden.filter(barn =>
         dokumentasjon.gjelderForBarnId.find(id => id === barn.id)
     );
-    const barnasNavn = slåSammen(barnDokGjelderFor.map(barn => barn.navn));
+    const barnasNavn = slåSammen(
+        barnDokGjelderFor.map(barn => barn.navn),
+        plainTekst,
+        frittståendeOrdTekster
+    );
 
     const tittelBlock =
         dokumentasjonstekster[

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg2.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg2.tsx
@@ -30,6 +30,7 @@ const LastOppVedlegg2: React.FC<Props> = ({ dokumentasjon, oppdaterDokumentasjon
     const { søknad, tekster, plainTekst } = useAppContext();
 
     const dokumentasjonTekster = tekster().DOKUMENTASJON;
+    const frittståendeOrdTekster = tekster().FELLES.frittståendeOrd;
 
     const { fjernAlleAvvisteFiler } = useFilopplaster2(
         dokumentasjon,
@@ -55,7 +56,11 @@ const LastOppVedlegg2: React.FC<Props> = ({ dokumentasjon, oppdaterDokumentasjon
     const barnDokumentasjonenGjelderFor = søknad.barnInkludertISøknaden.filter(barn =>
         dokumentasjon.gjelderForBarnId.find(id => id === barn.id)
     );
-    const barnasNavn = slåSammen(barnDokumentasjonenGjelderFor.map(barn => barn.navn));
+    const barnasNavn = slåSammen(
+        barnDokumentasjonenGjelderFor.map(barn => barn.navn),
+        plainTekst,
+        frittståendeOrdTekster
+    );
 
     const dokumentasjonsbeskrivelse = dokumentasjonsbehovTilBeskrivelseSanityApiNavn(
         dokumentasjon.dokumentasjonsbehov

--- a/src/frontend/hooks/useSendInnSkjema.tsx
+++ b/src/frontend/hooks/useSendInnSkjema.tsx
@@ -23,6 +23,7 @@ export const useSendInnSkjema = (): {
         settSisteModellVersjon,
         tekster,
         tilRestLocaleRecord,
+        plainTekst,
     } = useAppContext();
     const { soknadApiProxyUrl } = Miljø();
     const { valgtLocale } = useSpråkContext();
@@ -39,7 +40,8 @@ export const useSendInnSkjema = (): {
                 tekster(),
                 tilRestLocaleRecord,
                 kontraktVersjon,
-                toggles[EFeatureToggle.SPOR_OM_MANED_IKKE_DATO] === true
+                toggles[EFeatureToggle.SPOR_OM_MANED_IKKE_DATO] === true,
+                plainTekst
             );
 
             const res = await sendInn<ISøknadKontrakt>(

--- a/src/frontend/typer/sanity/tekstInnhold.ts
+++ b/src/frontend/typer/sanity/tekstInnhold.ts
@@ -94,6 +94,7 @@ export interface IFrittståendeOrdTekstinnhold {
     vedleggMedFeil: LocaleRecordString;
     slipp: LocaleRecordString;
     eller: LocaleRecordString;
+    og: LocaleRecordString;
 }
 
 export interface INavigasjonTekstinnhold {

--- a/src/frontend/utils/mappingTilKontrakt/dokumentasjon.ts
+++ b/src/frontend/utils/mappingTilKontrakt/dokumentasjon.ts
@@ -9,8 +9,8 @@ import {
     ISøknadKontraktVedlegg,
 } from '../../typer/kontrakt/dokumentasjon';
 import { TilRestLocaleRecord } from '../../typer/kontrakt/generelle';
-import { ESanitySteg, FlettefeltVerdier } from '../../typer/sanity/sanity';
-import { ITekstinnhold } from '../../typer/sanity/tekstInnhold';
+import { ESanitySteg, FlettefeltVerdier, PlainTekst } from '../../typer/sanity/sanity';
+import { IFrittståendeOrdTekstinnhold, ITekstinnhold } from '../../typer/sanity/tekstInnhold';
 import { ISøknad } from '../../typer/søknad';
 import { slåSammen } from '../slåSammen';
 
@@ -18,7 +18,8 @@ export const dokumentasjonISøknadFormat = (
     dokumentasjon: IDokumentasjon,
     tekster: ITekstinnhold,
     tilRestLocaleRecord: TilRestLocaleRecord,
-    søknad: ISøknad
+    søknad: ISøknad,
+    plainTekst: PlainTekst
 ): ISøknadKontraktDokumentasjon => {
     const dokumentsjonstekster = tekster[ESanitySteg.DOKUMENTASJON];
 
@@ -32,14 +33,21 @@ export const dokumentasjonISøknadFormat = (
             dokumentsjonstekster[
                 dokumentasjonsbehovTilTittelSanityApiNavn(dokumentasjon.dokumentasjonsbehov)
             ],
-            flettefelterForDokumentasjonTittel(dokumentasjon, søknad)
+            flettefelterForDokumentasjonTittel(
+                dokumentasjon,
+                søknad,
+                plainTekst,
+                tekster.FELLES.frittståendeOrd
+            )
         ),
     };
 };
 
 const flettefelterForDokumentasjonTittel = (
     dokumentasjon: IDokumentasjon,
-    søknad: ISøknad
+    søknad: ISøknad,
+    plainTekst: PlainTekst,
+    frittståendeOrdTekster: IFrittståendeOrdTekstinnhold
 ): FlettefeltVerdier => {
     switch (dokumentasjon.dokumentasjonsbehov) {
         case Dokumentasjonsbehov.BOR_FAST_MED_SØKER:
@@ -47,7 +55,11 @@ const flettefelterForDokumentasjonTittel = (
                 .filter(barn => dokumentasjon.gjelderForBarnId.find(id => barn.id === id))
                 .map(barn => barn.navn);
             return {
-                barnetsNavn: slåSammen(barnDokumentasjonsbehovGjelderFor),
+                barnetsNavn: slåSammen(
+                    barnDokumentasjonsbehovGjelderFor,
+                    plainTekst,
+                    frittståendeOrdTekster
+                ),
             };
         default:
             return {};

--- a/src/frontend/utils/mappingTilKontrakt/søknad.ts
+++ b/src/frontend/utils/mappingTilKontrakt/søknad.ts
@@ -11,7 +11,7 @@ import { ESivilstand, TilRestLocaleRecord } from '../../typer/kontrakt/generelle
 import { ISøknadKontrakt } from '../../typer/kontrakt/kontrakt';
 import { ISøker } from '../../typer/person';
 import { PersonType } from '../../typer/personType';
-import { LocaleRecordBlock, LocaleRecordString } from '../../typer/sanity/sanity';
+import { LocaleRecordBlock, LocaleRecordString, PlainTekst } from '../../typer/sanity/sanity';
 import { ITekstinnhold } from '../../typer/sanity/tekstInnhold';
 import { ISøknadSpørsmålMap } from '../../typer/spørsmål';
 import { ISøknad } from '../../typer/søknad';
@@ -58,7 +58,8 @@ export const dataISøknadKontraktFormat = (
     tekster: ITekstinnhold,
     tilRestLocaleRecord: TilRestLocaleRecord,
     kontraktVersjon: number,
-    toggleSpørOmMånedIkkeDato: boolean
+    toggleSpørOmMånedIkkeDato: boolean,
+    plainTekst: PlainTekst
 ): ISøknadKontrakt => {
     const { søker } = søknad;
 
@@ -253,7 +254,9 @@ export const dataISøknadKontraktFormat = (
         },
         dokumentasjon: søknad.dokumentasjon
             .filter(dok => erDokumentasjonRelevant(dok))
-            .map(dok => dokumentasjonISøknadFormat(dok, tekster, tilRestLocaleRecord, søknad)),
+            .map(dok =>
+                dokumentasjonISøknadFormat(dok, tekster, tilRestLocaleRecord, søknad, plainTekst)
+            ),
         teksterUtenomSpørsmål: {
             ...lokaleTekster(),
             ...teksterFraSanity(tekster, tilRestLocaleRecord),

--- a/src/frontend/utils/slåSammen.ts
+++ b/src/frontend/utils/slåSammen.ts
@@ -1,4 +1,11 @@
-export const slåSammen = (tekstListe: string[]) => {
+import { PlainTekst } from '../typer/sanity/sanity';
+import { IFrittståendeOrdTekstinnhold } from '../typer/sanity/tekstInnhold';
+
+export const slåSammen = (
+    tekstListe: string[],
+    plainTekst: PlainTekst,
+    frittståendeOrdTekster: IFrittståendeOrdTekstinnhold
+) => {
     if (tekstListe.length === 0) {
         return '';
     }
@@ -7,5 +14,7 @@ export const slåSammen = (tekstListe: string[]) => {
         return tekstListe[0];
     }
 
-    return tekstListe.join(', ').replace(/,(?=[^,]+$)/, ' og');
+    return tekstListe
+        .join(', ')
+        .replace(/,(?=[^,]+$)/, ` ${plainTekst(frittståendeOrdTekster.og)}`);
 };


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24814
Samme oppgave er også gjort i KS: https://github.com/navikt/familie-ks-soknad/pull/910

### 💰 Hva forsøker du å løse i denne PR'en
- Fikser hardkodet "og" tekst i slåSammen funksjonen ved å bytte til Sanity tekst

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Ikke nødvendig.

### 🤷‍♀ ️Hvor er det lurt å starte?
- Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Nå viser dette "and" istedenfor "og" på engelsk
![image](https://github.com/user-attachments/assets/1a3d60e9-dedf-4ae1-8747-75a5ed87d74c)
