### PR TITLE
Ignorer @types/node V26 i Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,6 +10,7 @@ updates:
       - dependency-name: "@types/node"
         versions:
           - "25"
+          - "26"
     cooldown:
       default-days: 4
     open-pull-requests-limit: 20


### PR DESCRIPTION
### 📮 Favro: N/A

### 💰 Hva skal gjøres, og hvorfor?
Vi kjører på node 24 og ønsker ikke bumpe typer forbi det punktet.
