### PR TITLE
Fikser undefined svalbardOppholdPerioder som resultat av gammel søknad

### DIFF
--- a/src/frontend/utils/mappingTilKontrakt/søknad.ts
+++ b/src/frontend/utils/mappingTilKontrakt/søknad.ts
@@ -114,14 +114,16 @@ export const dataISøknadKontraktFormat = (
             ),
             adresse: søknadsfelt('pdf.søker.adresse.label', sammeVerdiAlleSpråk(adresse)),
             adressebeskyttelse: søker.adressebeskyttelse,
-            svalbardOppholdPerioder: svalbardOppholdPerioder.map((periode, index) =>
-                svalbardOppholdPeriodeTilISøknadsfelt({
-                    svalbardOppholdPeriode: periode,
-                    periodeNummer: index + 1,
-                    tekster: fellesTekster.modaler.svalbardOpphold[PersonType.Søker],
-                    tilRestLocaleRecord,
-                })
-            ),
+            svalbardOppholdPerioder: svalbardOppholdPerioder
+                ? svalbardOppholdPerioder.map((periode, index) =>
+                      svalbardOppholdPeriodeTilISøknadsfelt({
+                          svalbardOppholdPeriode: periode,
+                          periodeNummer: index + 1,
+                          tekster: fellesTekster.modaler.svalbardOpphold[PersonType.Søker],
+                          tilRestLocaleRecord,
+                      })
+                  )
+                : [],
             utenlandsperioder: utenlandsperioder.map((periode, index) =>
                 utenlandsperiodeTilISøknadsfelt({
                     utenlandperiode: periode,


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Stopper map() fra å bruker på `svalbardOppholdPerioder` dersom den er undefined som resultat av gammel søknad som sendes inn gjennom ny kode.
