### PR TITLE
Valider lengde på filnavn

### DIFF
--- a/mocks/testdata/sanity/sider/dokumentasjon.ts
+++ b/mocks/testdata/sanity/sider/dokumentasjon.ts
@@ -50,6 +50,7 @@ export const dokumentasjonTekstinnhold: IDokumentasjonTekstinnhold = {
     filtypeFeilmelding: lagLocaleRecordString(),
     filstorrelseFeilmelding: lagLocaleRecordString(),
     antallFilerFeilmelding: lagLocaleRecordString(),
+    filnavnForLangtFeilmelding: lagLocaleRecordString(),
     ukjentFeilmelding: lagLocaleRecordString(),
     velgFil: lagLocaleRecordString(),
     velgFiler: lagLocaleRecordString(),

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/useFilopplaster.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/useFilopplaster.tsx
@@ -23,34 +23,47 @@ export enum EStandardFileRejectionReasons {
 export enum ECustomFileRejectionReasons {
     FIL_DIMENSJONER_FOR_LITEN = 'filDimensjonerForLiten',
     MAKS_ANTALL_FILER_NÅDD = 'maksAntallFilerNådd',
+    FILNAVN_FOR_LANGT = 'filnavnForLangt',
     UKJENT_FEIL = 'ukjentFeil',
 }
 
 const filtrerFiler = (
     filer: FileObject[],
     antallEksisterendeFiler: number,
-    maksAntallFiler: number
+    maksAntallFiler: number,
+    maksFilnavnLengde: number
 ): { aksepterteFiler: FileAccepted[]; feilendeFiler: FileRejected[] } => {
     const filerUtenFeil: FileAccepted[] = filer.filter(file => !file.error);
     const filerMedFeil: FileRejected[] = filer.filter(file => file.error);
 
-    const ikkeForMangeFiler = antallEksisterendeFiler + filerUtenFeil.length <= maksAntallFiler;
+    // Backend avviser vedlegg med filnavn over maksFilnavnLengde tegn, så vi validerer det her for å gi brukeren beskjed med en gang.
+    const filerMedForLangtNavn: FileRejected[] = filerUtenFeil
+        .filter(fil => fil.file.name.length > maksFilnavnLengde)
+        .map(fil => ({
+            file: fil.file,
+            error: true,
+            reasons: [ECustomFileRejectionReasons.FILNAVN_FOR_LANGT],
+        }));
+
+    const filerMedGyldigNavn: FileAccepted[] = filerUtenFeil.filter(fil => fil.file.name.length <= maksFilnavnLengde);
+
+    const ikkeForMangeFiler = antallEksisterendeFiler + filerMedGyldigNavn.length <= maksAntallFiler;
 
     if (ikkeForMangeFiler) {
-        return { aksepterteFiler: filerUtenFeil, feilendeFiler: filerMedFeil };
+        return { aksepterteFiler: filerMedGyldigNavn, feilendeFiler: [...filerMedFeil, ...filerMedForLangtNavn] };
     } else {
         const ledigePlasser = maksAntallFiler - antallEksisterendeFiler;
 
-        const aksepterteFiler = filerUtenFeil.slice(0, ledigePlasser);
+        const aksepterteFiler = filerMedGyldigNavn.slice(0, ledigePlasser);
 
-        const filerOverMaksAntall = filerUtenFeil.slice(aksepterteFiler.length);
+        const filerOverMaksAntall = filerMedGyldigNavn.slice(aksepterteFiler.length);
         const filerOverMaksAntallMedFeil: FileRejected[] = filerOverMaksAntall.map(fil => ({
             file: fil.file,
             error: true,
             reasons: [ECustomFileRejectionReasons.MAKS_ANTALL_FILER_NÅDD],
         }));
 
-        const feilendeFiler = [...filerMedFeil, ...filerOverMaksAntallMedFeil];
+        const feilendeFiler = [...filerMedFeil, ...filerMedForLangtNavn, ...filerOverMaksAntallMedFeil];
 
         return { aksepterteFiler, feilendeFiler };
     }
@@ -101,6 +114,7 @@ export const useFilopplaster = (
     const MAKS_FILSTØRRELSE_MB = 10;
     const MAKS_FILSTØRRELSE_BYTES = MAKS_FILSTØRRELSE_MB * 1024 * 1024;
     const MAKS_ANTALL_FILER = 25;
+    const MAKS_FILNAVN_LENGDE = 200;
     const STØTTEDE_FILTYPER = [EFiltyper.PNG, EFiltyper.JPG, EFiltyper.JPEG, EFiltyper.PDF];
 
     const feilmeldinger: Record<FileRejectionReason | ECustomFileRejectionReasons, string> = {
@@ -108,6 +122,7 @@ export const useFilopplaster = (
         [EStandardFileRejectionReasons.FIL_STØRRELSE_FOR_STOR]: `${plainTekst(dokumentasjonTekster.filstorrelseFeilmelding)} ${MAKS_FILSTØRRELSE_MB} MB`,
         [ECustomFileRejectionReasons.FIL_DIMENSJONER_FOR_LITEN]: plainTekst(dokumentasjonTekster.bildetForLite),
         [ECustomFileRejectionReasons.MAKS_ANTALL_FILER_NÅDD]: `${plainTekst(dokumentasjonTekster.antallFilerFeilmelding)} ${MAKS_ANTALL_FILER}`,
+        [ECustomFileRejectionReasons.FILNAVN_FOR_LANGT]: `${plainTekst(dokumentasjonTekster.filnavnForLangtFeilmelding)} ${MAKS_FILNAVN_LENGDE}`,
         [ECustomFileRejectionReasons.UKJENT_FEIL]: plainTekst(dokumentasjonTekster.ukjentFeilmelding),
     };
 
@@ -117,7 +132,8 @@ export const useFilopplaster = (
         const { aksepterteFiler, feilendeFiler } = filtrerFiler(
             nyeFiler,
             dokumentasjon.opplastedeVedlegg.length,
-            MAKS_ANTALL_FILER
+            MAKS_ANTALL_FILER,
+            MAKS_FILNAVN_LENGDE
         );
 
         if (feilendeFiler.length > 0) {

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/innholdTyper.ts
@@ -53,6 +53,7 @@ export type IDokumentasjonTekstinnhold = {
     filtypeFeilmelding: LocaleRecordString;
     filstorrelseFeilmelding: LocaleRecordString;
     antallFilerFeilmelding: LocaleRecordString;
+    filnavnForLangtFeilmelding: LocaleRecordString;
     ukjentFeilmelding: LocaleRecordString;
     velgFil: LocaleRecordString;
     velgFiler: LocaleRecordString;


### PR DESCRIPTION
### 📮 Favro:
  [NAV-29014 – Validering på filer med 200 karakterer lengde](https://favro.com/organization/.../NAV-29014)

  ### 💰 Hva skal gjøres, og hvorfor?
  Backend avviser vedlegg med filnavn over 200 tegn med en kryptisk valideringsfeil først
  ved innsending: `Valideringsfeil(objectPath=dokumentasjon[0].opplastedeVedlegg[0].navn,
  feilmelding=Verdi overskrider maksimal lengde på 200 tegn (faktisk: 232))`.

  Nå validerer vi filnavnlengden i frontend ved opplasting, slik at brukeren får beskjed
  med en gang om at filnavnet er for langt og at hen må gi filen et kortere navn i stedet
  for å oppdage det først når søknaden sendes inn.

  Endringer i `Dokumentasjon/filopplaster/useFilopplaster.tsx`:
  - Ny avvisningsårsak `ECustomFileRejectionReasons.FILNAVN_FOR_LANGT` og konstant
    `MAKS_FILNAVN_LENGDE = 200` (samme grense som backend `@Size(max=200)`).
  - `filtrerFiler` avviser filer med `navn.length > 200` før opplasting, slik at de aldri
    lastes opp. De vises i lista over «vedlegg med feil» med en sletteknapp, på samme måte
    som øvrige avviste filer.
  - Ny Sanity-tekstnøkkel `filnavnForLangtFeilmelding` lagt til i `innholdTyper.ts`.

<img width="658" height="537" alt="Screenshot 2026-05-31 at 19 42 49" src="https://github.com/user-attachments/assets/d4be8992-8861-47bd-907e-f0a5c7ca4a0b" />
  
  
  Sanity tekst som er lagt inn: https://familie-baks-soknad.sanity.studio/ba-production/structure/steg;dokumentasjon;knapperOgCheckbox;48eaf0a7-7123-4b05-9b21-624b09fa2104%2Ctemplate%3DDOKUMENTASJON_KNAPPER_OG_CHECKBOX?perspective=published
