### PR TITLE
Fiks accessibility feil i oppsummering

### DIFF
--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnet/AndreForelderOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnet/AndreForelderOppsummering.tsx
@@ -37,10 +37,10 @@ const AndreForelderOppsummering: React.FC<{
     } = omBarnetTekster;
 
     return (
-        <FormSummary.Answers>
+        <>
             {andreForelder[andreForelderDataKeySpørsmål.kanIkkeGiOpplysninger].svar ===
             ESvar.NEI ? (
-                <>
+                <FormSummary.Answers>
                     {andreForelder[andreForelderDataKeySpørsmål.navn].svar && (
                         <OppsummeringFelt
                             tittel={<TekstBlock block={navnAndreForelder.sporsmal} />}
@@ -160,13 +160,15 @@ const AndreForelderOppsummering: React.FC<{
                             })()}
                         />
                     )}
-                </>
+                </FormSummary.Answers>
             ) : (
-                <BodyShort>
-                    <TekstBlock block={navnAndreForelder.checkboxLabel} />
-                </BodyShort>
+                <FormSummary.Answer>
+                    <BodyShort>
+                        <TekstBlock block={navnAndreForelder.checkboxLabel} />
+                    </BodyShort>
+                </FormSummary.Answer>
             )}
-        </FormSummary.Answers>
+        </>
     );
 };
 


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25208
Samme oppgave gjøres i KS: https://github.com/navikt/familie-ks-soknad/pull/914

### 💰 Hva forsøker du å løse i denne PR'en
- Endrer wrapper rundt svar om at bruker ikke kan gi opplysninger om den andre forelderen.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Ikke nødvendig.

### 🤷‍♀ ️Hvor er det lurt å starte?
- Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
#### Før
![image](https://github.com/user-attachments/assets/0ab5974b-82e7-4719-beda-5772eb827f2f)

#### Etter
![image](https://github.com/user-attachments/assets/5db4da72-1bc1-49b3-99d8-c81aead41b28)