### PR TITLE
Legger til fjernknapp for barnetrygd perioder

### DIFF
--- a/mocks/testdata/sanity/felles/modaler/barnetrygdperiode.ts
+++ b/mocks/testdata/sanity/felles/modaler/barnetrygdperiode.ts
@@ -19,4 +19,5 @@ export const barnetrygdsperiodeTekstinnhold: IBarnetrygdsperiodeTekstinnhold = {
     sluttdato: lagSanitySpørsmålDokument(),
     belopPerManed: lagSanitySpørsmålDokument(),
     belopFormatFeilmelding: lagLocaleRecordBlock(),
+    fjernKnapp: lagLocaleRecordBlock(),
 };

--- a/src/frontend/components/Felleskomponenter/Barnetrygdperiode/BarnetrygdperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/Barnetrygdperiode/BarnetrygdperiodeOppsummering.tsx
@@ -55,6 +55,7 @@ export const BarnetrygdsperiodeOppsummering: React.FC<Props> = ({
     return (
         <PeriodeOppsummering
             fjernPeriodeCallback={fjernPeriodeCallback && (() => fjernPeriodeCallback(barnetrygdsperiode))}
+            fjernKnappTekst={teksterForPersonType.fjernKnapp}
             tittel={
                 <TekstBlock
                     block={teksterForPersonType.oppsummeringstittel}

--- a/src/frontend/typer/sanity/modaler/barnetrygdperiode.ts
+++ b/src/frontend/typer/sanity/modaler/barnetrygdperiode.ts
@@ -14,4 +14,5 @@ export interface IBarnetrygdsperiodeTekstinnhold {
     sluttdato: ISanitySpørsmålDokument;
     belopPerManed: ISanitySpørsmålDokument;
     belopFormatFeilmelding: LocaleRecordBlock;
+    fjernKnapp: LocaleRecordBlock;
 }


### PR DESCRIPTION
### 📮 Favro: NAV-29274

### 💰 Hva skal gjøres, og hvorfor?

Vi må legge til fjerne knapp for barnetrygd perioder i utlandet.

FØR:
<img width="784" height="666" alt="Screenshot 2026-05-27 at 20 21 49" src="https://github.com/user-attachments/assets/cd3634ab-f14d-4d9a-82f9-14b3d8756731" />

ETTER:
<img width="830" height="860" alt="Screenshot 2026-05-27 at 20 20 47" src="https://github.com/user-attachments/assets/70c437f3-89d6-44fc-9377-aa2bcee45c57" />
