### PR TITLE
NAV-28205: Oppdatere til InfoCard

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { BrowserRouter as Router } from 'react-router';
 
-import { Alert } from '@navikt/ds-react';
+import { GlobalAlert } from '@navikt/ds-react';
 
 import { BASE_PATH } from '../common/miljø';
 
@@ -23,12 +23,16 @@ function App() {
                         <StegProvider>
                             <GlobalStyle />
                             {process.env.NODE_ENV !== 'production' && (
-                                <Alert variant={'warning'}>
-                                    {`Denne siden er under utvikling. `}
-                                    <a href="https://www.nav.no/no/person/familie/barnetrygd-og-kontantstotte/barnetrygd">
-                                        Klikk her for å gå til våre sider for barnetrygd
-                                    </a>
-                                </Alert>
+                                <GlobalAlert status={'warning'}>
+                                    <GlobalAlert.Header>
+                                        <GlobalAlert.Title>Denne siden er under utvikling.</GlobalAlert.Title>
+                                    </GlobalAlert.Header>
+                                    <GlobalAlert.Content>
+                                        <a href="https://www.nav.no/no/person/familie/barnetrygd-og-kontantstotte/barnetrygd">
+                                            Klikk her for å gå til våre sider for barnetrygd
+                                        </a>
+                                    </GlobalAlert.Content>
+                                </GlobalAlert>
                             )}
                             <AppNavigationProvider>
                                 <AppContainer />

--- a/src/frontend/AppContainer.tsx
+++ b/src/frontend/AppContainer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Alert, Box, Page } from '@navikt/ds-react';
+import { Box, GlobalAlert, Page } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { Feilside } from './components/Felleskomponenter/Feilside/Feilside';
@@ -17,12 +17,16 @@ const AppContainer = () => {
                 {systemetLaster() && <SystemetLaster />}
                 {sluttbruker.status === RessursStatus.IKKE_TILGANG && (
                     <Box marginBlock="space-128">
-                        <Alert variant={'warning'}>
-                            {'Du må søke på papir. '}
-                            <a href="https://www.nav.no/no/person/familie/barnetrygd-og-kontantstotte/barnetrygd">
-                                Klikk her for å gå til våre sider for barnetrygd
-                            </a>
-                        </Alert>
+                        <GlobalAlert status={'warning'}>
+                            <GlobalAlert.Header>
+                                <GlobalAlert.Title>Du må søke på papir.</GlobalAlert.Title>
+                            </GlobalAlert.Header>
+                            <GlobalAlert.Content>
+                                <a href="https://www.nav.no/no/person/familie/barnetrygd-og-kontantstotte/barnetrygd">
+                                    Klikk her for å gå til våre sider for barnetrygd
+                                </a>
+                            </GlobalAlert.Content>
+                        </GlobalAlert>
                     </Box>
                 )}
                 {systemetOK() && <Søknad />}

--- a/src/frontend/components/Felleskomponenter/Barnetrygdperiode/BarnetrygdperiodeModal.tsx
+++ b/src/frontend/components/Felleskomponenter/Barnetrygdperiode/BarnetrygdperiodeModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Alert } from '@navikt/ds-react';
+import { InlineMessage } from '@navikt/ds-react';
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { useAppContext } from '../../../context/AppContext';
@@ -159,9 +159,9 @@ export const BarnetrygdperiodeModal: React.FC<Props> = ({
                         />
                     }
                     description={
-                        <Alert variant={'info'} inline>
+                        <InlineMessage status={'info'}>
                             <TekstBlock block={teksterForModal.belopPerManed.beskrivelse} />
-                        </Alert>
+                        </InlineMessage>
                     }
                     fullbredde={false}
                 />

--- a/src/frontend/components/Felleskomponenter/PictureScanningGuide/PictureScanningExample.tsx
+++ b/src/frontend/components/Felleskomponenter/PictureScanningGuide/PictureScanningExample.tsx
@@ -1,20 +1,25 @@
 import React from 'react';
 
-import { Alert, type AlertProps, BodyShort, Label } from '@navikt/ds-react';
+import { BodyShort, InfoCard, type InfoCardProps } from '@navikt/ds-react';
 
 interface Props {
     image: React.ReactNode;
-    variant: AlertProps['variant'];
+    variant: InfoCardProps['data-color'];
     statusText: string;
     description: string;
+    icon: React.ReactNode;
 }
 
-const PictureScanningExample = ({ image, variant, statusText, description }: Props) => (
-    <Alert variant={variant}>
-        <Label as="div">{statusText}</Label>
-        <BodyShort spacing>{description}</BodyShort>
-        {image}
-    </Alert>
+const PictureScanningExample = ({ image, icon, variant, statusText, description }: Props) => (
+    <InfoCard data-color={variant}>
+        <InfoCard.Header icon={icon}>
+            <InfoCard.Title>{statusText}</InfoCard.Title>
+        </InfoCard.Header>
+        <InfoCard.Content>
+            <BodyShort spacing>{description}</BodyShort>
+            {image}
+        </InfoCard.Content>
+    </InfoCard>
 );
 
 export default PictureScanningExample;

--- a/src/frontend/components/Felleskomponenter/PictureScanningGuide/PictureScanningGuide.tsx
+++ b/src/frontend/components/Felleskomponenter/PictureScanningGuide/PictureScanningGuide.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
+import { CheckmarkCircleIcon, XMarkOctagonIcon } from '@navikt/aksel-icons';
 import { ExpansionCard, Heading, HGrid, VStack } from '@navikt/ds-react';
 
 import { useAppContext } from '../../../context/AppContext';
@@ -54,25 +55,29 @@ const PictureScanningGuide = () => {
                         <HGrid gap="space-16" columns={{ xs: 1, sm: 2 }}>
                             <PictureScanningExample
                                 image={<ScanningIcon status="good" height={svgIconHeight} />}
+                                icon={<CheckmarkCircleIcon aria-hidden />}
                                 variant="success"
                                 statusText={plainTekst(dokumentasjonTekster.bra)}
                                 description={plainTekst(dokumentasjonTekster.fyllerHeleBildet)}
                             />
                             <PictureScanningExample
                                 image={<ScanningIcon status="keystone" height={svgIconHeight} />}
-                                variant="error"
+                                icon={<XMarkOctagonIcon aria-hidden />}
+                                variant="danger"
                                 statusText={plainTekst(dokumentasjonTekster.daarlig)}
                                 description={plainTekst(dokumentasjonTekster.ikkeTattOvenfra)}
                             />
                             <PictureScanningExample
                                 image={<ScanningIcon status="horizontal" height={svgIconHeight} />}
-                                variant="error"
+                                icon={<XMarkOctagonIcon aria-hidden />}
+                                variant="danger"
                                 statusText={plainTekst(dokumentasjonTekster.daarlig)}
                                 description={plainTekst(dokumentasjonTekster.ikkeRiktigRetning)}
                             />
                             <PictureScanningExample
                                 image={<ScanningIcon status="shadow" height={svgIconHeight} />}
-                                variant="error"
+                                icon={<XMarkOctagonIcon aria-hidden />}
+                                variant="danger"
                                 statusText={plainTekst(dokumentasjonTekster.daarlig)}
                                 description={plainTekst(dokumentasjonTekster.skyggePaaDokumentet)}
                             />

--- a/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
@@ -2,8 +2,8 @@ import React, { ReactNode, useEffect } from 'react';
 
 import { useNavigate } from 'react-router';
 
-import { ArrowLeftIcon } from '@navikt/aksel-icons';
-import { Alert, Box, FormProgress, GuidePanel, Heading, Link, VStack } from '@navikt/ds-react';
+import { ArrowLeftIcon, InformationSquareIcon } from '@navikt/aksel-icons';
+import { Box, FormProgress, GuidePanel, Heading, InfoCard, Link, VStack } from '@navikt/ds-react';
 import type { ISkjema } from '@navikt/familie-skjema';
 import { setAvailableLanguages } from '@navikt/nav-dekoratoren-moduler';
 
@@ -190,10 +190,12 @@ const Steg: React.FC<ISteg> = ({ tittel, guide, skjema, gåVidereCallback, vedle
                             <SkjemaFeiloppsummering skjema={skjema.skjema} />
                         )}
                         {visVedleggOppsummering && (
-                            <Alert variant="info">
-                                {plainTekst(dokumentasjonTekster.lastOppSenereISoknad)}
-                                <VedleggOppsummering vedlegg={vedleggOppsummering} />
-                            </Alert>
+                            <InfoCard data-color="info">
+                                <InfoCard.Message icon={<InformationSquareIcon aria-hidden />}>
+                                    {plainTekst(dokumentasjonTekster.lastOppSenereISoknad)}
+                                    <VedleggOppsummering vedlegg={vedleggOppsummering} />
+                                </InfoCard.Message>
+                            </InfoCard>
                         )}
                         {!erPåKvitteringsside() && (
                             <Navigeringspanel

--- a/src/frontend/components/Felleskomponenter/SøkerMåBrukePDF.tsx
+++ b/src/frontend/components/Felleskomponenter/SøkerMåBrukePDF.tsx
@@ -1,6 +1,7 @@
 import React, { FC, ReactNode } from 'react';
 
-import { Alert, Box } from '@navikt/ds-react';
+import { ExclamationmarkTriangleIcon } from '@navikt/aksel-icons';
+import { Box, InfoCard } from '@navikt/ds-react';
 
 import { useAppContext } from '../../context/AppContext';
 
@@ -15,11 +16,13 @@ export const SøkerMåBrukePDF: FC<SøkerMåBrukePDFProps> = ({ advarselTekst })
     const { brukPDFKontantstoette } = tekster().FELLES.kanIkkeBrukeSoeknad;
 
     return (
-        <Alert variant={'warning'} data-testid="søker-må-bruke-pdf">
-            {advarselTekst}
-            <Box marginBlock="space-12 space-0">
-                <TekstBlock block={brukPDFKontantstoette} />
-            </Box>
-        </Alert>
+        <InfoCard data-color={'warning'} data-testid="søker-må-bruke-pdf">
+            <InfoCard.Message icon={<ExclamationmarkTriangleIcon aria-hidden />}>
+                {advarselTekst}
+                <Box marginBlock="space-12 space-0">
+                    <TekstBlock block={brukPDFKontantstoette} />
+                </Box>
+            </InfoCard.Message>
+        </InfoCard>
     );
 };

--- a/src/frontend/components/Kontoinformasjon/Kontoinformasjon.tsx
+++ b/src/frontend/components/Kontoinformasjon/Kontoinformasjon.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { Alert, Heading, Label, Loader, VStack } from '@navikt/ds-react';
+import { ExclamationmarkTriangleIcon } from '@navikt/aksel-icons';
+import { Heading, InfoCard, Label, Loader, VStack } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { ESanitySteg, Typografi } from '../../../common/sanity';
@@ -35,9 +36,11 @@ const Kontoinformasjon: React.FC = () => {
 
             {kontoinformasjon.status === RessursStatus.FEILET && (
                 <>
-                    <Alert variant="warning">
-                        <TekstBlock block={kvitteringstekster.finnerIngenKontonummerAdvarsel} />
-                    </Alert>
+                    <InfoCard data-color="warning">
+                        <InfoCard.Message icon={<ExclamationmarkTriangleIcon aria-hidden />}>
+                            <TekstBlock block={kvitteringstekster.finnerIngenKontonummerAdvarsel} />
+                        </InfoCard.Message>
+                    </InfoCard>
                     <Heading level="2" size="medium">
                         {plainTekst(kvitteringstekster.manglerKontonummerTittel)}
                     </Heading>

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/Dokumentasjon.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/Dokumentasjon.tsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 
 import { add, isBefore } from 'date-fns';
 
-import { Alert, BodyShort, Heading, VStack } from '@navikt/ds-react';
+import { ExclamationmarkTriangleIcon, XMarkOctagonIcon } from '@navikt/aksel-icons';
+import { BodyShort, Heading, InfoCard, VStack } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { ESanitySteg, Typografi } from '../../../../common/sanity';
@@ -96,16 +97,18 @@ const Dokumentasjon: React.FC = () => {
         >
             <VStack gap="space-48">
                 {slettaVedlegg.length > 0 && (
-                    <Alert variant={'warning'}>
-                        <TekstBlock block={stegTekster.forLangTidDokumentasjon} typografi={Typografi.BodyLong} />
-                        <ul>
-                            {slettaVedlegg.map(vedlegg => (
-                                <li key={vedlegg.dokumentId}>
-                                    <BodyShort>{vedlegg.navn}</BodyShort>
-                                </li>
-                            ))}
-                        </ul>
-                    </Alert>
+                    <InfoCard data-color={'warning'}>
+                        <InfoCard.Message icon={<ExclamationmarkTriangleIcon aria-hidden />}>
+                            <TekstBlock block={stegTekster.forLangTidDokumentasjon} />
+                            <ul>
+                                {slettaVedlegg.map(vedlegg => (
+                                    <li key={vedlegg.dokumentId}>
+                                        <BodyShort>{vedlegg.navn}</BodyShort>
+                                    </li>
+                                ))}
+                            </ul>
+                        </InfoCard.Message>
+                    </InfoCard>
                 )}
                 {brukerHarVedleggskrav ? (
                     <>
@@ -146,12 +149,11 @@ const Dokumentasjon: React.FC = () => {
                     />
                 ))}
                 {innsendingStatus.status === RessursStatus.FEILET && (
-                    <Alert variant="error" role="alert">
-                        <TekstBlock
-                            block={stegTekster.dokumentasjonFeilmeldingVedInnsending}
-                            typografi={Typografi.BodyLong}
-                        />
-                    </Alert>
+                    <InfoCard data-color="danger" role="alert">
+                        <InfoCard.Message icon={<XMarkOctagonIcon aria-hidden />}>
+                            <TekstBlock block={stegTekster.dokumentasjonFeilmeldingVedInnsending} />
+                        </InfoCard.Message>
+                    </InfoCard>
                 )}
             </VStack>
         </Steg>

--- a/src/frontend/components/SøknadsSteg/Forside/FortsettPåSøknad.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/FortsettPåSøknad.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { Alert, Button, VStack } from '@navikt/ds-react';
+import { InformationSquareIcon } from '@navikt/aksel-icons';
+import { Button, InfoCard, VStack } from '@navikt/ds-react';
 
-import { Typografi } from '../../../../common/sanity';
 import { useAppContext } from '../../../context/AppContext';
 import TekstBlock from '../../Felleskomponenter/Sanity/TekstBlock';
 import { SlettSøknadenModal } from '../../Felleskomponenter/Steg/SlettSøknadenModal';
@@ -19,9 +19,13 @@ export const FortsettPåSøknad: React.FC = () => {
 
     return (
         <>
-            <Alert variant={'info'}>
-                <TekstBlock block={forsideTekster.mellomlagretAlert} typografi={Typografi.BodyLong} />
-            </Alert>
+            <InfoCard data-color={'info'}>
+                <InfoCard.Message icon={<InformationSquareIcon aria-hidden />}>
+                    <VStack gap={'space-16'}>
+                        <TekstBlock block={forsideTekster.mellomlagretAlert} />
+                    </VStack>
+                </InfoCard.Message>
+            </InfoCard>
             <VStack gap="space-32" width={{ sm: 'fit-content' }} marginInline={{ sm: 'auto' }}>
                 <Button onClick={fortsettPåSøknaden}>{plainTekst(navigasjonTekster.fortsettKnapp)}</Button>
                 <Button variant={'secondary'} onClick={() => settVisStartPåNyttModal(true)}>

--- a/src/frontend/components/SøknadsSteg/Kvittering/Kvittering.tsx
+++ b/src/frontend/components/SøknadsSteg/Kvittering/Kvittering.tsx
@@ -2,7 +2,8 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import { format } from 'date-fns';
 
-import { Alert, VStack } from '@navikt/ds-react';
+import { CheckmarkCircleIcon, ExclamationmarkTriangleIcon } from '@navikt/aksel-icons';
+import { InfoCard, VStack } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { Typografi } from '../../../../common/sanity';
@@ -61,19 +62,23 @@ const Kvittering: React.FC = () => {
 
     return (
         <Steg tittel={plainTekst(kvitteringTekster.kvitteringTittel)}>
-            <Alert variant={'success'}>
-                {plainTekst(kvitteringTekster.soeknadMottatt, {
-                    klokkeslett: klokkeslett,
-                    dato: dato,
-                })}
-            </Alert>
+            <InfoCard data-color={'success'}>
+                <InfoCard.Message icon={<CheckmarkCircleIcon aria-hidden />}>
+                    {plainTekst(kvitteringTekster.soeknadMottatt, {
+                        klokkeslett: klokkeslett,
+                        dato: dato,
+                    })}
+                </InfoCard.Message>
+            </InfoCard>
             <VStack gap="space-24">
                 {allNødvendigDokumentasjonErLastetOpp.current ? (
                     <TekstBlock block={kvitteringTekster.trengerIkkeEttersendeVedlegg} typografi={Typografi.BodyLong} />
                 ) : (
-                    <Alert variant="warning">
-                        <TekstBlock block={kvitteringTekster.maaEttersendeVedleggAlert} />
-                    </Alert>
+                    <InfoCard data-color={'warning'}>
+                        <InfoCard.Message icon={<ExclamationmarkTriangleIcon aria-hidden />}>
+                            <TekstBlock block={kvitteringTekster.maaEttersendeVedleggAlert} />
+                        </InfoCard.Message>
+                    </InfoCard>
                 )}
                 <TekstBlock block={kvitteringTekster.infoTilSoker} typografi={Typografi.BodyLong} />
             </VStack>

--- a/src/frontend/components/SøknadsSteg/OmDeg/OmDeg.tsx
+++ b/src/frontend/components/SøknadsSteg/OmDeg/OmDeg.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { Alert } from '@navikt/ds-react';
+import { ExclamationmarkTriangleIcon, InformationSquareIcon } from '@navikt/aksel-icons';
+import { InfoCard } from '@navikt/ds-react';
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { ESanitySteg, Typografi } from '../../../../common/sanity';
@@ -75,9 +76,11 @@ const OmDeg: React.FC = () => {
                     spørsmålDokument={borPaaRegistrertAdresse}
                 />
                 {skjema.felter.borPåRegistrertAdresse.verdi === ESvar.NEI && (
-                    <Alert variant="warning">
-                        <TekstBlock block={personopplysningerAlert} />
-                    </Alert>
+                    <InfoCard data-color="warning">
+                        <InfoCard.Message icon={<ExclamationmarkTriangleIcon aria-hidden />}>
+                            <TekstBlock block={personopplysningerAlert} />
+                        </InfoCard.Message>
+                    </InfoCard>
                 )}
             </KomponentGruppe>
             <KomponentGruppe>
@@ -125,9 +128,11 @@ const OmDeg: React.FC = () => {
                         spørsmålDokument={planleggerAaBoINorgeTolvMnd}
                     />
                     {skjema.felter.planleggerÅBoINorgeTolvMnd.verdi === ESvar.NEI && (
-                        <Alert variant="info">
-                            <TekstBlock block={planleggerAaBoINorgeTolvMnd.alert} />
-                        </Alert>
+                        <InfoCard data-color={'info'}>
+                            <InfoCard.Message icon={<InformationSquareIcon aria-hidden />}>
+                                <TekstBlock block={planleggerAaBoINorgeTolvMnd.alert} />
+                            </InfoCard.Message>
+                        </InfoCard>
                     )}
                 </KomponentGruppe>
             )}


### PR DESCRIPTION
### 📮 Favro: NAV-28205

### 💰 Hva skal gjøres, og hvorfor?
Alert er avviklet av Aksel og erstattes med en av [GlobalAlert](https://aksel.nav.no/komponenter/core/globalalert)
[LocalAlert](https://aksel.nav.no/komponenter/core/localalert)
[InfoCard](https://aksel.nav.no/komponenter/core/infocard)
[InlineMessage](https://aksel.nav.no/komponenter/core/inlinemessage)

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Vurdering er gjort ang. å beholde InfoCard data-color=(warning|danger). Problemet er at på søknads-sidene (i motsetning til saksbehandlingssidene) så er det mye vanskeligere å splitte opp tekster pga. tekstene kommer fra Sanity og det kan skape trøbbel med usynkroniserte tekster m.m. Og å beholde dagens tekster i kun LocalAlert/GlobalAlert kun tittel versjon blir altfor mektig av en Alert, så vi beholder warning|danger som InfoCard selv om de kankjse teknisk sett burde være LocalAlert|GlobalAlert.
Eksempel på hvorfor jeg IKKE bytter fra InfoCard->LocalAlert
<img width="965" height="351" alt="image" src="https://github.com/user-attachments/assets/8c622694-a7a1-43fd-a0db-2482f5d13fd2" />


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har endret søknadskontrakten og modellversjon i miljø.ts
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_


### 👀 Screen shots
Bilder ble sletta fordi jeg skulle skrive over som ikke ble nødvendig likevel, så ish skjermbilder kan sees på [ks-søknad PR](https://github.com/navikt/familie-ks-soknad/pull/1301)

Slettet gamle bilder, se [PR i KS-søknad ](https://github.com/navikt/familie-ks-soknad/pull/1301) for tilsvarende bilder
Gamle venstre - Ny høyre 
<img width="1111" height="726" alt="image" src="https://github.com/user-attachments/assets/2d5aef2b-9de2-478f-bb05-29f5c1dea4c6" />

Ny
<img width="666" height="554" alt="image" src="https://github.com/user-attachments/assets/3dd2a988-c843-44b2-b8a8-f7780f166e31" />

????
<img width="1468" height="988" alt="image" src="https://github.com/user-attachments/assets/f8ce9fe7-a928-48a3-81b2-47f2f3175d33" />
