### PR TITLE
Tillat prod deploy fra ikke-main branch og bruk nytt varslingoppsett

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,6 +56,8 @@ jobs:
   varsle-slack:
     name: Slack-melding ved feil
     if: failure()
+    permissions: {}
     needs: [ build, deploy-dev, deploy-prod ]
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/notify-slack.yaml@main # ratchet:exclude
-    secrets: inherit
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/notify-failed-workflow.yaml@main # ratchet:exclude
+    secrets:
+      BAKS_DEPLOYMENTS_SLACK_WEBHOOK: ${{ secrets.BAKS_DEPLOYMENTS_SLACK_WEBHOOK }}

--- a/.github/workflows/manual-deploy-prod.yaml
+++ b/.github/workflows/manual-deploy-prod.yaml
@@ -1,4 +1,4 @@
-name: Manual deploy to prod (from main)
+name: Manual deploy to prod
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/manual-deploy-prod.yaml
+++ b/.github/workflows/manual-deploy-prod.yaml
@@ -14,7 +14,6 @@ on:
 jobs:
   build:
     name: Build
-    if: github.ref == 'refs/heads/main' # Only deploy to prod from main branch
     permissions:
       contents: read
       id-token: write
@@ -37,3 +36,11 @@ jobs:
       cluster: prod-gcp
       resource: .nais/app-prod.yaml
     secrets: inherit
+  notify-audit:
+    name: Notify if audited deploy
+    if: github.ref != 'refs/heads/main'
+    permissions: {}
+    needs: deploy-with-new-image
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/notify-audited-deploy.yaml@main # ratchet:exclude
+    secrets:
+      BAKS_AUDIT_ALERTS_SLACK_WEBHOOK: ${{ secrets.BAKS_AUDIT_ALERTS_SLACK_WEBHOOK }}

--- a/.github/workflows/manual-deploy-with-image.yaml
+++ b/.github/workflows/manual-deploy-with-image.yaml
@@ -26,3 +26,11 @@ jobs:
       cluster: ${{ inputs.environment }}-gcp
       resource: .nais/app-${{ inputs.environment }}.yaml
     secrets: inherit
+  notify-audit:
+    name: Notify if audited deploy
+    if: github.ref != 'refs/heads/main' && inputs.environment == 'prod'
+    permissions: {}
+    needs: deploy-with-existing-image
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/notify-audited-deploy.yaml@main # ratchet:exclude
+    secrets:
+      BAKS_AUDIT_ALERTS_SLACK_WEBHOOK: ${{ secrets.BAKS_AUDIT_ALERTS_SLACK_WEBHOOK }}


### PR DESCRIPTION
### 📮 Favro: NAV-28509

### 💰 Hva skal gjøres, og hvorfor?
Fjerner kriterie om å deploye til prod fra main branch. Legger til rette for å gjøre hurtig deploy ved behov. Hvis det blir deployet fra ikke-main branch varsles det i slack-kanal: #team-baks-audit-alerts. Et etterlevelsekrav og sikkerhetstiltak.

Tar også i bruk ny workflow for varsling hvis workflow tryner. Fungerer tilsvarende som før, men med et litt annerledes oppsett. Definert her: https://github.com/navikt/familie-baks-gha-workflows/pull/84.

Slik ser varslene ut:
<img width="879" height="264" alt="image" src="https://github.com/user-attachments/assets/4305b948-3c3a-4fa8-a2ca-149624a36cfc" />
